### PR TITLE
feat: add Hermes session importer + fix short skill name matching

### DIFF
--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -9,6 +9,7 @@ already use.
 Supported sources:
   - Claude Code (~/.claude/history.jsonl) — user inputs only
   - GitHub Copilot (~/.copilot/session-state/*/events.jsonl) — full conversations
+  - Hermes Agent (~/.hermes/sessions/*.json) — user + assistant + tool context
 
 Usage as standalone CLI:
     python -m evolution.core.external_importers \\
@@ -127,7 +128,12 @@ def _is_relevant_to_skill(text: str, skill_name: str, skill_text: str) -> bool:
     text_lower = text.lower()
     skill_lower = skill_name.lower().replace("-", " ").replace("_", " ")
 
-    # Direct skill name mention (only words > 3 chars to avoid "tdd", "run", etc.)
+    # Exact full skill name match (handles short names like "mcp", "tdd", "git")
+    if skill_lower in text_lower:
+        return True
+
+    # Individual word match (only words > 3 chars to avoid false positives
+    # from short fragments like "run", "use", etc.)
     for word in skill_lower.split():
         if len(word) > 3 and word in text_lower:
             return True
@@ -323,6 +329,91 @@ def _parse_copilot_events(
         console.print(f"[dim]Skipped {session_id}: {e}[/dim]")
 
     return pairs
+
+
+class HermesSessionImporter:
+    """Import conversations from Hermes Agent session files.
+
+    Hermes stores session transcripts as JSON files in ~/.hermes/sessions/.
+    Each file contains an OpenAI-format message list with user, assistant,
+    and tool messages — providing richer signal than Claude Code (user-only)
+    or Copilot (user+assistant without tool context).
+
+    This mines user messages paired with the assistant's final response,
+    giving the LLM judge both the task and how it was actually handled.
+    """
+
+    SESSION_DIR = Path.home() / ".hermes" / "sessions"
+
+    @staticmethod
+    def extract_messages(limit: int = 0) -> list[dict]:
+        """Read user/assistant pairs from Hermes session files.
+
+        Args:
+            limit: Maximum messages to return (0 = no limit).
+
+        Returns:
+            List of dicts with keys: source, task_input, assistant_response,
+            session_id.
+        """
+        if not HermesSessionImporter.SESSION_DIR.exists():
+            return []
+
+        messages = []
+        session_files = sorted(
+            HermesSessionImporter.SESSION_DIR.glob("*.json"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,  # newest first
+        )
+
+        for session_file in session_files:
+            try:
+                data = json.loads(session_file.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+
+            msg_list = data.get("messages", [])
+            if not msg_list:
+                continue
+
+            session_id = data.get("session_id", session_file.stem)
+
+            # Walk messages: pair each user message with the next assistant
+            # response (skipping tool messages in between).
+            for i, msg in enumerate(msg_list):
+                if msg.get("role") != "user":
+                    continue
+                user_text = msg.get("content", "")
+                if not user_text or len(user_text) < 10:
+                    continue
+                if _contains_secret(user_text):
+                    continue
+
+                # Find the next assistant response
+                assistant_text = ""
+                for j in range(i + 1, len(msg_list)):
+                    if msg_list[j].get("role") == "assistant":
+                        content = msg_list[j].get("content", "")
+                        if content:
+                            assistant_text = content
+                            break
+                    elif msg_list[j].get("role") == "user":
+                        break  # next user turn, no assistant response found
+
+                if assistant_text and _contains_secret(assistant_text):
+                    continue
+
+                messages.append({
+                    "source": "hermes",
+                    "task_input": user_text,
+                    "assistant_response": assistant_text,
+                    "session_id": session_id,
+                })
+
+                if limit and len(messages) >= limit:
+                    return messages
+
+        return messages
 
 
 # ── Relevance Filtering ───────────────────────────────────────────────────
@@ -541,6 +632,7 @@ def build_dataset_from_external(
     importers = {
         "claude-code": ("Claude Code", ClaudeCodeImporter),
         "copilot": ("Copilot", CopilotImporter),
+        "hermes": ("Hermes Agent", HermesSessionImporter),
     }
 
     for source in sources:
@@ -637,7 +729,7 @@ def _load_skill_text(skill_name: str, skills_dir: Optional[Path] = None) -> tupl
 @click.command()
 @click.option(
     "--source",
-    type=click.Choice(["claude-code", "copilot", "all"]),
+    type=click.Choice(["claude-code", "copilot", "hermes", "all"]),
     default="all",
     help="Which tool to import from",
 )
@@ -660,12 +752,13 @@ def main(source, skill, output, model, max_examples, dry_run):
 
     console.print(f"  Loaded skill: {skill_name} ({len(skill_text):,} chars)")
 
-    sources = [source] if source != "all" else ["claude-code", "copilot"]
+    sources = [source] if source != "all" else ["claude-code", "copilot", "hermes"]
 
     if dry_run:
         importers = {
             "claude-code": ClaudeCodeImporter,
             "copilot": CopilotImporter,
+            "hermes": HermesSessionImporter,
         }
         for src in sources:
             msgs = importers[src].extract_messages()

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -88,7 +88,7 @@ def evolve(
         dataset = build_dataset_from_external(
             skill_name=skill_name,
             skill_text=skill["raw"],
-            sources=["claude-code", "copilot"],
+            sources=["claude-code", "copilot", "hermes"],
             output_path=save_path,
             model=eval_model,
         )

--- a/tests/core/test_external_importers.py
+++ b/tests/core/test_external_importers.py
@@ -34,6 +34,7 @@ from evolution.core.external_importers import (
     main,
     ClaudeCodeImporter,
     CopilotImporter,
+    HermesSessionImporter,
     RelevanceFilter,
     VALID_DIFFICULTIES,
     MIN_DATASET_SIZE,
@@ -461,6 +462,126 @@ class TestCopilotHelpers:
             assert pairs == []
         finally:
             events_path.chmod(0o644)  # Restore for cleanup
+
+
+# ── Hermes Session Importer ──────────────────────────────────────────────────
+
+
+class TestHermesSessionImporter:
+    def test_parses_session_json(self, tmp_path):
+        session = {
+            "session_id": "test-session",
+            "messages": [
+                {"role": "user", "content": "Fix the bug in auth.py"},
+                {"role": "assistant", "content": None, "tool_calls": [{"name": "read_file"}]},
+                {"role": "tool", "content": "file contents here"},
+                {"role": "assistant", "content": "I found the issue and fixed it."},
+                {"role": "user", "content": "Now run the tests"},
+                {"role": "assistant", "content": "All 42 tests passed."},
+            ],
+        }
+        (tmp_path / "session_001.json").write_text(json.dumps(session))
+
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
+            msgs = HermesSessionImporter.extract_messages()
+
+        assert len(msgs) == 2
+        assert msgs[0]["task_input"] == "Fix the bug in auth.py"
+        assert msgs[0]["assistant_response"] == "I found the issue and fixed it."
+        assert msgs[0]["source"] == "hermes"
+        assert msgs[1]["task_input"] == "Now run the tests"
+        assert msgs[1]["assistant_response"] == "All 42 tests passed."
+
+    def test_skips_short_messages(self, tmp_path):
+        session = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "Hello!"},
+            ],
+        }
+        (tmp_path / "s.json").write_text(json.dumps(session))
+
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
+            msgs = HermesSessionImporter.extract_messages()
+        assert len(msgs) == 0
+
+    def test_filters_secrets(self, tmp_path):
+        session = {
+            "messages": [
+                {"role": "user", "content": "Set ANTHROPIC_API_KEY=sk-ant-api03-xyz in the env"},
+                {"role": "assistant", "content": "Done."},
+            ],
+        }
+        (tmp_path / "s.json").write_text(json.dumps(session))
+
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
+            msgs = HermesSessionImporter.extract_messages()
+        assert len(msgs) == 0
+
+    def test_handles_missing_dir(self, tmp_path):
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path / "nonexistent"):
+            msgs = HermesSessionImporter.extract_messages()
+        assert msgs == []
+
+    def test_handles_malformed_json(self, tmp_path):
+        (tmp_path / "bad.json").write_text("{not valid json")
+
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
+            msgs = HermesSessionImporter.extract_messages()
+        assert msgs == []
+
+    def test_handles_no_assistant_response(self, tmp_path):
+        session = {
+            "messages": [
+                {"role": "user", "content": "Do something interesting please"},
+            ],
+        }
+        (tmp_path / "s.json").write_text(json.dumps(session))
+
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
+            msgs = HermesSessionImporter.extract_messages()
+        assert len(msgs) == 1
+        assert msgs[0]["assistant_response"] == ""
+
+    def test_respects_limit(self, tmp_path):
+        session = {
+            "messages": [
+                {"role": "user", "content": f"Message number {i} with enough text"} for i in range(10)
+            ],
+        }
+        (tmp_path / "s.json").write_text(json.dumps(session))
+
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
+            msgs = HermesSessionImporter.extract_messages(limit=3)
+        assert len(msgs) == 3
+
+
+# ── Skill Name Matching ──────────────────────────────────────────────────────
+
+
+class TestSkillNameMatching:
+    """Verify that short skill names match via exact full-name check."""
+
+    def test_short_skill_name_matches_exact(self):
+        assert _is_relevant_to_skill(
+            "configure the mcp server settings",
+            "mcp",
+            "Model Context Protocol server management",
+        )
+
+    def test_short_skill_name_tdd(self):
+        assert _is_relevant_to_skill(
+            "set up tdd workflow for the project",
+            "tdd",
+            "Test driven development enforcement",
+        )
+
+    def test_hyphenated_skill_name_matches(self):
+        assert _is_relevant_to_skill(
+            "I need to do a code review on this PR",
+            "code-review",
+            "Review pull requests and provide feedback",
+        )
 
 
 # ── RelevanceFilter (mocked DSPy) ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two improvements on top of the external importers from PR #2:

### 1. Hermes Session Importer

Adds `HermesSessionImporter` that mines `~/.hermes/sessions/*.json` for user/assistant message pairs. Hermes sessions have the richest signal of all three sources — full tool-calling context with user messages, tool results, and assistant responses.

- Walks messages pairing each user turn with the next assistant response (skipping tool messages in between)
- Secret filtering on both user and assistant content
- Newest sessions first (sorted by mtime)
- Respects limit parameter

### 2. Short Skill Name Fix

`_is_relevant_to_skill` had a `len(word) > 3` filter on skill name words, which meant skills like `mcp`, `tdd`, `git` could never match on their name. Now checks for exact full skill name match first (e.g. "mcp" in text), then falls back to the individual word matching for longer names.

## Test plan
- 116 passed (10 new: 7 for Hermes importer + 3 for skill name matching)
- All existing 106 tests still pass