### PR TITLE
fix: extract evolved skill text from DSPy signature, not dead instance attr

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -180,8 +180,8 @@ def evolve(
     console.print(f"\n  Optimization completed in {elapsed:.1f}s")
 
     # ── 6. Extract evolved skill text ───────────────────────────────────
-    # The optimized module's instructions contain the evolved skill text
-    evolved_body = optimized_module.skill_text
+    # DSPy optimizers mutate predictor.signature.instructions, not instance attrs
+    evolved_body = optimized_module.get_evolved_text()
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
     # ── 7. Validate evolved skill ───────────────────────────────────────

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -84,34 +84,34 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
 class SkillModule(dspy.Module):
     """A DSPy module that wraps a skill file for optimization.
 
-    The skill text (body) is the parameter that GEPA optimizes.
-    On each forward pass, the module:
-    1. Uses the skill text as instructions
-    2. Processes the task input
-    3. Returns the agent's response
+    The skill text is embedded as the signature's instructions — the part
+    that DSPy optimizers (GEPA, MIPROv2) actually mutate. After
+    optimizer.compile(), call get_evolved_text() to extract the result.
     """
-
-    class TaskWithSkill(dspy.Signature):
-        """Complete a task following the provided skill instructions.
-
-        You are an AI agent following specific skill instructions to complete a task.
-        Read the skill instructions carefully and follow the procedure described.
-        """
-        skill_instructions: str = dspy.InputField(desc="The skill instructions to follow")
-        task_input: str = dspy.InputField(desc="The task to complete")
-        output: str = dspy.OutputField(desc="Your response following the skill instructions")
 
     def __init__(self, skill_text: str):
         super().__init__()
+        # Store original for reference/diff
         self.skill_text = skill_text
-        self.predictor = dspy.ChainOfThought(self.TaskWithSkill)
+        # Embed skill text as signature instructions — this is what GEPA evolves
+        sig = dspy.Signature(
+            "task_input: str -> output: str",
+            instructions=skill_text,
+        )
+        self.predictor = dspy.ChainOfThought(sig)
 
     def forward(self, task_input: str) -> dspy.Prediction:
-        result = self.predictor(
-            skill_instructions=self.skill_text,
-            task_input=task_input,
-        )
+        result = self.predictor(task_input=task_input)
         return dspy.Prediction(output=result.output)
+
+    def get_evolved_text(self) -> str:
+        """Extract the (potentially optimized) skill text from the predictor.
+
+        DSPy optimizers mutate predictor.signature.instructions, not
+        arbitrary instance attributes. ChainOfThought wraps an inner
+        Predict at self.predictor.predict — that's where the signature lives.
+        """
+        return self.predictor.predict.signature.instructions
 
 
 def reassemble_skill(frontmatter: str, evolved_body: str) -> str:

--- a/tests/skills/test_skill_module.py
+++ b/tests/skills/test_skill_module.py
@@ -2,7 +2,11 @@
 
 import pytest
 from pathlib import Path
-from evolution.skills.skill_module import load_skill, reassemble_skill
+from unittest.mock import patch
+
+import dspy
+
+from evolution.skills.skill_module import load_skill, reassemble_skill, SkillModule
 
 
 SAMPLE_SKILL = """---
@@ -90,3 +94,48 @@ class TestReassembleSkill:
 
         assert "EVOLVED" in result
         assert "New and improved" in result
+
+
+class TestSkillModule:
+    """Tests for SkillModule — ensures skill text is stored as signature
+    instructions (the part DSPy optimizers mutate), not just an instance attr."""
+
+    SKILL_TEXT = "# Review Code\n\n## Procedure\n1. Read the diff\n2. Check for bugs"
+
+    def test_skill_text_is_signature_instructions(self):
+        module = SkillModule(self.SKILL_TEXT)
+        # ChainOfThought wraps an inner Predict at .predict
+        assert module.predictor.predict.signature.instructions == self.SKILL_TEXT
+
+    def test_get_evolved_text_returns_instructions(self):
+        module = SkillModule(self.SKILL_TEXT)
+        assert module.get_evolved_text() == self.SKILL_TEXT
+
+    def test_get_evolved_text_reflects_mutations(self):
+        """Simulates what DSPy optimizers do: mutate signature.instructions."""
+        module = SkillModule(self.SKILL_TEXT)
+        evolved = "# Evolved Review\n\n## Procedure\n1. Summarize changes\n2. Flag issues"
+        # This is what GEPA/MIPROv2 do internally via with_instructions()
+        inner = module.predictor.predict
+        inner.signature = inner.signature.with_instructions(evolved)
+        assert module.get_evolved_text() == evolved
+        # Original instance attr is unchanged (preserved for diffing)
+        assert module.skill_text == self.SKILL_TEXT
+
+    def test_original_skill_text_preserved(self):
+        module = SkillModule(self.SKILL_TEXT)
+        assert module.skill_text == self.SKILL_TEXT
+
+    def test_predictor_is_chain_of_thought(self):
+        module = SkillModule(self.SKILL_TEXT)
+        assert isinstance(module.predictor, dspy.ChainOfThought)
+
+    def test_signature_has_expected_fields(self):
+        module = SkillModule(self.SKILL_TEXT)
+        sig = module.predictor.predict.signature
+        input_fields = list(sig.input_fields.keys())
+        output_fields = list(sig.output_fields.keys())
+        assert "task_input" in input_fields
+        assert "output" in output_fields
+        # skill_instructions should NOT be an input field — it's the instructions now
+        assert "skill_instructions" not in input_fields


### PR DESCRIPTION
## Summary

`SkillModule` passed skill text as a runtime `InputField` to the predictor, but DSPy optimizers (GEPA, MIPROv2) only mutate **signature instructions** — they never touch arbitrary instance attributes. This meant `optimized_module.skill_text` always returned the original baseline, making the entire optimization pipeline a silent no-op.

- Embed skill text as the signature's `instructions` parameter (what `named_predictors()` exposes to optimizers)
- Add `SkillModule.get_evolved_text()` that reads from `predictor.predict.signature.instructions`
- Fix `evolve_skill.py` to use `get_evolved_text()` instead of the dead `skill_text` attribute

## Root Cause

DSPy's GEPA calls `student.named_predictors()` → extracts `pred.signature.instructions` → evolves the string → writes it back via `pred.signature.with_instructions(...)`. A plain `str` instance attribute like `self.skill_text` is not a `dspy.Parameter` and is completely invisible to the optimizer. After `compile()`, `optimized_module.skill_text` still contained the original text passed in `__init__`.

## Test Plan

- [x] `test_skill_text_is_signature_instructions` — skill text lands in signature
- [x] `test_get_evolved_text_returns_instructions` — extraction works
- [x] `test_get_evolved_text_reflects_mutations` — simulates GEPA's `with_instructions()` call; confirms evolved ≠ original
- [x] `test_original_skill_text_preserved` — `self.skill_text` unchanged for diffing
- [x] `test_predictor_is_chain_of_thought` — structural check
- [x] `test_signature_has_expected_fields` — `task_input`/`output` present, `skill_instructions` removed from input fields
- [x] Full suite: 129/129 pass (16 `test_constraints` errors are pre-existing — missing `hermes-agent` repo fixture)