### PR TITLE
feat: add CodexLM support via dspy-local for zero-cost evolution

### DIFF
--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import dspy
+from dspy.clients.codex import CodexLM, is_codex_model
 
 from evolution.core.config import EvolutionConfig
 
@@ -123,7 +124,10 @@ class SyntheticDatasetBuilder:
         n = num_cases or self.config.eval_dataset_size
 
         # Configure DSPy to use the judge model for generation
-        lm = dspy.LM(self.config.judge_model)
+        if is_codex_model(self.config.judge_model):
+            lm = CodexLM(model=self.config.judge_model, repo_root=self.config.hermes_agent_path, timeout_seconds=600)
+        else:
+            lm = dspy.LM(self.config.judge_model)
 
         with dspy.context(lm=lm):
             result = self.generator(

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -5,6 +5,7 @@ Supports length penalties and multi-dimensional scoring.
 """
 
 import dspy
+from dspy.clients.codex import CodexLM, is_codex_model
 from dataclasses import dataclass
 from typing import Optional
 
@@ -72,7 +73,10 @@ class LLMJudge:
     ) -> FitnessScore:
         """Score an agent output using LLM-as-judge."""
 
-        lm = dspy.LM(self.config.eval_model)
+        if is_codex_model(self.config.eval_model):
+            lm = CodexLM(model=self.config.eval_model, repo_root=self.config.hermes_agent_path, timeout_seconds=600)
+        else:
+            lm = dspy.LM(self.config.eval_model)
 
         with dspy.context(lm=lm):
             result = self.judge(
@@ -104,7 +108,7 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None, pred_name=None, pred_trace=None) -> float:
     """DSPy-compatible metric function for skill optimization.
 
     This is what gets passed to dspy.GEPA(metric=...).

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 import click
 import dspy
+from dspy.clients.codex import CodexLM, is_codex_model
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -138,7 +139,10 @@ def evolve(
     console.print(f"  Eval model: {eval_model}")
 
     # Configure DSPy
-    lm = dspy.LM(eval_model)
+    if is_codex_model(eval_model):
+        lm = CodexLM(model=eval_model, repo_root=config.hermes_agent_path, timeout_seconds=600)
+    else:
+        lm = dspy.LM(eval_model)
     dspy.configure(lm=lm)
 
     # Create the baseline skill module
@@ -156,7 +160,8 @@ def evolve(
     try:
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
-            max_steps=iterations,
+            max_metric_calls=iterations * 10,
+            reflection_lm=lm,
         )
 
         optimized_module = optimizer.compile(


### PR DESCRIPTION
## Summary

Adds support for running the full evolution pipeline through **Codex subscription** via [dspy-local](https://github.com/NousResearch/dspy-local)'s `CodexLM` backend. This enables zero API cost evolution using GPT-5.4 (or any Codex-available model).

## Motivation

The default evolution pipeline requires OpenAI API keys and incurs per-token costs. With Codex subscription + dspy-local, you can run unlimited evolution iterations at no additional cost — ideal for iterative skill optimization.

## Changes

| File | Change |
|---|---|
| `evolve_skill.py` | Auto-detect `codex/` model prefix → use `CodexLM` instead of `dspy.LM`. Add `reflection_lm` for GEPA. Fix `max_steps` → `max_metric_calls` for current DSPy API. |
| `dataset_builder.py` | CodexLM support for synthetic dataset generation |
| `fitness.py` | CodexLM support for LLM-as-judge. Extend metric to 5 args for GEPA compatibility. |

All `CodexLM` instances use `timeout_seconds=600` to handle GEPA's longer reflection prompts.

## Usage

```bash
# Install dspy-local instead of official dspy
pip install -e path/to/dspy-local

# Run evolution with Codex
python -m evolution.skills.evolve_skill \\
  --skill reddit-scanner \\
  --eval-model codex/default \\
  --optimizer-model codex/default \\
  --iterations 3 \\
  --hermes-repo ~/.hermes
```

## Testing

Tested with:
- **MIPROv2**: Full 10-trial optimization completed (917s), baseline 40.7% → best 42.2%
- **GEPA**: Full 4-iteration optimization completed (550s), with reflective instruction generation
- Both optimizers successfully generate evolved skills and pass all constraints (with #7)

## Dependencies

- [dspy-local](https://github.com/NousResearch/dspy-local) with `CodexLM` backend
- Active Codex subscription (`~/.codex/auth.json`)