### PR TITLE
fix: DSPy 3.1+ compatibility — GEPA API, constraint validation, fitness metric

### DIFF
--- a/evolution/core/constraints.py
+++ b/evolution/core/constraints.py
@@ -148,27 +148,30 @@ class ConstraintValidator:
             )
 
     def _check_skill_structure(self, text: str) -> ConstraintResult:
-        """Check that a skill file has valid YAML frontmatter and markdown body."""
-        has_frontmatter = text.strip().startswith("---")
-        has_name = "name:" in text[:500] if has_frontmatter else False
-        has_description = "description:" in text[:500] if has_frontmatter else False
+        """Check that a skill body has valid markdown structure.
 
-        if has_frontmatter and has_name and has_description:
+        Note: validate_all() receives the skill body (after frontmatter has been
+        stripped by load_skill()), not the full file. Frontmatter is preserved
+        separately and reassembled by reassemble_skill() after evolution.
+        Therefore we validate the body's markdown structure, not frontmatter presence.
+        """
+        has_heading = text.strip().startswith("#") or "\n#" in text
+        has_content = len(text.strip()) > 50
+
+        if has_heading and has_content:
             return ConstraintResult(
                 passed=True,
                 constraint_name="skill_structure",
-                message="Skill has valid frontmatter (name + description)",
+                message="Skill body has valid markdown structure",
             )
         else:
             missing = []
-            if not has_frontmatter:
-                missing.append("YAML frontmatter (---)")
-            if not has_name:
-                missing.append("name field")
-            if not has_description:
-                missing.append("description field")
+            if not has_heading:
+                missing.append("markdown heading (#)")
+            if not has_content:
+                missing.append("meaningful content (>50 chars)")
             return ConstraintResult(
                 passed=False,
                 constraint_name="skill_structure",
-                message=f"Skill missing: {', '.join(missing)}",
+                message=f"Skill body missing: {', '.join(missing)}",
             )

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -104,36 +104,49 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
-    """DSPy-compatible metric function for skill optimization.
+def skill_fitness_metric(example, prediction, trace=None, pred_name=None, pred_trace=None):
+    """Fitness metric compatible with both GEPA and MIPROv2.
 
-    This is what gets passed to dspy.GEPA(metric=...).
-    Returns a float 0-1 score.
+    Returns dspy.Prediction(score=float, feedback=str) which:
+    - GEPA reads for reflective trace-aware mutation (uses feedback)
+    - MIPROv2 extracts as a float via __float__() (ignores feedback)
+
+    Uses LLM-as-judge via the currently configured dspy.LM for meaningful
+    evaluation. Falls back to keyword overlap if the LLM call fails.
     """
-    # The prediction should have an 'output' field with the agent's response
     agent_output = getattr(prediction, "output", "") or ""
     expected = getattr(example, "expected_behavior", "") or ""
     task = getattr(example, "task_input", "") or ""
 
     if not agent_output.strip():
-        return 0.0
+        return dspy.Prediction(score=0.0, feedback="Agent produced empty output.")
 
-    # Quick heuristic scoring (for speed during optimization)
-    # Full LLM-as-judge scoring is expensive — use it selectively
-    score = 0.5  # Base score for non-empty output
-
-    # Check if key phrases from expected behavior appear
-    expected_lower = expected.lower()
-    output_lower = agent_output.lower()
-
-    # Simple keyword overlap as a fast proxy
-    expected_words = set(expected_lower.split())
-    output_words = set(output_lower.split())
-    if expected_words:
-        overlap = len(expected_words & output_words) / len(expected_words)
-        score = 0.3 + (0.7 * overlap)
-
-    return min(1.0, max(0.0, score))
+    # Primary: LLM-as-judge using whatever model is currently configured
+    try:
+        judge = dspy.ChainOfThought(
+            "task_input, expected_behavior, agent_output -> score: float, feedback: str"
+        )
+        result = judge(
+            task_input=task,
+            expected_behavior=expected,
+            agent_output=agent_output,
+        )
+        score = _parse_score(result.score)
+        feedback = str(getattr(result, "feedback", ""))
+        return dspy.Prediction(score=score, feedback=feedback)
+    except Exception:
+        # Fallback: keyword overlap (no LLM cost, works offline)
+        expected_words = set(expected.lower().split())
+        output_words = set(agent_output.lower().split())
+        if expected_words:
+            overlap = len(expected_words & output_words) / len(expected_words)
+            score = min(1.0, max(0.0, 0.3 + 0.7 * overlap))
+        else:
+            score = 0.5
+        return dspy.Prediction(
+            score=score,
+            feedback=f"Keyword overlap fallback: {score:.2f}",
+        )
 
 
 def _parse_score(value) -> float:

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -154,10 +154,15 @@ def evolve(
     start_time = time.time()
 
     try:
-        optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
-            max_steps=iterations,
-        )
+        # DSPy >=3.0: GEPA uses auto/max_metric_calls/max_full_evals (not max_steps)
+        gepa_kwargs = dict(metric=skill_fitness_metric, auto="light")
+
+        # GEPA benefits from a dedicated reflection LM for trace-aware mutations.
+        # If not provided, GEPA will raise — so we configure one from the optimizer model.
+        optimizer_lm = dspy.LM(optimizer_model, temperature=1.0, max_tokens=4096)
+        gepa_kwargs["reflection_lm"] = optimizer_lm
+
+        optimizer = dspy.GEPA(**gepa_kwargs)
 
         optimized_module = optimizer.compile(
             baseline_module,
@@ -165,8 +170,8 @@ def evolve(
             valset=valset,
         )
     except Exception as e:
-        # Fall back to MIPROv2 if GEPA isn't available in this DSPy version
-        console.print(f"[yellow]GEPA not available ({e}), falling back to MIPROv2[/yellow]")
+        # Fall back to MIPROv2 if GEPA isn't available or misconfigured
+        console.print(f"[yellow]GEPA unavailable ({e}), falling back to MIPROv2[/yellow]")
         optimizer = dspy.MIPROv2(
             metric=skill_fitness_metric,
             auto="light",

--- a/tests/core/test_constraints.py
+++ b/tests/core/test_constraints.py
@@ -65,34 +65,53 @@ class TestNonEmpty:
 
 
 class TestSkillStructure:
-    def test_valid_skill(self, validator):
-        skill = "---\nname: test-skill\ndescription: A test skill\n---\n\n# Test\nContent here"
-        result = validator._check_skill_structure(skill)
+    """Tests for skill body structure validation.
+
+    Note: _check_skill_structure receives the body (after frontmatter),
+    not the full file. Frontmatter is preserved separately by load_skill()
+    and reassembled by reassemble_skill(). The validator checks markdown
+    structure of the body only.
+    """
+
+    def test_valid_body(self, validator):
+        body = "# Test Skill\n\nThis is a valid skill body with content."
+        result = validator._check_skill_structure(body)
         assert result.passed
 
-    def test_missing_frontmatter(self, validator):
-        skill = "# Test\nContent without frontmatter"
-        result = validator._check_skill_structure(skill)
+    def test_body_with_subheadings(self, validator):
+        body = "# Main\n\n## Section 1\nContent here.\n\n## Section 2\nMore content."
+        result = validator._check_skill_structure(body)
+        assert result.passed
+
+    def test_body_without_heading_fails(self, validator):
+        body = "Just some text without any markdown heading, this should fail."
+        result = validator._check_skill_structure(body)
         assert not result.passed
 
-    def test_missing_name(self, validator):
-        skill = "---\ndescription: A test skill\n---\n\n# Test"
-        result = validator._check_skill_structure(skill)
+    def test_empty_body_fails(self, validator):
+        body = ""
+        result = validator._check_skill_structure(body)
         assert not result.passed
 
-    def test_missing_description(self, validator):
-        skill = "---\nname: test-skill\n---\n\n# Test"
-        result = validator._check_skill_structure(skill)
+    def test_whitespace_only_body_fails(self, validator):
+        body = "   \n\n  "
+        result = validator._check_skill_structure(body)
         assert not result.passed
+
+    def test_heading_only_too_short_fails(self, validator):
+        body = "# Title"
+        result = validator._check_skill_structure(body)
+        assert not result.passed
+        assert "meaningful content" in result.message
 
 
 class TestValidateAll:
-    def test_valid_skill_passes_all(self, validator):
-        skill = "---\nname: test\ndescription: Test skill\n---\n\n# Procedure\n1. Do thing"
-        results = validator.validate_all(skill, "skill")
+    def test_valid_body_passes_all(self, validator):
+        body = "# Procedure\n\n1. Do thing\n2. Do another thing\n3. Verify result"
+        results = validator.validate_all(body, "skill")
         assert all(r.passed for r in results)
 
-    def test_empty_skill_fails(self, validator):
+    def test_empty_body_fails(self, validator):
         results = validator.validate_all("", "skill")
         failed = [r for r in results if not r.passed]
         assert len(failed) > 0


### PR DESCRIPTION
## Summary

Three fixes that make `hermes-agent-self-evolution` work correctly with DSPy >=3.1. Without these, the pipeline silently falls back to MIPROv2 and rejects every evolved skill at the constraint gate.

Fixes #10, #11, #12

## Changes

### 1. `evolution/skills/evolve_skill.py` — GEPA API fix
- **Problem:** `dspy.GEPA(max_steps=N)` — DSPy 3.x has no `max_steps` param
- **Fix:** Use `dspy.GEPA(auto="light")` and configure `reflection_lm` from the existing `optimizer_model`
- **Impact:** GEPA now actually runs instead of always falling back to MIPROv2

### 2. `evolution/core/constraints.py` — Constraint validation fix
- **Problem:** `_check_skill_structure()` checks for YAML frontmatter (`---`) in the skill body, but `validate_all()` receives body-only text (frontmatter stripped by `load_skill()`)
- **Fix:** Validate markdown structure (headings + content length) instead of frontmatter presence
- **Impact:** Evolved skills that pass optimization are no longer rejected at the constraint gate

### 3. `evolution/core/fitness.py` — Fitness metric upgrade
- **Problem:** Keyword overlap metric scores everything in 37-49% range — insufficient signal for optimization
- **Fix:** Use LLM-as-judge (via configured `dspy.LM`) with keyword overlap fallback. Returns `dspy.Prediction(score, feedback)` compatible with both GEPA and MIPROv2
- **Impact:** Real evaluation signal; GEPA gets feedback for reflective mutations

### 4. `tests/core/test_constraints.py` — Updated tests
- Tests updated to validate body structure (matching the corrected constraint behavior)
- All 25 tests pass

## Testing

Tested end-to-end with:
- DSPy 3.1.3
- Anthropic models (claude-sonnet-4-6 optimizer, claude-haiku-4-5 eval)
- 136 Hermes Agent skills
- Results: proactive-agent 67.2% → 81.4% (+21%), verification-before-completion 96.2% → 96.2% (already optimal)

All changes are model-agnostic — `dspy.LM()` routes via LiteLLM, so any provider (OpenAI, Anthropic, local models) works without modification.

```bash
# Verified with:
PYTHONPATH="" .venv/bin/python -m pytest tests/core/test_constraints.py tests/skills/test_skill_module.py -q
# 25 passed in 2.12s
```