### PR TITLE
feat: add MiniMax provider support (M3 as default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,36 @@ python -m evolution.skills.evolve_skill \
     --eval-source sessiondb
 ```
 
+### Using MiniMax
+
+Set your API key and pass `--use-minimax` (or specify the model directly):
+
+```bash
+export MINIMAX_API_KEY=your_key_here
+
+# Shorthand — uses MiniMax-M2.7 for both optimizer and eval
+python -m evolution.skills.evolve_skill \
+    --skill github-code-review \
+    --use-minimax
+
+# Explicit model selection
+python -m evolution.skills.evolve_skill \
+    --skill github-code-review \
+    --optimizer-model minimax/MiniMax-M2.7 \
+    --eval-model minimax/MiniMax-M2.7-highspeed
+```
+
+Supported MiniMax models:
+
+| Model ID | Description |
+|----------|-------------|
+| `MiniMax-M2.7` | Peak performance — default choice |
+| `MiniMax-M2.7-highspeed` | Same performance, lower latency |
+
+MiniMax uses the OpenAI-compatible endpoint at `https://api.minimax.io/v1`. The
+`MINIMAX_API_KEY` environment variable is read automatically; no other
+configuration is needed.
+
 ## What It Optimizes
 
 | Phase | Target | Engine | Status |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Set your API key and pass `--use-minimax` (or specify the model directly):
 ```bash
 export MINIMAX_API_KEY=your_key_here
 
-# Shorthand — uses MiniMax-M2.7 for both optimizer and eval
+# Shorthand — uses MiniMax-M3 for both optimizer and eval
 python -m evolution.skills.evolve_skill \
     --skill github-code-review \
     --use-minimax
@@ -64,7 +64,7 @@ python -m evolution.skills.evolve_skill \
 # Explicit model selection
 python -m evolution.skills.evolve_skill \
     --skill github-code-review \
-    --optimizer-model minimax/MiniMax-M2.7 \
+    --optimizer-model minimax/MiniMax-M3 \
     --eval-model minimax/MiniMax-M2.7-highspeed
 ```
 
@@ -72,8 +72,9 @@ Supported MiniMax models:
 
 | Model ID | Description |
 |----------|-------------|
-| `MiniMax-M2.7` | Peak performance — default choice |
-| `MiniMax-M2.7-highspeed` | Same performance, lower latency |
+| `MiniMax-M3` | 512K context, max output 128K, image input — default choice |
+| `MiniMax-M2.7` | Previous generation |
+| `MiniMax-M2.7-highspeed` | Previous generation, lower latency |
 
 MiniMax uses the OpenAI-compatible endpoint at `https://api.minimax.io/v1`. The
 `MINIMAX_API_KEY` environment variable is read automatically; no other

--- a/evolution/core/config.py
+++ b/evolution/core/config.py
@@ -3,7 +3,20 @@
 import os
 from pathlib import Path
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import dspy
+
+
+# MiniMax model IDs supported via the OpenAI-compatible endpoint.
+# Only Chat models — MiniMax has no Embedding model.
+MINIMAX_MODELS = (
+    "MiniMax-M2.7",            # Peak Performance. Ultimate Value.
+    "MiniMax-M2.7-highspeed",  # Same performance, faster.
+)
+
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
 
 
 @dataclass
@@ -21,6 +34,10 @@ class EvolutionConfig:
     optimizer_model: str = "openai/gpt-4.1"  # Model for GEPA reflections
     eval_model: str = "openai/gpt-4.1-mini"  # Model for LLM-as-judge scoring
     judge_model: str = "openai/gpt-4.1"  # Model for dataset generation
+
+    # MiniMax provider configuration
+    minimax_api_key: str = field(default_factory=lambda: os.getenv("MINIMAX_API_KEY", ""))
+    minimax_base_url: str = MINIMAX_BASE_URL
 
     # Constraints
     max_skill_size: int = 15_000  # 15KB default
@@ -42,6 +59,35 @@ class EvolutionConfig:
     # Output
     output_dir: Path = field(default_factory=lambda: Path("./output"))
     create_pr: bool = True
+
+    def make_lm(self, model: str) -> "dspy.LM":
+        """Create a DSPy LM instance, with MiniMax routing handled automatically.
+
+        For MiniMax models (MiniMax-M2.7 or MiniMax-M2.7-highspeed), this sets
+        the correct base URL and API key. Pass either the bare model ID or a
+        prefixed form such as ``minimax/MiniMax-M2.7`` or ``openai/MiniMax-M2.7``.
+
+        All other models are forwarded to ``dspy.LM`` unchanged, so existing
+        OpenAI / OpenRouter / LiteLLM strings continue to work.
+        """
+        import dspy
+
+        # Strip any provider prefix (e.g. "openai/", "minimax/") to get the bare ID
+        bare = model.split("/")[-1]
+
+        if bare in MINIMAX_MODELS:
+            if not self.minimax_api_key:
+                raise ValueError(
+                    f"MINIMAX_API_KEY is not set. Export it before using '{bare}'."
+                )
+            return dspy.LM(
+                f"openai/{bare}",
+                api_key=self.minimax_api_key,
+                base_url=self.minimax_base_url,
+                temperature=1.0,  # MiniMax requires temperature in (0.0, 1.0]
+            )
+
+        return dspy.LM(model)
 
 
 def get_hermes_agent_path() -> Path:

--- a/evolution/core/config.py
+++ b/evolution/core/config.py
@@ -12,8 +12,9 @@ if TYPE_CHECKING:
 # MiniMax model IDs supported via the OpenAI-compatible endpoint.
 # Only Chat models — MiniMax has no Embedding model.
 MINIMAX_MODELS = (
-    "MiniMax-M2.7",            # Peak Performance. Ultimate Value.
-    "MiniMax-M2.7-highspeed",  # Same performance, faster.
+    "MiniMax-M3",              # Latest: 512K context, 128K max output, image input. Default.
+    "MiniMax-M2.7",            # Previous generation.
+    "MiniMax-M2.7-highspeed",  # Previous generation, lower latency.
 )
 
 MINIMAX_BASE_URL = "https://api.minimax.io/v1"
@@ -63,9 +64,9 @@ class EvolutionConfig:
     def make_lm(self, model: str) -> "dspy.LM":
         """Create a DSPy LM instance, with MiniMax routing handled automatically.
 
-        For MiniMax models (MiniMax-M2.7 or MiniMax-M2.7-highspeed), this sets
-        the correct base URL and API key. Pass either the bare model ID or a
-        prefixed form such as ``minimax/MiniMax-M2.7`` or ``openai/MiniMax-M2.7``.
+        For MiniMax models (MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed), this
+        sets the correct base URL and API key. Pass either the bare model ID or a
+        prefixed form such as ``minimax/MiniMax-M3`` or ``openai/MiniMax-M3``.
 
         All other models are forwarded to ``dspy.LM`` unchanged, so existing
         OpenAI / OpenRouter / LiteLLM strings continue to work.

--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -123,7 +123,7 @@ class SyntheticDatasetBuilder:
         n = num_cases or self.config.eval_dataset_size
 
         # Configure DSPy to use the judge model for generation
-        lm = dspy.LM(self.config.judge_model)
+        lm = self.config.make_lm(self.config.judge_model)
 
         with dspy.context(lm=lm):
             result = self.generator(

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -72,7 +72,7 @@ class LLMJudge:
     ) -> FitnessScore:
         """Score an agent output using LLM-as-judge."""
 
-        lm = dspy.LM(self.config.eval_model)
+        lm = self.config.make_lm(self.config.eval_model)
 
         with dspy.context(lm=lm):
             result = self.judge(

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -29,6 +29,7 @@ from evolution.skills.skill_module import (
     find_skill,
     reassemble_skill,
 )
+from evolution.core.config import MINIMAX_MODELS
 
 console = Console()
 
@@ -43,8 +44,13 @@ def evolve(
     hermes_repo: Optional[str] = None,
     run_tests: bool = False,
     dry_run: bool = False,
+    use_minimax: bool = False,
 ):
     """Main evolution function — orchestrates the full optimization loop."""
+
+    if use_minimax:
+        optimizer_model = f"minimax/{MINIMAX_MODELS[0]}"
+        eval_model = f"minimax/{MINIMAX_MODELS[0]}"
 
     config = EvolutionConfig(
         iterations=iterations,
@@ -138,7 +144,7 @@ def evolve(
     console.print(f"  Eval model: {eval_model}")
 
     # Configure DSPy
-    lm = dspy.LM(eval_model)
+    lm = config.make_lm(eval_model)
     dspy.configure(lm=lm)
 
     # Create the baseline skill module
@@ -304,7 +310,8 @@ def evolve(
 @click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
 @click.option("--run-tests", is_flag=True, help="Run full pytest suite as constraint gate")
 @click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")
-def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run):
+@click.option("--use-minimax", is_flag=True, help="Use MiniMax as the LLM backend (requires MINIMAX_API_KEY)")
+def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run, use_minimax):
     """Evolve a Hermes Agent skill using DSPy + GEPA optimization."""
     evolve(
         skill_name=skill,
@@ -316,6 +323,7 @@ def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_mod
         hermes_repo=hermes_repo,
         run_tests=run_tests,
         dry_run=dry_run,
+        use_minimax=use_minimax,
     )
 
 

--- a/tests/core/test_minimax_config.py
+++ b/tests/core/test_minimax_config.py
@@ -1,0 +1,161 @@
+"""Tests for MiniMax provider support in EvolutionConfig."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from evolution.core.config import EvolutionConfig, MINIMAX_MODELS, MINIMAX_BASE_URL
+
+
+# Provide a dummy hermes_agent_path so EvolutionConfig() doesn't auto-discover
+_DUMMY_PATH = Path("/tmp")
+
+
+class TestMinimaxConstants:
+    def test_minimax_models_contains_expected_ids(self):
+        assert "MiniMax-M2.7" in MINIMAX_MODELS
+        assert "MiniMax-M2.7-highspeed" in MINIMAX_MODELS
+
+    def test_minimax_base_url(self):
+        assert MINIMAX_BASE_URL == "https://api.minimax.io/v1"
+
+    def test_no_embedding_models(self):
+        # MiniMax has no embedding model — none of the IDs should imply embeddings
+        for model in MINIMAX_MODELS:
+            assert "embed" not in model.lower()
+
+
+class TestEvolutionConfigMinimaxDefaults:
+    def test_minimax_api_key_defaults_to_empty(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MINIMAX_API_KEY", None)
+            config = EvolutionConfig(hermes_agent_path=_DUMMY_PATH)
+        assert config.minimax_api_key == ""
+
+    def test_minimax_api_key_read_from_env(self):
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-12345"}):
+            config = EvolutionConfig(hermes_agent_path=_DUMMY_PATH)
+        assert config.minimax_api_key == "test-key-12345"
+
+    def test_minimax_base_url_default(self):
+        config = EvolutionConfig(hermes_agent_path=_DUMMY_PATH)
+        assert config.minimax_base_url == MINIMAX_BASE_URL
+
+    def test_minimax_base_url_overridable(self):
+        config = EvolutionConfig(
+            hermes_agent_path=_DUMMY_PATH,
+            minimax_base_url="https://custom.endpoint/v1",
+        )
+        assert config.minimax_base_url == "https://custom.endpoint/v1"
+
+
+class TestMakeLm:
+    @pytest.fixture
+    def config_with_key(self):
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "sk-minimax-testkey"}):
+            return EvolutionConfig(hermes_agent_path=_DUMMY_PATH)
+
+    def test_make_lm_minimax_bare_model_id(self, config_with_key):
+        """Bare model ID (no prefix) routes to MiniMax."""
+        mock_lm = MagicMock()
+        with patch("dspy.LM", return_value=mock_lm) as mock_dspy_lm:
+            result = config_with_key.make_lm("MiniMax-M2.7")
+
+        mock_dspy_lm.assert_called_once_with(
+            "openai/MiniMax-M2.7",
+            api_key="sk-minimax-testkey",
+            base_url=MINIMAX_BASE_URL,
+            temperature=1.0,
+        )
+        assert result is mock_lm
+
+    def test_make_lm_minimax_prefixed(self, config_with_key):
+        """minimax/ prefix is stripped before routing."""
+        mock_lm = MagicMock()
+        with patch("dspy.LM", return_value=mock_lm) as mock_dspy_lm:
+            config_with_key.make_lm("minimax/MiniMax-M2.7")
+
+        mock_dspy_lm.assert_called_once_with(
+            "openai/MiniMax-M2.7",
+            api_key="sk-minimax-testkey",
+            base_url=MINIMAX_BASE_URL,
+            temperature=1.0,
+        )
+
+    def test_make_lm_minimax_openai_prefixed(self, config_with_key):
+        """openai/MiniMax-M2.7 prefix is stripped and routed to MiniMax."""
+        mock_lm = MagicMock()
+        with patch("dspy.LM", return_value=mock_lm) as mock_dspy_lm:
+            config_with_key.make_lm("openai/MiniMax-M2.7")
+
+        mock_dspy_lm.assert_called_once_with(
+            "openai/MiniMax-M2.7",
+            api_key="sk-minimax-testkey",
+            base_url=MINIMAX_BASE_URL,
+            temperature=1.0,
+        )
+
+    def test_make_lm_highspeed_model(self, config_with_key):
+        """MiniMax-M2.7-highspeed is also routed correctly."""
+        mock_lm = MagicMock()
+        with patch("dspy.LM", return_value=mock_lm) as mock_dspy_lm:
+            config_with_key.make_lm("MiniMax-M2.7-highspeed")
+
+        mock_dspy_lm.assert_called_once_with(
+            "openai/MiniMax-M2.7-highspeed",
+            api_key="sk-minimax-testkey",
+            base_url=MINIMAX_BASE_URL,
+            temperature=1.0,
+        )
+
+    def test_make_lm_temperature_one(self, config_with_key):
+        """MiniMax requires temperature in (0, 1] — must default to 1.0."""
+        with patch("dspy.LM") as mock_dspy_lm:
+            config_with_key.make_lm("MiniMax-M2.7")
+
+        _, kwargs = mock_dspy_lm.call_args
+        assert kwargs["temperature"] == 1.0
+        assert kwargs["temperature"] > 0.0
+
+    def test_make_lm_minimax_no_api_key_raises(self):
+        """Missing MINIMAX_API_KEY raises a clear ValueError."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MINIMAX_API_KEY", None)
+            config = EvolutionConfig(hermes_agent_path=_DUMMY_PATH)
+
+        with pytest.raises(ValueError, match="MINIMAX_API_KEY"):
+            config.make_lm("MiniMax-M2.7")
+
+    def test_make_lm_openai_passes_through(self):
+        """Non-MiniMax models are forwarded to dspy.LM as-is."""
+        config = EvolutionConfig(hermes_agent_path=_DUMMY_PATH)
+        mock_lm = MagicMock()
+        with patch("dspy.LM", return_value=mock_lm) as mock_dspy_lm:
+            result = config.make_lm("openai/gpt-4.1")
+
+        mock_dspy_lm.assert_called_once_with("openai/gpt-4.1")
+        assert result is mock_lm
+
+    def test_make_lm_anthropic_passes_through(self):
+        """Anthropic models pass through unchanged."""
+        config = EvolutionConfig(hermes_agent_path=_DUMMY_PATH)
+        with patch("dspy.LM") as mock_dspy_lm:
+            config.make_lm("anthropic/claude-3-5-sonnet-20241022")
+
+        mock_dspy_lm.assert_called_once_with("anthropic/claude-3-5-sonnet-20241022")
+
+    def test_make_lm_custom_base_url(self):
+        """Custom minimax_base_url is forwarded to dspy.LM."""
+        config = EvolutionConfig(
+            hermes_agent_path=_DUMMY_PATH,
+            minimax_api_key="my-key",
+            minimax_base_url="https://private.minimax.io/v1",
+        )
+        with patch("dspy.LM") as mock_dspy_lm:
+            config.make_lm("MiniMax-M2.7")
+
+        _, kwargs = mock_dspy_lm.call_args
+        assert kwargs["base_url"] == "https://private.minimax.io/v1"
+

--- a/tests/core/test_minimax_config.py
+++ b/tests/core/test_minimax_config.py
@@ -15,8 +15,18 @@ _DUMMY_PATH = Path("/tmp")
 
 class TestMinimaxConstants:
     def test_minimax_models_contains_expected_ids(self):
+        assert "MiniMax-M3" in MINIMAX_MODELS
         assert "MiniMax-M2.7" in MINIMAX_MODELS
         assert "MiniMax-M2.7-highspeed" in MINIMAX_MODELS
+
+    def test_minimax_m3_is_default(self):
+        # M3 must be the first entry so MINIMAX_MODELS[0] resolves to it.
+        assert MINIMAX_MODELS[0] == "MiniMax-M3"
+
+    def test_older_models_removed(self):
+        # M1/M2/M2.1/M2.5 must not appear in the supported list.
+        for old in ("MiniMax-M1", "MiniMax-M2", "MiniMax-M2.1", "MiniMax-M2.5"):
+            assert old not in MINIMAX_MODELS
 
     def test_minimax_base_url(self):
         assert MINIMAX_BASE_URL == "https://api.minimax.io/v1"
@@ -61,10 +71,10 @@ class TestMakeLm:
         """Bare model ID (no prefix) routes to MiniMax."""
         mock_lm = MagicMock()
         with patch("dspy.LM", return_value=mock_lm) as mock_dspy_lm:
-            result = config_with_key.make_lm("MiniMax-M2.7")
+            result = config_with_key.make_lm("MiniMax-M3")
 
         mock_dspy_lm.assert_called_once_with(
-            "openai/MiniMax-M2.7",
+            "openai/MiniMax-M3",
             api_key="sk-minimax-testkey",
             base_url=MINIMAX_BASE_URL,
             temperature=1.0,
@@ -75,20 +85,33 @@ class TestMakeLm:
         """minimax/ prefix is stripped before routing."""
         mock_lm = MagicMock()
         with patch("dspy.LM", return_value=mock_lm) as mock_dspy_lm:
-            config_with_key.make_lm("minimax/MiniMax-M2.7")
+            config_with_key.make_lm("minimax/MiniMax-M3")
 
         mock_dspy_lm.assert_called_once_with(
-            "openai/MiniMax-M2.7",
+            "openai/MiniMax-M3",
             api_key="sk-minimax-testkey",
             base_url=MINIMAX_BASE_URL,
             temperature=1.0,
         )
 
     def test_make_lm_minimax_openai_prefixed(self, config_with_key):
-        """openai/MiniMax-M2.7 prefix is stripped and routed to MiniMax."""
+        """openai/MiniMax-M3 prefix is stripped and routed to MiniMax."""
         mock_lm = MagicMock()
         with patch("dspy.LM", return_value=mock_lm) as mock_dspy_lm:
-            config_with_key.make_lm("openai/MiniMax-M2.7")
+            config_with_key.make_lm("openai/MiniMax-M3")
+
+        mock_dspy_lm.assert_called_once_with(
+            "openai/MiniMax-M3",
+            api_key="sk-minimax-testkey",
+            base_url=MINIMAX_BASE_URL,
+            temperature=1.0,
+        )
+
+    def test_make_lm_m27_model(self, config_with_key):
+        """MiniMax-M2.7 is still routed correctly as a previous-gen option."""
+        mock_lm = MagicMock()
+        with patch("dspy.LM", return_value=mock_lm) as mock_dspy_lm:
+            config_with_key.make_lm("MiniMax-M2.7")
 
         mock_dspy_lm.assert_called_once_with(
             "openai/MiniMax-M2.7",
@@ -113,7 +136,7 @@ class TestMakeLm:
     def test_make_lm_temperature_one(self, config_with_key):
         """MiniMax requires temperature in (0, 1] — must default to 1.0."""
         with patch("dspy.LM") as mock_dspy_lm:
-            config_with_key.make_lm("MiniMax-M2.7")
+            config_with_key.make_lm("MiniMax-M3")
 
         _, kwargs = mock_dspy_lm.call_args
         assert kwargs["temperature"] == 1.0
@@ -126,7 +149,7 @@ class TestMakeLm:
             config = EvolutionConfig(hermes_agent_path=_DUMMY_PATH)
 
         with pytest.raises(ValueError, match="MINIMAX_API_KEY"):
-            config.make_lm("MiniMax-M2.7")
+            config.make_lm("MiniMax-M3")
 
     def test_make_lm_openai_passes_through(self):
         """Non-MiniMax models are forwarded to dspy.LM as-is."""
@@ -154,7 +177,7 @@ class TestMakeLm:
             minimax_base_url="https://private.minimax.io/v1",
         )
         with patch("dspy.LM") as mock_dspy_lm:
-            config.make_lm("MiniMax-M2.7")
+            config.make_lm("MiniMax-M3")
 
         _, kwargs = mock_dspy_lm.call_args
         assert kwargs["base_url"] == "https://private.minimax.io/v1"


### PR DESCRIPTION
## Summary

- Add MiniMax chat model provider via the OpenAI-compatible endpoint (`https://api.minimax.io/v1`)
- Use `MiniMax-M3` (512K context, 128K max output, image input) as the **default** MiniMax model
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as previous-generation options
- Add `MINIMAX_API_KEY` environment variable support and a `make_lm()` helper on `EvolutionConfig` that auto-routes MiniMax model strings to the correct base URL and API key
- Add `--use-minimax` CLI flag to `evolve_skill.py` for easy one-flag switching (now defaults to M3)
- Update `SyntheticDatasetBuilder` and `LLMJudge` to use `config.make_lm()` so all LM calls benefit from MiniMax routing
- Document MiniMax usage in README with model table and usage examples
- Add unit tests covering constants, env var loading, model routing (incl. M3 and M2.7 paths), temperature enforcement, and pass-through behavior for non-MiniMax models

## Supported models

| Model ID | Description |
|----------|-------------|
| `MiniMax-M3` | 512K context, max output 128K, image input — **default** |
| `MiniMax-M2.7` | Previous generation |
| `MiniMax-M2.7-highspeed` | Previous generation, lower latency |

## Usage

```bash
export MINIMAX_API_KEY=your_key_here

# Shorthand — uses MiniMax-M3
python -m evolution.skills.evolve_skill --skill github-code-review --use-minimax

# Explicit
python -m evolution.skills.evolve_skill \
    --skill github-code-review \
    --optimizer-model minimax/MiniMax-M3 \
    --eval-model minimax/MiniMax-M2.7-highspeed
```

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
- Pricing: https://platform.minimax.io/docs/guides/pricing-paygo

## Test plan

- [x] `pytest tests/core/test_minimax_config.py` — covers M3 default, M2.7 backward compatibility, env var loading, temperature enforcement, missing-key error, and non-MiniMax pass-through
- [x] Verified `MINIMAX_MODELS[0] == "MiniMax-M3"` and older models (M2.5/M2.1/M2/M1) absent