### PR TITLE
fix: gate evolution success on artifact diffs

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -33,6 +33,11 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+def _is_successful_improvement(baseline_text: str, evolved_text: str, improvement: float) -> bool:
+    """Return True only when optimization produced a real artifact change and a score win."""
+    return evolved_text != baseline_text and improvement > 0
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -225,6 +230,7 @@ def evolve(
     avg_baseline = sum(baseline_scores) / max(1, len(baseline_scores))
     avg_evolved = sum(evolved_scores) / max(1, len(evolved_scores))
     improvement = avg_evolved - avg_baseline
+    successful_improvement = _is_successful_improvement(skill["raw"], evolved_full, improvement)
 
     # ── 9. Report results ───────────────────────────────────────────────
     table = Table(title="Evolution Results")
@@ -285,9 +291,12 @@ def evolve(
 
     console.print(f"\n  Output saved to {output_dir}/")
 
-    if improvement > 0:
+    if successful_improvement:
         console.print(f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement/max(0.001, avg_baseline)*100:+.1f}%)[/bold green]")
         console.print(f"  Review the diff: diff {output_dir}/baseline_skill.md {output_dir}/evolved_skill.md")
+    elif evolved_full == skill["raw"]:
+        console.print(f"\n[yellow]⚠ Evolution produced no artifact change (score delta: {improvement:+.3f})[/yellow]")
+        console.print("  Identical baseline/evolved files are treated as a no-op run")
     else:
         console.print(f"\n[yellow]⚠ Evolution did not improve skill (change: {improvement:+.3f})[/yellow]")
         console.print("  Try: more iterations, better eval dataset, or different optimizer model")

--- a/tests/skills/test_evolve_skill.py
+++ b/tests/skills/test_evolve_skill.py
@@ -1,0 +1,11 @@
+"""Tests for evolve_skill helpers."""
+
+from evolution.skills.evolve_skill import _is_successful_improvement
+
+
+class TestIsSuccessfulImprovement:
+    def test_requires_artifact_diff_and_positive_improvement(self):
+        assert not _is_successful_improvement("same", "same", 0.1)
+        assert not _is_successful_improvement("before", "after", 0.0)
+        assert not _is_successful_improvement("before", "after", -0.1)
+        assert _is_successful_improvement("before", "after", 0.1)


### PR DESCRIPTION
## Summary
- only treat evolution runs as success when the evolved artifact actually differs from baseline
- surface artifact-change status in the results table and metrics output
- add a focused unit test for the success gate

## Why
A run can report a small positive holdout delta even when `baseline_skill.md` and `evolved_skill.md` are byte-for-byte identical. Those should be treated as no-op runs, not successful improvements.

## Testing
- `pytest tests/skills/test_evolve_skill.py tests/core/test_constraints.py tests/skills/test_skill_module.py`