### PR TITLE
Fix nightly evolution reliability and enforce real skill mutation

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -33,6 +33,47 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+class RewriteSkillBody(dspy.Signature):
+    """Rewrite a SKILL.md body to improve execution behavior.
+
+    Return only markdown body text (no YAML frontmatter, no code fences).
+    Preserve command correctness and keep changes minimal/surgical.
+    """
+
+    original_skill_body: str = dspy.InputField(desc="Original SKILL.md body markdown")
+    optimizer_observations: str = dspy.InputField(desc="Optimization observations and behavioral deltas")
+    rewritten_skill_body: str = dspy.OutputField(desc="Improved SKILL.md body markdown only")
+
+
+def rewrite_skill_body_from_observations(
+    original_skill_body: str,
+    optimizer_observations: str,
+    optimizer_model: str,
+) -> tuple[str, str]:
+    """Try to generate an evolved SKILL body when optimizer didn't mutate module attrs.
+
+    Returns: (candidate_body, rewrite_status)
+    """
+    if not optimizer_observations.strip():
+        return original_skill_body, "rewrite_skipped_no_observations"
+
+    try:
+        rewriter = dspy.Predict(RewriteSkillBody)
+        with dspy.context(lm=dspy.LM(optimizer_model)):
+            pred = rewriter(
+                original_skill_body=original_skill_body,
+                optimizer_observations=optimizer_observations,
+            )
+        candidate = (getattr(pred, "rewritten_skill_body", "") or "").strip()
+        if not candidate:
+            return original_skill_body, "rewrite_failed_empty"
+        if candidate.strip() == original_skill_body.strip():
+            return original_skill_body, "rewrite_no_change"
+        return candidate, "rewrite_success"
+    except Exception as e:
+        return original_skill_body, f"rewrite_error:{type(e).__name__}"
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -119,7 +160,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -180,13 +221,56 @@ def evolve(
     console.print(f"\n  Optimization completed in {elapsed:.1f}s")
 
     # ── 6. Extract evolved skill text ───────────────────────────────────
-    # The optimized module's instructions contain the evolved skill text
+    # NOTE: DSPy optimizers often tune predictor prompts/demos, not arbitrary module attrs.
+    # If `skill_text` stays unchanged, any score delta is not promotable to SKILL.md.
     evolved_body = optimized_module.skill_text
+    skill_mutated = evolved_body.strip() != skill["body"].strip()
+    mutation_source = "optimizer_direct"
+    rewrite_status = "not_needed"
+
+    if not skill_mutated:
+        observations = []
+        try:
+            sig = getattr(getattr(optimized_module, "predictor", None), "signature", None)
+            instr = getattr(sig, "instructions", "") if sig else ""
+            if instr:
+                observations.append(f"optimized_predictor_instructions:\n{instr}")
+        except Exception:
+            pass
+        try:
+            dumped = optimized_module.dump_state()
+            maybe_sig = dumped.get("predictor", {}).get("signature_instructions") if isinstance(dumped, dict) else None
+            if maybe_sig:
+                observations.append(f"dumped_signature_instructions:\n{maybe_sig}")
+        except Exception:
+            pass
+
+        observations.append(
+            "behavioral_requirements:\n"
+            "- direct action phrasing over hedging\n"
+            "- avoid patterns like 'please run', 'once you provide', 'if you'd like I can'\n"
+            "- keep command sequences concrete and executable\n"
+            "- minimize wording changes outside behavior-critical sections"
+        )
+
+        evolved_body, rewrite_status = rewrite_skill_body_from_observations(
+            original_skill_body=skill["body"],
+            optimizer_observations="\n\n".join(observations),
+            optimizer_model=optimizer_model,
+        )
+        skill_mutated = evolved_body.strip() != skill["body"].strip()
+        if skill_mutated:
+            mutation_source = "llm_rewrite_from_optimizer"
+            console.print("[green]✓ Applied fallback SKILL body rewrite from optimizer observations[/green]")
+
+    if not skill_mutated:
+        console.print("[yellow]⚠ Optimizer did not mutate SKILL body text (non-promotable run)[/yellow]")
+
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"
@@ -211,6 +295,7 @@ def evolve(
 
     baseline_scores = []
     evolved_scores = []
+    evolved_module = SkillModule(evolved_body)
     for ex in holdout_examples:
         # Score baseline
         with dspy.context(lm=lm):
@@ -218,13 +303,16 @@ def evolve(
             baseline_score = skill_fitness_metric(ex, baseline_pred)
             baseline_scores.append(baseline_score)
 
-            evolved_pred = optimized_module(task_input=ex.task_input)
+            evolved_pred = evolved_module(task_input=ex.task_input)
             evolved_score = skill_fitness_metric(ex, evolved_pred)
             evolved_scores.append(evolved_score)
 
     avg_baseline = sum(baseline_scores) / max(1, len(baseline_scores))
     avg_evolved = sum(evolved_scores) / max(1, len(evolved_scores))
-    improvement = avg_evolved - avg_baseline
+    raw_improvement = avg_evolved - avg_baseline
+    improvement = raw_improvement if skill_mutated else 0.0
+
+    run_status = "success" if skill_mutated else "no_skill_mutation"
 
     # ── 9. Report results ───────────────────────────────────────────────
     table = Table(title="Evolution Results")
@@ -240,6 +328,8 @@ def evolve(
         f"{avg_evolved:.3f}",
         f"[{change_color}]{improvement:+.3f}[/{change_color}]",
     )
+    if not skill_mutated:
+        table.add_row("Raw delta (non-promotable)", "", "", f"{raw_improvement:+.3f}")
     table.add_row(
         "Skill Size",
         f"{len(skill['body']):,} chars",
@@ -263,6 +353,12 @@ def evolve(
     # Save baseline for comparison
     (output_dir / "baseline_skill.md").write_text(skill["raw"])
 
+    # Save optimizer state for forensic/debugging
+    try:
+        (output_dir / "optimized_module_state.json").write_text(json.dumps(optimized_module.dump_state(), indent=2))
+    except Exception as e:
+        console.print(f"[yellow]⚠ Could not dump optimized module state: {e}[/yellow]")
+
     # Save metrics
     metrics = {
         "skill_name": skill_name,
@@ -273,6 +369,11 @@ def evolve(
         "baseline_score": avg_baseline,
         "evolved_score": avg_evolved,
         "improvement": improvement,
+        "raw_improvement": raw_improvement,
+        "skill_mutated": skill_mutated,
+        "mutation_source": mutation_source,
+        "rewrite_status": rewrite_status,
+        "run_status": run_status,
         "baseline_size": len(skill["body"]),
         "evolved_size": len(evolved_body),
         "train_examples": len(dataset.train),
@@ -285,9 +386,12 @@ def evolve(
 
     console.print(f"\n  Output saved to {output_dir}/")
 
-    if improvement > 0:
+    if skill_mutated and improvement > 0:
         console.print(f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement/max(0.001, avg_baseline)*100:+.1f}%)[/bold green]")
         console.print(f"  Review the diff: diff {output_dir}/baseline_skill.md {output_dir}/evolved_skill.md")
+    elif not skill_mutated:
+        console.print("\n[yellow]⚠ Run completed but SKILL text was unchanged; marked as non-promotable[/yellow]")
+        console.print(f"  Raw holdout delta (prompt-only): {raw_improvement:+.3f}")
     else:
         console.print(f"\n[yellow]⚠ Evolution did not improve skill (change: {improvement:+.3f})[/yellow]")
         console.print("  Try: more iterations, better eval dataset, or different optimizer model")

--- a/scripts/evaluate_latest_run.py
+++ b/scripts/evaluate_latest_run.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+OUTPUT_ROOT = Path('/Users/kirniy/dev/hermes-agent-self-evolution/output')
+MAX_SIZE_GROWTH_RATIO = 0.15
+MAX_SUSPICIOUS_IMPROVEMENT = 0.35
+MIN_HOLDOUT_EXAMPLES = 3
+MIN_TOTAL_EXAMPLES = 10
+MAX_RUN_AGE_SECONDS = 8 * 60 * 60
+
+
+def latest_metrics() -> Path:
+    candidates = sorted(OUTPUT_ROOT.glob('*/**/metrics.json'), key=lambda p: p.stat().st_mtime, reverse=True)
+    if not candidates:
+        raise SystemExit('No metrics.json files found under output/.')
+    return candidates[0]
+
+
+def main() -> int:
+    metrics_path = latest_metrics()
+    metrics = json.loads(metrics_path.read_text())
+
+    baseline = float(metrics.get('baseline_score', 0.0))
+    evolved = float(metrics.get('evolved_score', 0.0))
+    improvement = float(metrics.get('improvement', evolved - baseline))
+    baseline_size = int(metrics.get('baseline_size', 0))
+    evolved_size = int(metrics.get('evolved_size', 0))
+    constraints_passed = bool(metrics.get('constraints_passed', False))
+    holdout = int(metrics.get('holdout_examples', 0))
+    total_examples = int(metrics.get('train_examples', 0)) + int(metrics.get('val_examples', 0)) + holdout
+
+    run_dir = metrics_path.parent
+    baseline_skill_path = run_dir / 'baseline_skill.md'
+    evolved_skill_path = run_dir / 'evolved_skill.md'
+
+    reasons: list[str] = []
+    if not constraints_passed:
+        reasons.append('constraints failed')
+    if improvement <= 0:
+        reasons.append(f'non-positive improvement: {improvement:+.3f}')
+    if metrics.get('run_status') not in (None, 'success'):
+        reasons.append(f"run status not successful: {metrics.get('run_status')}")
+    if baseline_size > 0 and evolved_size > baseline_size * (1 + MAX_SIZE_GROWTH_RATIO):
+        reasons.append(f'size growth too large: {baseline_size} -> {evolved_size}')
+    if improvement > MAX_SUSPICIOUS_IMPROVEMENT:
+        reasons.append(f'suspiciously large improvement: {improvement:+.3f}')
+    if holdout < MIN_HOLDOUT_EXAMPLES:
+        reasons.append(f'holdout examples too low: {holdout}')
+    if total_examples < MIN_TOTAL_EXAMPLES:
+        reasons.append(f'total examples too low: {total_examples}')
+    if baseline_skill_path.exists() and evolved_skill_path.exists():
+        if baseline_skill_path.read_bytes() == evolved_skill_path.read_bytes():
+            reasons.append('baseline/evolved skills are byte-identical (metric-gaming suspect)')
+
+    run_age_seconds = time.time() - metrics_path.stat().st_mtime
+    if run_age_seconds > MAX_RUN_AGE_SECONDS:
+        hours = run_age_seconds / 3600.0
+        reasons.append(f'stale run artifact: latest metrics is {hours:.1f}h old')
+
+    print(f'Latest metrics: {metrics_path}')
+    print(json.dumps(metrics, indent=2))
+
+    if reasons:
+        print('\nREJECTED')
+        for reason in reasons:
+            print(f'- {reason}')
+        return 2
+
+    print('\nACCEPTABLE')
+    print(f'- improvement: {improvement:+.3f}')
+    print(f'- size delta: {evolved_size - baseline_size:+d}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/google_key_pool.py
+++ b/scripts/google_key_pool.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+ENV_PATH = Path('/Users/kirniy/.hermes/.env')
+STATE_PATH = Path('/Users/kirniy/.hermes/google_key_pool_state.json')
+KEY_PATTERNS = [
+    re.compile(r'^(GOOGLE_API_KEY)(?:_(\d+))?$'),
+    re.compile(r'^(GEMINI_API_KEY)(?:_(\d+))?$'),
+]
+COOLDOWN_SECONDS = 6 * 60 * 60
+
+
+def parse_env(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    entries = []
+    seen = set()
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+        key, value = line.split('=', 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if not value:
+            continue
+        for pattern in KEY_PATTERNS:
+            m = pattern.match(key)
+            if m:
+                order = int(m.group(2) or '1')
+                if value in seen:
+                    break
+                seen.add(value)
+                entries.append({'env_key': key, 'value': value, 'order': order})
+                break
+    entries.sort(key=lambda item: (item['order'], item['env_key']))
+    return entries
+
+
+def load_state() -> dict:
+    if not STATE_PATH.exists():
+        return {'bad': {}, 'cursor': 0}
+    try:
+        return json.loads(STATE_PATH.read_text())
+    except Exception:
+        return {'bad': {}, 'cursor': 0}
+
+
+def save_state(state: dict) -> None:
+    STATE_PATH.write_text(json.dumps(state, indent=2) + '\n')
+
+
+def select_key() -> int:
+    entries = parse_env(ENV_PATH)
+    if not entries:
+        print('No GOOGLE_API_KEY / GEMINI_API_KEY pool entries found in ~/.hermes/.env', file=sys.stderr)
+        return 1
+
+    state = load_state()
+    now = time.time()
+    bad = {k: v for k, v in (state.get('bad') or {}).items() if float(v.get('until', 0)) > now}
+    state['bad'] = bad
+    cursor = int(state.get('cursor', 0) or 0)
+
+    ordered = entries[cursor:] + entries[:cursor]
+    chosen = None
+    for idx, entry in enumerate(ordered):
+        if entry['env_key'] in bad:
+            continue
+        chosen = entry
+        state['cursor'] = (cursor + idx + 1) % len(entries)
+        break
+
+    if chosen is None:
+        # All keys cooling down. Reset cooldowns and try first key again.
+        state['bad'] = {}
+        chosen = ordered[0]
+        state['cursor'] = (cursor + 1) % len(entries)
+
+    save_state(state)
+    print(chosen['env_key'])
+    print(chosen['value'])
+    return 0
+
+
+def mark_bad(env_key: str, reason: str) -> int:
+    entries = parse_env(ENV_PATH)
+    if not any(entry['env_key'] == env_key for entry in entries):
+        print(f'Unknown env key: {env_key}', file=sys.stderr)
+        return 1
+    state = load_state()
+    bad = state.setdefault('bad', {})
+    bad[env_key] = {
+        'reason': reason,
+        'at': time.time(),
+        'until': time.time() + COOLDOWN_SECONDS,
+    }
+    save_state(state)
+    print(f'marked bad: {env_key} ({reason})')
+    return 0
+
+
+def reset_state() -> int:
+    save_state({'bad': {}, 'cursor': 0})
+    print('reset')
+    return 0
+
+
+def count_keys() -> int:
+    print(len(parse_env(ENV_PATH)))
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print('usage: google_key_pool.py select|mark-bad <ENV_KEY> <reason>|reset|count', file=sys.stderr)
+        return 1
+    cmd = argv[1]
+    if cmd == 'select':
+        return select_key()
+    if cmd == 'mark-bad' and len(argv) >= 4:
+        return mark_bad(argv[2], ' '.join(argv[3:]))
+    if cmd == 'reset':
+        return reset_state()
+    if cmd == 'count':
+        return count_keys()
+    print('usage: google_key_pool.py select|mark-bad <ENV_KEY> <reason>|reset|count', file=sys.stderr)
+    return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main(sys.argv))

--- a/scripts/nightly_evolve_skill.sh
+++ b/scripts/nightly_evolve_skill.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+source .venv311/bin/activate
+if [[ -f /Users/kirniy/.hermes/.env ]]; then
+  set -a
+  source /Users/kirniy/.hermes/.env
+  set +a
+fi
+export HERMES_AGENT_REPO="${HERMES_AGENT_REPO:-/Users/kirniy/.hermes/hermes-agent}"
+export PYTHONUNBUFFERED=1
+# Force Gemini through local SOCKS5 geo-bypass proxy (Nano Banana pattern)
+export GEMINI_PROXY="${GEMINI_PROXY:-socks5://127.0.0.1:10818}"
+export ALL_PROXY="${ALL_PROXY:-socks5h://127.0.0.1:10818}"
+export HTTPS_PROXY="${HTTPS_PROXY:-socks5h://127.0.0.1:10818}"
+export HTTP_PROXY="${HTTP_PROXY:-socks5h://127.0.0.1:10818}"
+GOOGLE_KEY_ENV=""
+GOOGLE_KEY_VALUE=""
+POOL_SIZE="$(python ./scripts/google_key_pool.py count 2>/dev/null || echo 0)"
+select_google_key() {
+  local selection
+  selection="$(python ./scripts/google_key_pool.py select 2>/dev/null)" || return 1
+  GOOGLE_KEY_ENV="$(printf '%s\n' "$selection" | sed -n '1p')"
+  GOOGLE_KEY_VALUE="$(printf '%s\n' "$selection" | sed -n '2p')"
+  export GOOGLE_API_KEY="$GOOGLE_KEY_VALUE"
+  export GEMINI_API_KEY="$GOOGLE_KEY_VALUE"
+}
+
+SKILL_NAME="${SKILL_NAME:-github-code-review}"
+ITERATIONS="${ITERATIONS:-1}"
+EVAL_SOURCE="${EVAL_SOURCE:-synthetic}"
+OPTIMIZER_MODEL="${OPTIMIZER_MODEL:-gemini/gemini-3.1-pro-preview}"
+EVAL_MODEL="${EVAL_MODEL:-gemini/gemini-3.1-pro-preview}"
+RUN_TESTS="${RUN_TESTS:-0}"
+
+cmd=(python -m evolution.skills.evolve_skill
+  --skill "$SKILL_NAME"
+  --iterations "$ITERATIONS"
+  --eval-source "$EVAL_SOURCE"
+  --optimizer-model "$OPTIMIZER_MODEL"
+  --eval-model "$EVAL_MODEL"
+)
+
+if [[ "$RUN_TESTS" == "1" ]]; then
+  cmd+=(--run-tests)
+fi
+
+printf 'Running nightly skill evolution: %s\n' "$SKILL_NAME"
+printf 'Repo: %s\n' "$REPO_ROOT"
+printf 'Hermes repo: %s\n' "$HERMES_AGENT_REPO"
+printf 'Pool size: %s\n' "$POOL_SIZE"
+printf 'Command: %q ' "${cmd[@]}"
+printf '\n\n'
+
+attempt=0
+max_attempts=${POOL_SIZE:-0}
+if [[ "$max_attempts" -le 0 ]]; then
+  max_attempts=1
+fi
+
+while [[ $attempt -lt $max_attempts ]]; do
+  attempt=$((attempt + 1))
+  if select_google_key; then
+    printf 'Attempt %s/%s with key %s\n' "$attempt" "$max_attempts" "$GOOGLE_KEY_ENV"
+  fi
+  set +e
+  "${cmd[@]}"
+  status=$?
+  set -e
+  if [[ $status -eq 0 ]]; then
+    exit 0
+  fi
+  if [[ -n "$GOOGLE_KEY_ENV" ]]; then
+    python ./scripts/google_key_pool.py mark-bad "$GOOGLE_KEY_ENV" "run_failed_exit_${status}" >/dev/null 2>&1 || true
+  fi
+  printf 'Attempt %s failed with exit %s\n\n' "$attempt" "$status"
+done
+
+exit ${status:-1}


### PR DESCRIPTION
## What\n- add reliable nightly runner scripts with key-pool rotation\n- reduce nightly default iterations to 1 to avoid long optimizer overruns\n- add anti-gaming mutation gate and fallback body rewrite when DSPy only mutates prompt internals\n- evaluate evolved body via a dedicated SkillModule and persist mutation metadata\n\n## Why\nNightly runs were repeatedly failing or producing non-promotable no-op candidates (). This patch makes the pipeline produce real, auditable skill mutations and stable nightly artifacts.\n\n## Validation\n- reset pool + run Running nightly skill evolution: github-code-review
Repo: /Users/kirniy/dev/hermes-agent-self-evolution
Hermes repo: /Users/kirniy/.hermes/hermes-agent
Pool size: 4
Command: python Command: -m Command: evolution.skills.evolve_skill Command: --skill Command: github-code-review Command: --iterations Command: 1 Command: --eval-source Command: synthetic Command: --optimizer-model Command: gemini/gemini-3.1-pro-preview Command: --eval-model Command: gemini/gemini-3.1-pro-preview 

Attempt 1/4 with key GOOGLE_API_KEY_3

🧬 Hermes Agent Self-Evolution — Evolving skill: github-code-review

  Loaded: skills/github/github-code-review/SKILL.md
  Name: github-code-review
  Size: 13,555 chars
  Description: Review code changes by analyzing git diffs, leaving inline 
comments on PRs, and ...

Building evaluation dataset (source: synthetic)
  Generated 20 synthetic examples
  Saved to datasets/skills/github-code-review/
  Split: 10 train / 5 val / 5 holdout

Validating baseline constraints
  ✓ size_limit: Size OK: 13555/15000 chars
  ✓ non_empty: Artifact is non-empty
  ✓ skill_structure: Skill has valid frontmatter (name + description)

Configuring optimizer
  Optimizer: GEPA (1 iterations)
  Optimizer model: gemini/gemini-3.1-pro-preview
  Eval model: gemini/gemini-3.1-pro-preview

Running GEPA optimization (1 iterations)...

GEPA not available (GEPA.__init__() got an unexpected keyword argument 
'max_steps'), falling back to MIPROv2
Bootstrapping set 1/6
Bootstrapping set 2/6
Bootstrapping set 3/6
Bootstrapped 2 full traces after 1 examples for up to 1 rounds, amounting to 2 attempts.
Bootstrapping set 4/6
Bootstrapped 1 full traces after 1 examples for up to 1 rounds, amounting to 1 attempts.
Bootstrapping set 5/6
Bootstrapped 1 full traces after 1 examples for up to 1 rounds, amounting to 1 attempts.
Bootstrapping set 6/6
Bootstrapped 2 full traces after 1 examples for up to 1 rounds, amounting to 2 attempts.
Error getting data summary: litellm.BadRequestError: GeminiException BadRequestError - {
  "error": {
    "code": 400,
    "message": "API key expired. Please renew the API key.",
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
        "reason": "API_KEY_INVALID",
        "domain": "googleapis.com",
        "metadata": {
          "service": "generativelanguage.googleapis.com"
        }
      },
      {
        "@type": "type.googleapis.com/google.rpc.LocalizedMessage",
        "locale": "en-US",
        "message": "API key expired. Please renew the API key."
      }
    ]
  }
}
.

Running without data aware proposer.

Attempt 1 failed with exit 1

Attempt 2/4 with key GOOGLE_API_KEY_2

🧬 Hermes Agent Self-Evolution — Evolving skill: github-code-review

  Loaded: skills/github/github-code-review/SKILL.md
  Name: github-code-review
  Size: 13,555 chars
  Description: Review code changes by analyzing git diffs, leaving inline 
comments on PRs, and ...

Building evaluation dataset (source: synthetic)
  Generated 20 synthetic examples
  Saved to datasets/skills/github-code-review/
  Split: 10 train / 5 val / 5 holdout

Validating baseline constraints
  ✓ size_limit: Size OK: 13555/15000 chars
  ✓ non_empty: Artifact is non-empty
  ✓ skill_structure: Skill has valid frontmatter (name + description)

Configuring optimizer
  Optimizer: GEPA (1 iterations)
  Optimizer model: gemini/gemini-3.1-pro-preview
  Eval model: gemini/gemini-3.1-pro-preview

Running GEPA optimization (1 iterations)...

GEPA not available (GEPA.__init__() got an unexpected keyword argument 
'max_steps'), falling back to MIPROv2
Bootstrapping set 1/6
Bootstrapping set 2/6
Bootstrapping set 3/6
Bootstrapped 2 full traces after 1 examples for up to 1 rounds, amounting to 2 attempts.
Bootstrapping set 4/6
Bootstrapped 1 full traces after 1 examples for up to 1 rounds, amounting to 1 attempts.
Bootstrapping set 5/6
Bootstrapped 1 full traces after 1 examples for up to 1 rounds, amounting to 1 attempts.
Bootstrapping set 6/6
Bootstrapped 2 full traces after 1 examples for up to 1 rounds, amounting to 2 attempts.
  0%|          | 0/8 [00:00<?, ?it/s]Average Metric: 0.50 / 1 (49.6%):   0%|          | 0/8 [00:00<?, ?it/s]Average Metric: 1.14 / 2 (56.8%):  12%|█▎        | 1/8 [00:00<00:00, 46.53it/s]Average Metric: 1.79 / 3 (59.5%):  25%|██▌       | 2/8 [00:00<00:00, 91.00it/s]Average Metric: 2.31 / 4 (57.8%):  38%|███▊      | 3/8 [00:00<00:00, 134.36it/s]Average Metric: 2.91 / 5 (58.2%):  50%|█████     | 4/8 [00:00<00:00, 176.85it/s]Average Metric: 3.51 / 6 (58.5%):  62%|██████▎   | 5/8 [00:00<00:00, 218.64it/s]Average Metric: 4.13 / 7 (59.0%):  75%|███████▌  | 6/8 [00:00<00:00, 259.37it/s]Average Metric: 4.66 / 8 (58.2%):  88%|████████▊ | 7/8 [00:00<00:00, 299.27it/s]Average Metric: 4.66 / 8 (58.2%): 100%|██████████| 8/8 [00:00<00:00, 341.14it/s]
  0%|          | 0/8 [00:00<?, ?it/s]Average Metric: 0.70 / 1 (70.0%):   0%|          | 0/8 [00:08<?, ?it/s]Average Metric: 0.70 / 1 (70.0%):  12%|█▎        | 1/8 [00:08<01:02,  8.88s/it]Average Metric: 1.28 / 2 (64.0%):  12%|█▎        | 1/8 [00:09<01:02,  8.88s/it]Average Metric: 1.28 / 2 (64.0%):  25%|██▌       | 2/8 [00:09<00:25,  4.28s/it]Average Metric: 1.85 / 3 (61.8%):  25%|██▌       | 2/8 [00:12<00:25,  4.28s/it]Average Metric: 1.85 / 3 (61.8%):  38%|███▊      | 3/8 [00:12<00:16,  3.33s/it]Average Metric: 2.46 / 4 (61.4%):  38%|███▊      | 3/8 [00:12<00:16,  3.33s/it]Average Metric: 2.46 / 4 (61.4%):  50%|█████     | 4/8 [00:12<00:08,  2.06s/it]Average Metric: 3.12 / 5 (62.3%):  50%|█████     | 4/8 [00:12<00:08,  2.06s/it]Average Metric: 3.12 / 5 (62.3%):  62%|██████▎   | 5/8 [00:12<00:04,  1.47s/it]Average Metric: 3.77 / 6 (62.8%):  62%|██████▎   | 5/8 [00:13<00:04,  1.47s/it]Average Metric: 3.77 / 6 (62.8%):  75%|███████▌  | 6/8 [00:13<00:02,  1.34s/it]Average Metric: 4.38 / 7 (62.6%):  75%|███████▌  | 6/8 [00:15<00:02,  1.34s/it]Average Metric: 4.38 / 7 (62.6%):  88%|████████▊ | 7/8 [00:15<00:01,  1.41s/it]Average Metric: 4.93 / 8 (61.7%):  88%|████████▊ | 7/8 [00:18<00:01,  1.41s/it]Average Metric: 4.93 / 8 (61.7%): 100%|██████████| 8/8 [00:18<00:00,  1.82s/it]Average Metric: 4.93 / 8 (61.7%): 100%|██████████| 8/8 [00:18<00:00,  2.25s/it]
  0%|          | 0/8 [00:00<?, ?it/s]Average Metric: 0.58 / 1 (58.0%):   0%|          | 0/8 [00:11<?, ?it/s]Average Metric: 0.58 / 1 (58.0%):  12%|█▎        | 1/8 [00:11<01:22, 11.74s/it]Average Metric: 1.31 / 2 (65.7%):  12%|█▎        | 1/8 [00:14<01:22, 11.74s/it]Average Metric: 1.31 / 2 (65.7%):  25%|██▌       | 2/8 [00:14<00:37,  6.21s/it]Average Metric: 1.89 / 3 (62.9%):  25%|██▌       | 2/8 [00:14<00:37,  6.21s/it]Average Metric: 1.89 / 3 (62.9%):  38%|███▊      | 3/8 [00:14<00:17,  3.46s/it]Average Metric: 2.48 / 4 (62.0%):  38%|███▊      | 3/8 [00:19<00:17,  3.46s/it]Average Metric: 2.48 / 4 (62.0%):  50%|█████     | 4/8 [00:19<00:17,  4.29s/it]Average Metric: 3.08 / 5 (61.5%):  50%|█████     | 4/8 [00:19<00:17,  4.29s/it]Average Metric: 3.65 / 6 (60.8%):  62%|██████▎   | 5/8 [00:20<00:12,  4.29s/it]Average Metric: 3.65 / 6 (60.8%):  75%|███████▌  | 6/8 [00:20<00:04,  2.20s/it]Average Metric: 4.22 / 7 (60.3%):  75%|███████▌  | 6/8 [00:21<00:04,  2.20s/it]Average Metric: 4.22 / 7 (60.3%):  88%|████████▊ | 7/8 [00:21<00:01,  1.85s/it]Average Metric: 4.72 / 8 (59.0%):  88%|████████▊ | 7/8 [00:27<00:01,  1.85s/it]Average Metric: 4.72 / 8 (59.0%): 100%|██████████| 8/8 [00:27<00:00,  2.98s/it]Average Metric: 4.72 / 8 (59.0%): 100%|██████████| 8/8 [00:27<00:00,  3.41s/it]
  0%|          | 0/8 [00:00<?, ?it/s]Average Metric: 0.66 / 1 (66.1%):   0%|          | 0/8 [00:09<?, ?it/s]Average Metric: 0.66 / 1 (66.1%):  12%|█▎        | 1/8 [00:09<01:07,  9.65s/it]Average Metric: 1.39 / 2 (69.7%):  12%|█▎        | 1/8 [00:10<01:07,  9.65s/it]Average Metric: 1.39 / 2 (69.7%):  25%|██▌       | 2/8 [00:10<00:25,  4.21s/it]Average Metric: 1.94 / 3 (64.6%):  25%|██▌       | 2/8 [00:10<00:25,  4.21s/it]Average Metric: 1.94 / 3 (64.6%):  38%|███▊      | 3/8 [00:10<00:11,  2.37s/it]Average Metric: 2.49 / 4 (62.2%):  38%|███▊      | 3/8 [00:10<00:11,  2.37s/it]Average Metric: 2.49 / 4 (62.2%):  50%|█████     | 4/8 [00:10<00:05,  1.48s/it]Average Metric: 3.09 / 5 (61.7%):  50%|█████     | 4/8 [00:10<00:05,  1.48s/it]Average Metric: 3.09 / 5 (61.7%):  62%|██████▎   | 5/8 [00:10<00:03,  1.16s/it]Average Metric: 3.69 / 6 (61.5%):  62%|██████▎   | 5/8 [00:12<00:03,  1.16s/it]Average Metric: 3.69 / 6 (61.5%):  75%|███████▌  | 6/8 [00:12<00:02,  1.18s/it]Average Metric: 4.34 / 7 (62.0%):  75%|███████▌  | 6/8 [00:14<00:02,  1.18s/it]Average Metric: 4.34 / 7 (62.0%):  88%|████████▊ | 7/8 [00:14<00:01,  1.66s/it]Average Metric: 4.83 / 8 (60.4%):  88%|████████▊ | 7/8 [00:17<00:01,  1.66s/it]Average Metric: 4.83 / 8 (60.4%): 100%|██████████| 8/8 [00:17<00:00,  1.84s/it]Average Metric: 4.83 / 8 (60.4%): 100%|██████████| 8/8 [00:17<00:00,  2.13s/it]
  0%|          | 0/8 [00:00<?, ?it/s]Average Metric: 0.54 / 1 (54.5%):   0%|          | 0/8 [00:08<?, ?it/s]Average Metric: 0.54 / 1 (54.5%):  12%|█▎        | 1/8 [00:08<00:56,  8.09s/it]Average Metric: 1.24 / 2 (62.2%):  12%|█▎        | 1/8 [00:09<00:56,  8.09s/it]Average Metric: 1.24 / 2 (62.2%):  25%|██▌       | 2/8 [00:09<00:23,  3.99s/it]Average Metric: 1.87 / 3 (62.2%):  25%|██▌       | 2/8 [00:10<00:23,  3.99s/it]Average Metric: 1.87 / 3 (62.2%):  38%|███▊      | 3/8 [00:10<00:14,  2.80s/it]Average Metric: 2.46 / 4 (61.6%):  38%|███▊      | 3/8 [00:10<00:14,  2.80s/it]Average Metric: 3.04 / 5 (60.8%):  50%|█████     | 4/8 [00:10<00:11,  2.80s/it]Average Metric: 3.04 / 5 (60.8%):  62%|██████▎   | 5/8 [00:10<00:03,  1.33s/it]Average Metric: 3.61 / 6 (60.1%):  62%|██████▎   | 5/8 [00:11<00:03,  1.33s/it]Average Metric: 3.61 / 6 (60.1%):  75%|███████▌  | 6/8 [00:11<00:02,  1.07s/it]\n- latest run produced fresh metrics with , , \n-  =>  for latest artifact