### PR TITLE
feat: Add support for local network accessible models

### DIFF
--- a/evolution/core/config.py
+++ b/evolution/core/config.py
@@ -22,6 +22,10 @@ class EvolutionConfig:
     eval_model: str = "openai/gpt-4.1-mini"  # Model for LLM-as-judge scoring
     judge_model: str = "openai/gpt-4.1"  # Model for dataset generation
 
+    # Custom base URL for local models (e.g., vLLM, Ollama)
+    api_base: Optional[str] = None  # e.g., "http://localhost:8000/v1"
+    api_key: Optional[str] = None  # e.g., "sk_test_key"
+
     # Constraints
     max_skill_size: int = 15_000  # 15KB default
     max_tool_desc_size: int = 500  # chars

--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -123,7 +123,11 @@ class SyntheticDatasetBuilder:
         n = num_cases or self.config.eval_dataset_size
 
         # Configure DSPy to use the judge model for generation
-        lm = dspy.LM(self.config.judge_model)
+        lm = dspy.LM(
+            self.config.judge_model,
+            api_base=self.config.api_base,
+            api_key=self.config.api_key,
+        )
 
         with dspy.context(lm=lm):
             result = self.generator(

--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -442,9 +442,11 @@ class RelevanceFilter:
         assistant_response: str = dspy.InputField(desc="The assistant's actual response (may be empty)")
         scoring: str = dspy.OutputField(desc="JSON object with: relevant, expected_behavior, difficulty, category")
 
-    def __init__(self, model: str):
+    def __init__(self, model: str, api_base: Optional[str] = None, api_key: Optional[str] = None):
         self.scorer = dspy.ChainOfThought(self.ScoreRelevance)
         self.model = model
+        self.api_base = api_base
+        self.api_key = api_key
 
     def filter_and_score(
         self,
@@ -490,7 +492,11 @@ class RelevanceFilter:
         # Stage 2: LLM relevance scoring
         examples = []
         errors = 0
-        lm = dspy.LM(self.model)
+        lm = dspy.LM(
+            self.model,
+            api_base=self.api_base,
+            api_key=self.api_key,
+        )
 
         with Progress() as progress:
             task = progress.add_task("Scoring relevance...", total=len(candidates))
@@ -610,6 +616,8 @@ def build_dataset_from_external(
     output_path: Path,
     model: str,
     max_examples: int = 50,
+    api_base: Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> EvalDataset:
     """Extract messages from external tools, filter for relevance, and save.
 
@@ -623,6 +631,8 @@ def build_dataset_from_external(
         output_path: Directory to write train/val/holdout JSONL files.
         model: LiteLLM model string for relevance scoring.
         max_examples: Maximum eval examples to generate.
+        api_base: Optional API base URL for custom endpoints.
+        api_key: Optional API key for custom endpoints.
 
     Returns:
         EvalDataset with train/val/holdout splits.
@@ -651,7 +661,7 @@ def build_dataset_from_external(
     console.print(f"\n[bold]Total messages: {len(all_messages)}[/bold]")
     console.print(f"[bold]Filtering for relevance to skill: {skill_name}[/bold]")
 
-    relevance_filter = RelevanceFilter(model=model)
+    relevance_filter = RelevanceFilter(model=model, api_base=api_base, api_key=api_key)
     examples = relevance_filter.filter_and_score(
         all_messages, skill_name, skill_text, max_examples=max_examples,
     )
@@ -740,7 +750,11 @@ def _load_skill_text(skill_name: str, skills_dir: Optional[Path] = None) -> tupl
               help="LiteLLM model string for relevance scoring")
 @click.option("--max-examples", default=50, help="Max eval examples to generate")
 @click.option("--dry-run", is_flag=True, help="Show message counts without LLM scoring")
-def main(source, skill, output, model, max_examples, dry_run):
+@click.option("--api-base", default=None,
+              help="Optional API base URL for custom endpoints")
+@click.option("--api-key", default=None,
+              help="Optional API key for custom endpoints")
+def main(source, skill, output, model, max_examples, dry_run, api_base, api_key):
     """Import external session data into golden eval datasets for self-evolution."""
     console.print(f"\n[bold cyan]External Session Importer[/bold cyan] — skill: [bold]{skill}[/bold]\n")
 
@@ -778,6 +792,8 @@ def main(source, skill, output, model, max_examples, dry_run):
         output_path=output,
         model=model,
         max_examples=max_examples,
+        api_base=api_base,
+        api_key=api_key,
     )
 
 

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -72,7 +72,11 @@ class LLMJudge:
     ) -> FitnessScore:
         """Score an agent output using LLM-as-judge."""
 
-        lm = dspy.LM(self.config.eval_model)
+        lm = dspy.LM(
+            self.config.eval_model,
+            api_base=self.config.api_base,
+            api_key=self.config.api_key,
+        )
 
         with dspy.context(lm=lm):
             result = self.judge(

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -43,6 +43,8 @@ def evolve(
     hermes_repo: Optional[str] = None,
     run_tests: bool = False,
     dry_run: bool = False,
+    api_base: Optional[str] = None,
+    api_key: Optional[str] = None,
 ):
     """Main evolution function — orchestrates the full optimization loop."""
 
@@ -52,6 +54,8 @@ def evolve(
         eval_model=eval_model,
         judge_model=eval_model,  # Use same model for dataset generation
         run_pytest=run_tests,
+        api_base=api_base,
+        api_key=api_key,
     )
     if hermes_repo:
         config.hermes_agent_path = Path(hermes_repo)
@@ -91,6 +95,8 @@ def evolve(
             sources=["claude-code", "copilot", "hermes"],
             output_path=save_path,
             model=eval_model,
+            api_base=api_base,
+            api_key=api_key,
         )
         if not dataset.all_examples:
             console.print("[red]✗ No relevant examples found from session history[/red]")
@@ -138,7 +144,11 @@ def evolve(
     console.print(f"  Eval model: {eval_model}")
 
     # Configure DSPy
-    lm = dspy.LM(eval_model)
+    lm = dspy.LM(
+        eval_model,
+        api_base=config.api_base,
+        api_key=config.api_key,
+    )
     dspy.configure(lm=lm)
 
     # Create the baseline skill module
@@ -304,7 +314,9 @@ def evolve(
 @click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
 @click.option("--run-tests", is_flag=True, help="Run full pytest suite as constraint gate")
 @click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")
-def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run):
+@click.option("--api-base", default=None, help="API base URL (for custom endpoints like vLLM)")
+@click.option("--api-key", default=None, help="API key (for custom endpoints)")
+def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run, api_base, api_key):
     """Evolve a Hermes Agent skill using DSPy + GEPA optimization."""
     evolve(
         skill_name=skill,
@@ -316,6 +328,8 @@ def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_mod
         hermes_repo=hermes_repo,
         run_tests=run_tests,
         dry_run=dry_run,
+        api_base=api_base,
+        api_key=api_key,
     )
 
 


### PR DESCRIPTION
This PR adds support for local network accessible models (vLLM, Ollama, etc.) to the Hermes Agent self-evolution tools. Changes include api_base and api_key parameters to EvolutionConfig, updated DSPy LM initializations, and CLI options for --api-base and --api-key.