### PR TITLE
Add ChatGPT OAuth model backend and fix evolution runtime regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,33 @@ python -m evolution.skills.evolve_skill \
     --skill github-code-review \
     --iterations 10 \
     --eval-source sessiondb
+
+# Or use ChatGPT OAuth instead of an OpenAI API key
+python -m evolution.skills.evolve_skill \
+    --skill github-code-review \
+    --iterations 3 \
+    --eval-source synthetic \
+    --optimizer-model chatgpt/gpt-5.4 \
+    --eval-model chatgpt/gpt-5.4
 ```
+
+### ChatGPT OAuth-backed models
+
+If you already use ChatGPT/Codex OAuth locally, this repo can now use it directly.
+
+- Prefix the model with `chatgpt/` — for example `chatgpt/gpt-5.4`
+- The runner will resolve the bearer token from, in order:
+  1. `CHATGPT_OAUTH_TOKEN`
+  2. `CHATGPT_OAUTH_FILE`
+  3. `~/.openclaw/agents/main/agent/auth-profiles.json`
+  4. `~/.codex/auth.json`
+  5. `~/.hermes/auth.json`
+- Optional profile override for OpenClaw auth-profiles: `CHATGPT_AUTH_PROFILE=openai-codex:default`
+
+Notes:
+- This backend talks to `https://chatgpt.com/backend-api/codex/responses`
+- It is meant for practical local experimentation, not polished public API semantics
+- ChatGPT OAuth currently ignores unsupported OpenAI knobs like `temperature` and `max_tokens`
 
 ## What It Optimizes
 

--- a/evolution/core/chatgpt_oauth.py
+++ b/evolution/core/chatgpt_oauth.py
@@ -50,12 +50,40 @@ class ChatGPTOAuthLM(dspy.BaseLM):
         clean_model = normalize_chatgpt_model(model)
         super().__init__(model=clean_model, model_type="responses", temperature=None, max_tokens=None, cache=False)
         self.kwargs = {k: v for k, v in kwargs.items() if v is not None and k not in disallowed}
+        self.base_url = base_url
+        self.auth_file = str(Path(auth_file).expanduser()) if auth_file else None
+        self.auth_profile = auth_profile
         self.oauth_token = resolve_chatgpt_oauth_token(
             oauth_token=oauth_token,
             auth_file=auth_file,
             auth_profile=auth_profile,
         )
         self.client = OpenAI(base_url=base_url, api_key=self.oauth_token)
+
+    def copy(self, **kwargs: Any):
+        """Rebuild a fresh client instead of deepcopying the OpenAI/httpx stack."""
+        supported_attrs = {"model", "base_url", "oauth_token", "auth_file", "auth_profile"}
+        init_kwargs = {
+            "model": kwargs.pop("model", self.model),
+            "oauth_token": kwargs.pop("oauth_token", self.oauth_token),
+            "auth_file": kwargs.pop("auth_file", self.auth_file),
+            "auth_profile": kwargs.pop("auth_profile", self.auth_profile),
+            "base_url": kwargs.pop("base_url", self.base_url),
+            **self.kwargs,
+        }
+        copied = type(self)(**init_kwargs)
+        copied.history = []
+
+        for key, value in kwargs.items():
+            if key in supported_attrs and hasattr(copied, key):
+                setattr(copied, key, value)
+                continue
+            if value is None:
+                copied.kwargs.pop(key, None)
+            else:
+                copied.kwargs[key] = value
+
+        return copied
 
     def forward(
         self,

--- a/evolution/core/chatgpt_oauth.py
+++ b/evolution/core/chatgpt_oauth.py
@@ -1,0 +1,262 @@
+"""ChatGPT OAuth-backed model support for DSPy.
+
+This adds a practical path for running DSPy against ChatGPT Codex OAuth auth
+without requiring an OpenAI API key. Models using the ``chatgpt/`` prefix are
+sent to ``https://chatgpt.com/backend-api/codex/responses`` with the bearer
+access token resolved from common local auth files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Iterable
+
+import dspy
+from openai import OpenAI
+
+CHATGPT_BASE_URL = "https://chatgpt.com/backend-api/codex"
+DEFAULT_INSTRUCTIONS = "You are a precise assistant. Follow the conversation faithfully."
+DEFAULT_AUTH_PROFILE = "openai-codex:default"
+
+
+class ChatGPTOAuthLM(dspy.BaseLM):
+    """DSPy-compatible LM that talks to ChatGPT Codex via OAuth bearer auth."""
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        oauth_token: str | None = None,
+        auth_file: str | Path | None = None,
+        auth_profile: str | None = None,
+        base_url: str = CHATGPT_BASE_URL,
+        **kwargs: Any,
+    ):
+        disallowed = {
+            "temperature",
+            "max_tokens",
+            "max_output_tokens",
+            "max_completion_tokens",
+            "top_p",
+        }
+        bad = {key: value for key, value in kwargs.items() if value not in (None, False) and key in disallowed}
+        if bad:
+            key = next(iter(bad))
+            raise ValueError(f"ChatGPT OAuth backend does not support {key}")
+
+        clean_model = normalize_chatgpt_model(model)
+        super().__init__(model=clean_model, model_type="responses", temperature=None, max_tokens=None, cache=False)
+        self.kwargs = {k: v for k, v in kwargs.items() if v is not None and k not in disallowed}
+        self.oauth_token = resolve_chatgpt_oauth_token(
+            oauth_token=oauth_token,
+            auth_file=auth_file,
+            auth_profile=auth_profile,
+        )
+        self.client = OpenAI(base_url=base_url, api_key=self.oauth_token)
+
+    def forward(
+        self,
+        prompt: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ):
+        payload = build_chatgpt_request(model=self.model, prompt=prompt, messages=messages, **{**self.kwargs, **kwargs})
+        text_chunks: list[str] = []
+
+        with self.client.responses.stream(**payload) as stream:
+            for event in stream:
+                if getattr(event, "type", None) == "response.output_text.delta":
+                    text_chunks.append(event.delta)
+            final = stream.get_final_response()
+
+        return make_dspy_response(
+            model=self.model,
+            text="".join(text_chunks),
+            usage=getattr(final, "usage", None),
+        )
+
+
+def create_lm(model: str, **kwargs: Any):
+    """Create the right LM implementation for a model string."""
+    if is_chatgpt_model(model):
+        return ChatGPTOAuthLM(model, **kwargs)
+    return dspy.LM(model, **kwargs)
+
+
+def is_chatgpt_model(model: str) -> bool:
+    return model.startswith("chatgpt/")
+
+
+def normalize_chatgpt_model(model: str) -> str:
+    return model.split("/", 1)[1] if is_chatgpt_model(model) else model
+
+
+def build_chatgpt_request(
+    *,
+    model: str,
+    prompt: str | None = None,
+    messages: list[dict[str, Any]] | None = None,
+    instructions: str | None = None,
+    reasoning: dict[str, Any] | None = None,
+    **_: Any,
+) -> dict[str, Any]:
+    """Build the request payload accepted by the ChatGPT Codex responses API."""
+    input_messages, inferred_instructions = convert_messages_to_chatgpt_input(messages=messages, prompt=prompt)
+    payload = {
+        "model": normalize_chatgpt_model(model),
+        "instructions": instructions or inferred_instructions or DEFAULT_INSTRUCTIONS,
+        "input": input_messages,
+        "store": False,
+    }
+    if reasoning:
+        payload["reasoning"] = reasoning
+    return payload
+
+
+def convert_messages_to_chatgpt_input(
+    *,
+    messages: list[dict[str, Any]] | None = None,
+    prompt: str | None = None,
+) -> tuple[list[dict[str, Any]], str]:
+    if not messages:
+        if not prompt:
+            raise ValueError("ChatGPT OAuth requests need either messages or a prompt")
+        return [_make_input_message("user", prompt)], DEFAULT_INSTRUCTIONS
+
+    instructions: list[str] = []
+    input_messages: list[dict[str, Any]] = []
+    for message in messages:
+        role = message.get("role", "user")
+        content = flatten_message_content(message.get("content", ""))
+        if not content:
+            continue
+        if role in {"system", "developer"}:
+            instructions.append(content)
+            continue
+        if role == "assistant":
+            input_messages.append(_make_output_message(role, content))
+            continue
+        input_messages.append(_make_input_message(role, content))
+
+    if not input_messages and prompt:
+        input_messages.append(_make_input_message("user", prompt))
+
+    if not input_messages:
+        raise ValueError("ChatGPT OAuth request had no user/assistant content to send")
+
+    return input_messages, "\n\n".join(instructions) if instructions else DEFAULT_INSTRUCTIONS
+
+
+def flatten_message_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(part.strip() for part in parts if isinstance(part, str) and part.strip())
+    return str(content).strip() if content is not None else ""
+
+
+def _make_input_message(role: str, text: str) -> dict[str, Any]:
+    return {
+        "role": "user" if role not in {"user", "assistant"} else role,
+        "content": [{"type": "input_text", "text": text}],
+    }
+
+
+def _make_output_message(role: str, text: str) -> dict[str, Any]:
+    return {
+        "role": role,
+        "content": [{"type": "output_text", "text": text}],
+    }
+
+
+def resolve_chatgpt_oauth_token(
+    oauth_token: str | None = None,
+    auth_file: str | Path | None = None,
+    auth_profile: str | None = None,
+) -> str:
+    if oauth_token:
+        return oauth_token
+
+    env_token = os.getenv("CHATGPT_OAUTH_TOKEN")
+    if env_token:
+        return env_token
+
+    explicit_file = Path(auth_file).expanduser() if auth_file else None
+    env_file = Path(os.environ["CHATGPT_OAUTH_FILE"]).expanduser() if os.getenv("CHATGPT_OAUTH_FILE") else None
+    profile = auth_profile or os.getenv("CHATGPT_AUTH_PROFILE") or DEFAULT_AUTH_PROFILE
+
+    candidates: list[Path] = []
+    for path in [explicit_file, env_file, *default_auth_files()]:
+        if path and path not in candidates:
+            candidates.append(path)
+
+    for candidate in candidates:
+        token = _read_token_from_auth_file(candidate, profile)
+        if token:
+            return token
+
+    searched = ", ".join(str(path) for path in candidates)
+    raise FileNotFoundError(
+        "Could not resolve ChatGPT OAuth token. Set CHATGPT_OAUTH_TOKEN or provide an auth file. "
+        f"Checked: {searched}"
+    )
+
+
+def default_auth_files() -> Iterable[Path]:
+    home = Path.home()
+    return [
+        home / ".openclaw" / "agents" / "main" / "agent" / "auth-profiles.json",
+        home / ".codex" / "auth.json",
+        home / ".hermes" / "auth.json",
+    ]
+
+
+def _read_token_from_auth_file(path: Path, auth_profile: str) -> str | None:
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+
+    profiles = data.get("profiles")
+    if isinstance(profiles, dict):
+        profile = profiles.get(auth_profile)
+        if isinstance(profile, dict) and isinstance(profile.get("access"), str):
+            return profile["access"]
+
+    tokens = data.get("tokens")
+    if isinstance(tokens, dict) and isinstance(tokens.get("access_token"), str):
+        return tokens["access_token"]
+
+    providers = data.get("providers")
+    if isinstance(providers, dict):
+        provider = providers.get("openai-codex")
+        if isinstance(provider, dict):
+            provider_tokens = provider.get("tokens")
+            if isinstance(provider_tokens, dict) and isinstance(provider_tokens.get("access_token"), str):
+                return provider_tokens["access_token"]
+
+    return None
+
+
+def make_dspy_response(model: str, text: str, usage: Any = None):
+    usage_obj = usage or SimpleNamespace(
+        input_tokens=0,
+        output_tokens=0,
+        total_tokens=0,
+        cached_tokens=0,
+    )
+    return SimpleNamespace(
+        model=model,
+        usage=usage_obj,
+        output=[SimpleNamespace(type="message", content=[SimpleNamespace(text=text)])],
+    )

--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -15,6 +15,7 @@ from typing import Optional
 import dspy
 
 from evolution.core.config import EvolutionConfig
+from evolution.core.chatgpt_oauth import create_lm
 
 
 @dataclass
@@ -123,7 +124,7 @@ class SyntheticDatasetBuilder:
         n = num_cases or self.config.eval_dataset_size
 
         # Configure DSPy to use the judge model for generation
-        lm = dspy.LM(self.config.judge_model)
+        lm = create_lm(self.config.judge_model)
 
         with dspy.context(lm=lm):
             result = self.generator(

--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -28,11 +28,12 @@ import random
 from pathlib import Path
 from typing import Optional
 
-import click
 import dspy
+import click
 from rich.console import Console
 from rich.progress import Progress
 
+from evolution.core.chatgpt_oauth import create_lm
 from evolution.core.dataset_builder import EvalExample, EvalDataset
 
 console = Console()
@@ -490,7 +491,7 @@ class RelevanceFilter:
         # Stage 2: LLM relevance scoring
         examples = []
         errors = 0
-        lm = dspy.LM(self.model)
+        lm = create_lm(self.model)
 
         with Progress() as progress:
             task = progress.add_task("Scoring relevance...", total=len(candidates))

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -8,6 +8,7 @@ import dspy
 from dataclasses import dataclass
 from typing import Optional
 
+from evolution.core.chatgpt_oauth import create_lm
 from evolution.core.config import EvolutionConfig
 
 
@@ -72,7 +73,7 @@ class LLMJudge:
     ) -> FitnessScore:
         """Score an agent output using LLM-as-judge."""
 
-        lm = dspy.LM(self.config.eval_model)
+        lm = create_lm(self.config.eval_model)
 
         with dspy.context(lm=lm):
             result = self.judge(

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from evolution.core.chatgpt_oauth import create_lm
 from evolution.core.config import EvolutionConfig, get_hermes_agent_path
 from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset, GoldenDatasetLoader
 from evolution.core.external_importers import build_dataset_from_external
@@ -138,7 +139,8 @@ def evolve(
     console.print(f"  Eval model: {eval_model}")
 
     # Configure DSPy
-    lm = dspy.LM(eval_model)
+    lm = create_lm(eval_model)
+    optimizer_lm = create_lm(optimizer_model)
     dspy.configure(lm=lm)
 
     # Create the baseline skill module
@@ -157,6 +159,7 @@ def evolve(
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
             max_steps=iterations,
+            reflection_lm=optimizer_lm,
         )
 
         optimized_module = optimizer.compile(
@@ -170,6 +173,8 @@ def evolve(
         optimizer = dspy.MIPROv2(
             metric=skill_fitness_metric,
             auto="light",
+            prompt_model=optimizer_lm,
+            task_model=lm,
         )
         optimized_module = optimizer.compile(
             baseline_module,

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -79,24 +79,28 @@ def evolve(
         return
 
     # ── 2. Build or load evaluation dataset ─────────────────────────────
-    console.print(f"\n[bold]Building evaluation dataset[/bold] (source: {eval_source})")
+    # ── 2. Build / load evaluation dataset ──────────────────────────────
+    dataset_label = dataset_path if dataset_path else eval_source
+    console.print(f"\n[bold]Building evaluation dataset (source: {dataset_label})[/bold]")
 
-    if eval_source == "golden" and dataset_path:
-        dataset = GoldenDatasetLoader.load(Path(dataset_path))
+    if dataset_path:
+        dataset = EvalDataset.load(Path(dataset_path))
+        console.print(f"  Loaded dataset: {len(dataset.all_examples)} examples")
+    elif eval_source == "golden":
+        dataset = GoldenDatasetLoader().load_skill_dataset(skill_name)
         console.print(f"  Loaded golden dataset: {len(dataset.all_examples)} examples")
     elif eval_source == "sessiondb":
-        save_path = Path(dataset_path) if dataset_path else Path("datasets") / "skills" / skill_name
         dataset = build_dataset_from_external(
-            skill_name=skill_name,
-            skill_text=skill["raw"],
-            sources=["claude-code", "copilot", "hermes"],
-            output_path=save_path,
+            source="sessiondb",
+            artifact_name=skill_name,
+            artifact_type="skill",
             model=eval_model,
+            sample_size=50,
         )
-        if not dataset.all_examples:
-            console.print("[red]✗ No relevant examples found from session history[/red]")
-            sys.exit(1)
-        console.print(f"  Mined {len(dataset.all_examples)} examples from session history")
+        save_path = Path("datasets") / "skills" / skill_name
+        dataset.save(save_path)
+        console.print(f"  Imported {len(dataset.all_examples)} examples from sessiondb")
+        console.print(f"  Saved to {save_path}/")
     elif eval_source == "synthetic":
         builder = SyntheticDatasetBuilder(config)
         dataset = builder.generate(
@@ -108,9 +112,6 @@ def evolve(
         dataset.save(save_path)
         console.print(f"  Generated {len(dataset.all_examples)} synthetic examples")
         console.print(f"  Saved to {save_path}/")
-    elif dataset_path:
-        dataset = EvalDataset.load(Path(dataset_path))
-        console.print(f"  Loaded dataset: {len(dataset.all_examples)} examples")
     else:
         console.print("[red]✗ Specify --dataset-path or use --eval-source synthetic[/red]")
         sys.exit(1)
@@ -120,7 +121,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -179,6 +180,7 @@ def evolve(
         optimized_module = optimizer.compile(
             baseline_module,
             trainset=trainset,
+            valset=valset,
         )
 
     elapsed = time.time() - start_time
@@ -191,7 +193,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"

--- a/tests/core/test_chatgpt_oauth.py
+++ b/tests/core/test_chatgpt_oauth.py
@@ -1,0 +1,87 @@
+"""Tests for ChatGPT OAuth-backed model support."""
+
+from pathlib import Path
+
+import pytest
+
+from evolution.core.chatgpt_oauth import (
+    ChatGPTOAuthLM,
+    build_chatgpt_request,
+    create_lm,
+    resolve_chatgpt_oauth_token,
+)
+
+
+def test_resolve_token_from_openclaw_profile(tmp_path, monkeypatch):
+    auth_file = tmp_path / "auth-profiles.json"
+    auth_file.write_text(
+        '{"profiles":{"openai-codex:default":{"access":"token-from-openclaw"}}}'
+    )
+
+    token = resolve_chatgpt_oauth_token(auth_file=auth_file)
+
+    assert token == "token-from-openclaw"
+
+
+def test_resolve_token_from_codex_auth_file(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text('{"tokens":{"access_token":"token-from-codex"}}')
+
+    token = resolve_chatgpt_oauth_token(auth_file=auth_file)
+
+    assert token == "token-from-codex"
+
+
+def test_env_token_beats_file(tmp_path, monkeypatch):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text('{"tokens":{"access_token":"token-from-codex"}}')
+    monkeypatch.setenv("CHATGPT_OAUTH_TOKEN", "token-from-env")
+
+    token = resolve_chatgpt_oauth_token(auth_file=auth_file)
+
+    assert token == "token-from-env"
+
+
+def test_build_request_moves_system_messages_to_instructions():
+    payload = build_chatgpt_request(
+        model="chatgpt/gpt-5.4",
+        messages=[
+            {"role": "system", "content": "Be terse."},
+            {"role": "developer", "content": "Answer in lowercase."},
+            {"role": "user", "content": "Say hi"},
+            {"role": "assistant", "content": "hello"},
+        ],
+    )
+
+    assert payload["model"] == "gpt-5.4"
+    assert payload["store"] is False
+    assert payload["instructions"] == "Be terse.\n\nAnswer in lowercase."
+    assert payload["input"] == [
+        {"role": "user", "content": [{"type": "input_text", "text": "Say hi"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "hello"}]},
+    ]
+
+
+def test_build_request_uses_prompt_when_messages_missing():
+    payload = build_chatgpt_request(model="chatgpt/gpt-5.4", prompt="Say hi")
+
+    assert payload["input"] == [
+        {"role": "user", "content": [{"type": "input_text", "text": "Say hi"}]}
+    ]
+    assert payload["instructions"]
+
+
+def test_create_lm_returns_chatgpt_oauth_client(monkeypatch):
+    monkeypatch.setenv("CHATGPT_OAUTH_TOKEN", "token-from-env")
+
+    lm = create_lm("chatgpt/gpt-5.4")
+
+    assert isinstance(lm, ChatGPTOAuthLM)
+    assert lm.model == "gpt-5.4"
+
+
+def test_create_lm_rejects_unsupported_temperature(monkeypatch):
+    monkeypatch.setenv("CHATGPT_OAUTH_TOKEN", "token-from-env")
+
+    with pytest.raises(ValueError, match="does not support temperature"):
+        create_lm("chatgpt/gpt-5.4", temperature=0.2)

--- a/tests/core/test_chatgpt_oauth.py
+++ b/tests/core/test_chatgpt_oauth.py
@@ -85,3 +85,17 @@ def test_create_lm_rejects_unsupported_temperature(monkeypatch):
 
     with pytest.raises(ValueError, match="does not support temperature"):
         create_lm("chatgpt/gpt-5.4", temperature=0.2)
+
+
+def test_chatgpt_lm_copy_rebuilds_client_without_deepcopying_httpx(monkeypatch):
+    monkeypatch.setenv("CHATGPT_OAUTH_TOKEN", "token-from-env")
+
+    lm = create_lm("chatgpt/gpt-5.4", reasoning={"effort": "low"})
+    copied = lm.copy(rollout_id="r1")
+
+    assert isinstance(copied, ChatGPTOAuthLM)
+    assert copied is not lm
+    assert copied.client is not lm.client
+    assert copied.model == lm.model
+    assert copied.kwargs["reasoning"] == {"effort": "low"}
+    assert copied.kwargs["rollout_id"] == "r1"

--- a/tests/skills/test_evolve_skill_models.py
+++ b/tests/skills/test_evolve_skill_models.py
@@ -1,0 +1,87 @@
+"""Tests for model wiring in evolve_skill."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from evolution.core.dataset_builder import EvalDataset, EvalExample
+from evolution.skills.evolve_skill import evolve
+
+
+class _FakeOptimizer:
+    def __init__(self):
+        self.compile_calls = []
+
+    def compile(self, baseline_module, trainset, valset=None):
+        self.compile_calls.append(
+            {
+                "baseline_module": baseline_module,
+                "trainset": trainset,
+                "valset": valset,
+            }
+        )
+        return _FakeModule("# Evolved\nBetter")
+
+
+class _PassedConstraint:
+    passed = True
+    constraint_name = "ok"
+    message = "ok"
+
+
+class _FakeDatasetBuilder:
+    def __init__(self, config):
+        self.config = config
+
+    def generate(self, artifact_text, artifact_type="skill"):
+        example = EvalExample(task_input="task", expected_behavior="expected")
+        return EvalDataset(train=[example], val=[example], holdout=[example])
+
+
+class _FakeModule:
+    def __init__(self, skill_text):
+        self.skill_text = skill_text
+
+    def __call__(self, task_input):
+        return SimpleNamespace(output="done")
+
+
+def test_gepa_uses_optimizer_model_for_reflection_lm(tmp_path):
+    fake_gepa = _FakeOptimizer()
+    created_lms = []
+
+    def fake_create_lm(model, **kwargs):
+        created_lms.append((model, kwargs))
+        return f"lm:{model}"
+
+    with patch("evolution.skills.evolve_skill.find_skill", return_value=tmp_path / "SKILL.md"), \
+         patch("evolution.skills.evolve_skill.load_skill", return_value={
+             "name": "demo",
+             "description": "desc",
+             "raw": "---\nname: demo\ndescription: desc\n---\n\n# Demo\nBody",
+             "body": "# Demo\nBody",
+             "frontmatter": "name: demo\ndescription: desc",
+         }), \
+         patch("evolution.skills.evolve_skill.SyntheticDatasetBuilder", _FakeDatasetBuilder), \
+         patch("evolution.skills.evolve_skill.ConstraintValidator") as mock_validator_cls, \
+         patch("evolution.skills.evolve_skill.SkillModule", _FakeModule), \
+         patch("evolution.skills.evolve_skill.create_lm", side_effect=fake_create_lm), \
+         patch("evolution.skills.evolve_skill.dspy.configure"), \
+         patch("evolution.skills.evolve_skill.dspy.GEPA", return_value=fake_gepa), \
+         patch("evolution.skills.evolve_skill.skill_fitness_metric", return_value=0.8), \
+         patch("evolution.skills.evolve_skill.reassemble_skill", side_effect=lambda frontmatter, body: f"---\n{frontmatter}\n---\n\n{body}"):
+        mock_validator_cls.return_value.validate_all.return_value = [_PassedConstraint()]
+
+        evolve(
+            skill_name="demo",
+            iterations=2,
+            eval_source="synthetic",
+            optimizer_model="chatgpt/gpt-5.4",
+            eval_model="openai/gpt-4.1-mini",
+            hermes_repo=str(tmp_path),
+        )
+
+    assert created_lms == [
+        ("openai/gpt-4.1-mini", {}),
+        ("chatgpt/gpt-5.4", {}),
+    ]
+    assert fake_gepa.compile_calls

--- a/tests/skills/test_evolve_skill_models.py
+++ b/tests/skills/test_evolve_skill_models.py
@@ -22,6 +22,11 @@ class _FakeOptimizer:
         return _FakeModule("# Evolved\nBetter")
 
 
+class _ExplodingGEPA:
+    def __init__(self, *args, **kwargs):
+        raise TypeError("GEPA.__init__() got an unexpected keyword argument 'max_steps'")
+
+
 class _PassedConstraint:
     passed = True
     constraint_name = "ok"
@@ -43,6 +48,16 @@ class _FakeModule:
 
     def __call__(self, task_input):
         return SimpleNamespace(output="done")
+
+
+class _RecordingValidator:
+    def __init__(self, config):
+        self.config = config
+        self.calls = []
+
+    def validate_all(self, artifact_text, artifact_type, baseline_text=None):
+        self.calls.append((artifact_text, artifact_type, baseline_text))
+        return [_PassedConstraint()]
 
 
 def test_gepa_uses_optimizer_model_for_reflection_lm(tmp_path):
@@ -85,3 +100,124 @@ def test_gepa_uses_optimizer_model_for_reflection_lm(tmp_path):
         ("chatgpt/gpt-5.4", {}),
     ]
     assert fake_gepa.compile_calls
+
+
+def test_evolve_validates_full_skill_text_not_body_only(tmp_path):
+    fake_gepa = _FakeOptimizer()
+    validator = _RecordingValidator(config=None)
+    raw_skill = "---\nname: demo\ndescription: desc\n---\n\n# Demo\nBody"
+
+    with patch("evolution.skills.evolve_skill.find_skill", return_value=tmp_path / "SKILL.md"), \
+         patch("evolution.skills.evolve_skill.load_skill", return_value={
+             "name": "demo",
+             "description": "desc",
+             "raw": raw_skill,
+             "body": "# Demo\nBody",
+             "frontmatter": "name: demo\ndescription: desc",
+         }), \
+         patch("evolution.skills.evolve_skill.SyntheticDatasetBuilder", _FakeDatasetBuilder), \
+         patch("evolution.skills.evolve_skill.ConstraintValidator", return_value=validator), \
+         patch("evolution.skills.evolve_skill.SkillModule", _FakeModule), \
+         patch("evolution.skills.evolve_skill.create_lm", side_effect=lambda model, **kwargs: f"lm:{model}"), \
+         patch("evolution.skills.evolve_skill.dspy.configure"), \
+         patch("evolution.skills.evolve_skill.dspy.GEPA", return_value=fake_gepa), \
+         patch("evolution.skills.evolve_skill.skill_fitness_metric", return_value=0.8), \
+         patch("evolution.skills.evolve_skill.reassemble_skill", side_effect=lambda frontmatter, body: f"---\n{frontmatter}\n---\n\n{body}"):
+        evolve(
+            skill_name="demo",
+            iterations=1,
+            eval_source="synthetic",
+            optimizer_model="chatgpt/gpt-5.4",
+            eval_model="openai/gpt-4.1-mini",
+            hermes_repo=str(tmp_path),
+        )
+
+    assert validator.calls[0] == (raw_skill, "skill", None)
+    assert validator.calls[1] == (
+        "---\nname: demo\ndescription: desc\n---\n\n# Evolved\nBetter",
+        "skill",
+        raw_skill,
+    )
+
+
+def test_dataset_path_takes_priority_over_eval_source(tmp_path):
+    fake_gepa = _FakeOptimizer()
+    validator = _RecordingValidator(config=None)
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    for split in ("train", "val", "holdout"):
+        (dataset_dir / f"{split}.jsonl").write_text(
+            '{"task_input":"task","expected_behavior":"expected"}\n'
+        )
+
+    generated = {"called": False}
+
+    class _FailIfSyntheticBuilder:
+        def __init__(self, config):
+            generated["called"] = True
+
+        def generate(self, artifact_text, artifact_type="skill"):
+            raise AssertionError("synthetic builder should not run when dataset_path is provided")
+
+    with patch("evolution.skills.evolve_skill.find_skill", return_value=tmp_path / "SKILL.md"), \
+         patch("evolution.skills.evolve_skill.load_skill", return_value={
+             "name": "demo",
+             "description": "desc",
+             "raw": "---\nname: demo\ndescription: desc\n---\n\n# Demo\nBody",
+             "body": "# Demo\nBody",
+             "frontmatter": "name: demo\ndescription: desc",
+         }), \
+         patch("evolution.skills.evolve_skill.SyntheticDatasetBuilder", _FailIfSyntheticBuilder), \
+         patch("evolution.skills.evolve_skill.ConstraintValidator", return_value=validator), \
+         patch("evolution.skills.evolve_skill.SkillModule", _FakeModule), \
+         patch("evolution.skills.evolve_skill.create_lm", side_effect=lambda model, **kwargs: f"lm:{model}"), \
+         patch("evolution.skills.evolve_skill.dspy.configure"), \
+         patch("evolution.skills.evolve_skill.dspy.GEPA", return_value=fake_gepa), \
+         patch("evolution.skills.evolve_skill.skill_fitness_metric", return_value=0.8), \
+         patch("evolution.skills.evolve_skill.reassemble_skill", side_effect=lambda frontmatter, body: f"---\n{frontmatter}\n---\n\n{body}"):
+        evolve(
+            skill_name="demo",
+            iterations=1,
+            eval_source="synthetic",
+            dataset_path=str(dataset_dir),
+            optimizer_model="chatgpt/gpt-5.4",
+            eval_model="openai/gpt-4.1-mini",
+            hermes_repo=str(tmp_path),
+        )
+
+    assert generated["called"] is False
+    assert fake_gepa.compile_calls[0]["trainset"]
+
+
+def test_mipro_fallback_receives_valset(tmp_path):
+    fake_mipro = _FakeOptimizer()
+    validator = _RecordingValidator(config=None)
+
+    with patch("evolution.skills.evolve_skill.find_skill", return_value=tmp_path / "SKILL.md"), \
+         patch("evolution.skills.evolve_skill.load_skill", return_value={
+             "name": "demo",
+             "description": "desc",
+             "raw": "---\nname: demo\ndescription: desc\n---\n\n# Demo\nBody",
+             "body": "# Demo\nBody",
+             "frontmatter": "name: demo\ndescription: desc",
+         }), \
+         patch("evolution.skills.evolve_skill.SyntheticDatasetBuilder", _FakeDatasetBuilder), \
+         patch("evolution.skills.evolve_skill.ConstraintValidator", return_value=validator), \
+         patch("evolution.skills.evolve_skill.SkillModule", _FakeModule), \
+         patch("evolution.skills.evolve_skill.create_lm", side_effect=lambda model, **kwargs: f"lm:{model}"), \
+         patch("evolution.skills.evolve_skill.dspy.configure"), \
+         patch("evolution.skills.evolve_skill.dspy.GEPA", _ExplodingGEPA), \
+         patch("evolution.skills.evolve_skill.dspy.MIPROv2", return_value=fake_mipro), \
+         patch("evolution.skills.evolve_skill.skill_fitness_metric", return_value=0.8), \
+         patch("evolution.skills.evolve_skill.reassemble_skill", side_effect=lambda frontmatter, body: f"---\n{frontmatter}\n---\n\n{body}"):
+        evolve(
+            skill_name="demo",
+            iterations=1,
+            eval_source="synthetic",
+            optimizer_model="chatgpt/gpt-5.4",
+            eval_model="openai/gpt-4.1-mini",
+            hermes_repo=str(tmp_path),
+        )
+
+    assert fake_mipro.compile_calls
+    assert fake_mipro.compile_calls[0]["valset"]


### PR DESCRIPTION
## Summary
- add a ChatGPT OAuth-backed DSPy LM for `chatgpt/*` models so skill evolution can run without OpenAI API keys
- rebuild `ChatGPTOAuthLM` instances on `copy()` so DSPy avoids deepcopying the OpenAI/httpx client stack during optimization
- fix `evolve_skill.py` to prefer explicit `dataset_path` loading, validate the full skill text, and pass `valset` into the MIPRO fallback path so tiny datasets stop crashing
- add regression coverage for OAuth token resolution/request building, LM copy behavior, dataset-path precedence, full-skill validation, and GEPA → MIPRO fallback wiring

## Testing
- [x] `.venv/bin/pytest -q`
- [x] `.venv/bin/python -m evolution.skills.evolve_skill --skill github-code-review --iterations 1 --dataset-path /home/kyzer/Documents/projects/hermes-agent-self-evolution/tmp/github-code-review-mini --optimizer-model chatgpt/gpt-5.4 --eval-model chatgpt/gpt-5.4 --hermes-repo /home/kyzer/.hermes/hermes-agent`

## Notes
- Verified that a real evolution run now completes end-to-end with ChatGPT OAuth models.
- The latest mini-dataset run completed successfully and saved artifacts under `output/github-code-review/20260414_164858/`.
- The generated baseline/evolved skill artifacts were still byte-identical, which points to a separate optimizer/artifact-mutation issue outside the runtime fixes in this PR.
