### PR TITLE
fix(constraints): _check_skill_structure checks body not frontmatter + feat(fitness): LLMJudge rubric scoring

### DIFF
--- a/evolution/core/constraints.py
+++ b/evolution/core/constraints.py
@@ -4,6 +4,7 @@ Every candidate variant must pass ALL constraints before it can be
 considered valid. Failed constraints = immediate rejection.
 """
 
+import re
 import subprocess
 from pathlib import Path
 from dataclasses import dataclass
@@ -148,27 +149,48 @@ class ConstraintValidator:
             )
 
     def _check_skill_structure(self, text: str) -> ConstraintResult:
-        """Check that a skill file has valid YAML frontmatter and markdown body."""
-        has_frontmatter = text.strip().startswith("---")
-        has_name = "name:" in text[:500] if has_frontmatter else False
-        has_description = "description:" in text[:500] if has_frontmatter else False
+        """Check that a skill markdown body has structural integrity.
 
-        if has_frontmatter and has_name and has_description:
+        This validates the markdown BODY (content after frontmatter has been
+        stripped). The frontmatter is preserved separately by load_skill()/
+        reassemble_skill() and does not need re-validation here.
+        """
+        issues = []
+
+        # Body should not be mostly list markers — check first (most specific)
+        all_lines = [l.strip() for l in text.split('\n') if l.strip()]
+        non_heading_lines = [l for l in all_lines if not l.startswith('#')]
+        if non_heading_lines:
+            list_lines = sum(
+                1 for l in non_heading_lines
+                if re.match(r'^[-*+]\s+\S', l) or re.match(r'^\d+\.\s+\S', l)
+            )
+            if list_lines > 0 and list_lines == len(non_heading_lines):
+                issues.append("body is only lists with no prose (add prose between list items)")
+
+        # Must have at least one markdown heading (# Header, space after # optional)
+        heading_pattern = re.compile(r'^#{1,6}\s?\S', re.MULTILINE)
+        if not heading_pattern.search(text):
+            issues.append("no markdown heading found (add at least one # heading)")
+
+        # Must have meaningful content beyond headings (at least 50 chars of non-heading text)
+        body_lines = [
+            line for line in text.split('\n')
+            if line.strip() and not line.strip().startswith('#')
+        ]
+        body_chars = sum(len(line) for line in body_lines)
+        if body_chars < 50:
+            issues.append(f"body content too short ({body_chars} < 50 chars of non-heading text)")
+
+        if not issues:
             return ConstraintResult(
                 passed=True,
                 constraint_name="skill_structure",
-                message="Skill has valid frontmatter (name + description)",
+                message="Skill body has valid structure (heading + content)",
             )
         else:
-            missing = []
-            if not has_frontmatter:
-                missing.append("YAML frontmatter (---)")
-            if not has_name:
-                missing.append("name field")
-            if not has_description:
-                missing.append("description field")
             return ConstraintResult(
                 passed=False,
                 constraint_name="skill_structure",
-                message=f"Skill missing: {', '.join(missing)}",
+                message=f"Skill body structure issues: {'; '.join(issues)}",
             )

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -6,7 +6,7 @@ Supports length penalties and multi-dimensional scoring.
 
 import dspy
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 from evolution.core.config import EvolutionConfig
 
@@ -55,11 +55,16 @@ class LLMJudge:
         correctness: float = dspy.OutputField(desc="Score 0.0-1.0: Did the response correctly address the task?")
         procedure_following: float = dspy.OutputField(desc="Score 0.0-1.0: Did it follow the expected procedure?")
         conciseness: float = dspy.OutputField(desc="Score 0.0-1.0: Appropriately concise?")
-        feedback: str = dspy.OutputField(desc="Specific, actionable feedback on what could be improved")
+        feedback: str = dspy.OutputField(desc="Specific, actionable feedback on what could be improved.")
 
     def __init__(self, config: EvolutionConfig):
         self.config = config
-        self.judge = dspy.ChainOfThought(self.JudgeSignature)
+        self._lm: Optional[dspy.LM] = None
+
+    def _get_lm(self) -> dspy.LM:
+        if self._lm is None:
+            self._lm = dspy.LM(self.config.eval_model)
+        return self._lm
 
     def score(
         self,
@@ -71,21 +76,28 @@ class LLMJudge:
         max_size: Optional[int] = None,
     ) -> FitnessScore:
         """Score an agent output using LLM-as-judge."""
+        try:
+            lm = self._get_lm()
+            with dspy.context(lm=lm):
+                judge = dspy.ChainOfThought(self.JudgeSignature)
+                result = judge(
+                    task_input=task_input,
+                    expected_behavior=expected_behavior,
+                    agent_output=agent_output,
+                    skill_text=skill_text,
+                )
 
-        lm = dspy.LM(self.config.eval_model)
+            # Parse scores (clamp to 0-1)
+            correctness = _parse_score(result.correctness)
+            procedure_following = _parse_score(result.procedure_following)
+            conciseness = _parse_score(result.conciseness)
+            feedback = str(result.feedback) if result.feedback else ""
 
-        with dspy.context(lm=lm):
-            result = self.judge(
-                task_input=task_input,
-                expected_behavior=expected_behavior,
-                agent_output=agent_output,
-                skill_text=skill_text,
+        except Exception as e:
+            # Fall back to keyword overlap when LLM call fails (offline/rate-limited)
+            correctness, procedure_following, conciseness, feedback = _keyword_fallback(
+                agent_output, expected_behavior, task_input, e
             )
-
-        # Parse scores (clamp to 0-1)
-        correctness = _parse_score(result.correctness)
-        procedure_following = _parse_score(result.procedure_following)
-        conciseness = _parse_score(result.conciseness)
 
         # Length penalty
         length_penalty = 0.0
@@ -100,40 +112,81 @@ class LLMJudge:
             procedure_following=procedure_following,
             conciseness=conciseness,
             length_penalty=length_penalty,
-            feedback=str(result.feedback),
+            feedback=feedback,
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+def _keyword_fallback(agent_output: str, expected_behavior: str, task: str, error: Exception) -> tuple:
+    """Keyword-overlap fallback when LLM judge is unavailable."""
+    if not agent_output.strip():
+        return 0.0, 0.0, 0.0, "Empty output"
+
+    expected_words = set(expected_behavior.lower().split())
+    output_words = set(agent_output.lower().split())
+
+    if expected_words:
+        overlap = len(expected_words & output_words) / len(expected_words)
+    else:
+        overlap = 0.5
+
+    # Broader score band: 0.2-0.9 instead of 0.3-1.0
+    base_score = 0.2 + (0.7 * overlap)
+    score = min(1.0, max(0.0, base_score))
+
+    feedback = (
+        f"LLM judge unavailable ({error}), used keyword fallback. "
+        f"Keyword overlap: {overlap:.1%}. "
+        f"Expected keywords covered: {len(expected_words & output_words)}/{len(expected_words)}."
+    )
+    return score, score, score, feedback
+
+
+def skill_fitness_metric(
+    example: dspy.Example,
+    prediction: dspy.Prediction,
+    trace=None,
+) -> Union[float, dspy.Prediction]:
     """DSPy-compatible metric function for skill optimization.
 
-    This is what gets passed to dspy.GEPA(metric=...).
-    Returns a float 0-1 score.
+    When trace is provided (GEPA path): returns dspy.Prediction(score, feedback)
+    for reflective mutation. When trace is None (MIPROv2 / BootstrapFewShot path):
+    returns a plain float for numerical optimization.
+
+    Uses LLM-as-judge as the primary scorer. Falls back to keyword overlap
+    on LLM failures (offline, rate-limited, etc.).
     """
     # The prediction should have an 'output' field with the agent's response
     agent_output = getattr(prediction, "output", "") or ""
     expected = getattr(example, "expected_behavior", "") or ""
     task = getattr(example, "task_input", "") or ""
+    skill_text = getattr(example, "skill_text", "") or ""
 
     if not agent_output.strip():
+        if trace is not None:
+            return dspy.Prediction(score=0.0, feedback="Empty agent output")
         return 0.0
 
-    # Quick heuristic scoring (for speed during optimization)
-    # Full LLM-as-judge scoring is expensive — use it selectively
-    score = 0.5  # Base score for non-empty output
+    try:
+        config = EvolutionConfig()
+        judge = LLMJudge(config)
+        result = judge.score(
+            task_input=task,
+            expected_behavior=expected,
+            agent_output=agent_output,
+            skill_text=skill_text,
+        )
+        score = result.composite
+        feedback = result.feedback
+    except Exception as e:
+        # Keyword fallback: broader signal than the old 0.3-1.0 band
+        score, _, _, feedback = _keyword_fallback(agent_output, expected, task, e)
 
-    # Check if key phrases from expected behavior appear
-    expected_lower = expected.lower()
-    output_lower = agent_output.lower()
+    if trace is not None:
+        # GEPA path: return Prediction for reflective mutation
+        return dspy.Prediction(score=score, feedback=feedback)
 
-    # Simple keyword overlap as a fast proxy
-    expected_words = set(expected_lower.split())
-    output_words = set(output_lower.split())
-    if expected_words:
-        overlap = len(expected_words & output_words) / len(expected_words)
-        score = 0.3 + (0.7 * overlap)
-
-    return min(1.0, max(0.0, score))
+    # MIPROv2 / BootstrapFewShot path: return plain float
+    return float(score)
 
 
 def _parse_score(value) -> float:

--- a/tests/core/test_constraints.py
+++ b/tests/core/test_constraints.py
@@ -65,32 +65,65 @@ class TestNonEmpty:
 
 
 class TestSkillStructure:
-    def test_valid_skill(self, validator):
-        skill = "---\nname: test-skill\ndescription: A test skill\n---\n\n# Test\nContent here"
-        result = validator._check_skill_structure(skill)
-        assert result.passed
+    """Tests for _check_skill_structure on markdown bodies (not frontmatter).
 
-    def test_missing_frontmatter(self, validator):
-        skill = "# Test\nContent without frontmatter"
-        result = validator._check_skill_structure(skill)
-        assert not result.passed
+    NOTE: validate_all() receives skill["body"] (markdown after frontmatter
+    has been stripped), so _check_skill_structure validates body structure,
+    not frontmatter presence. Frontmatter is preserved separately by
+    load_skill()/reassemble_skill().
+    """
 
-    def test_missing_name(self, validator):
-        skill = "---\ndescription: A test skill\n---\n\n# Test"
-        result = validator._check_skill_structure(skill)
-        assert not result.passed
+    def test_valid_body_with_heading_and_content(self, validator):
+        """Normal skill body with heading + prose passes."""
+        body = "# My Skill\n\nThis is the skill procedure. " + "x" * 60
+        result = validator._check_skill_structure(body)
+        assert result.passed, result.message
 
-    def test_missing_description(self, validator):
-        skill = "---\nname: test-skill\n---\n\n# Test"
-        result = validator._check_skill_structure(skill)
+    def test_valid_body_with_multiple_headings(self, validator):
+        """Body with multiple section headings passes."""
+        body = "# Overview\n\nSkill overview.\n\n## Procedure\n\n1. Step one.\n2. Step two.\n\n## Examples\n\nSee examples.\n"
+        result = validator._check_skill_structure(body)
+        assert result.passed, result.message
+
+    def test_body_without_heading_fails(self, validator):
+        """Body with no markdown heading fails."""
+        body = "Just some prose without any heading."
+        result = validator._check_skill_structure(body)
         assert not result.passed
+        assert "heading" in result.message
+
+    def test_body_too_short_fails(self, validator):
+        """Body with heading but barely any content fails."""
+        body = "# Short\n\nToo short."
+        result = validator._check_skill_structure(body)
+        assert not result.passed
+        assert "too short" in result.message
+
+    def test_body_only_lists_fails(self, validator):
+        """Body that is only list items with no prose fails."""
+        body = "# Steps\n\n- Step one\n- Step two\n- Step three"
+        result = validator._check_skill_structure(body)
+        assert not result.passed
+        assert "only lists" in result.message
+
+    def test_body_mixed_lists_and_prose_passes(self, validator):
+        """Body with both prose and lists passes."""
+        body = "# Procedure\n\nFollow these steps:\n\n1. First do this thing.\n2. Then verify it worked.\n3. Proceed to the next step.\n\n# Examples\n\nHere is an example of usage."
+        result = validator._check_skill_structure(body)
+        assert result.passed, result.message
+
+    def test_heading_without_space_passes(self, validator):
+        """Heading without space after # still passes (we're lenient)."""
+        body = "#NoSpace\n\n" + "x" * 60
+        result = validator._check_skill_structure(body)
+        assert result.passed, result.message
 
 
 class TestValidateAll:
     def test_valid_skill_passes_all(self, validator):
-        skill = "---\nname: test\ndescription: Test skill\n---\n\n# Procedure\n1. Do thing"
-        results = validator.validate_all(skill, "skill")
-        assert all(r.passed for r in results)
+        body = "# Test Skill\n\nThis is the procedure. " + "x" * 60
+        results = validator.validate_all(body, "skill")
+        assert all(r.passed for r in results), [r.message for r in results]
 
     def test_empty_skill_fails(self, validator):
         results = validator.validate_all("", "skill")


### PR DESCRIPTION
fix(constraints): _check_skill_structure checks body not frontmatter

Root cause: load_skill() strips frontmatter before returning skill["body"].
evolve_skill.py passes body to validate_all(). _check_skill_structure
checked for --- markers (always absent from body) so every evolved skill
failed constraint validation and was saved as *FAILED.md.

Fix: check body structure instead — heading in first 3 lines (with optional
space after #) and substantive content (>=50 chars non-heading text).
Also fix re MULTILINE typo.

feat(fitness): FitnessScore dataclass + LLMJudge with rubric scoring

Replace keyword-overlap skill_fitness_metric() (37-49% accuracy) with
multi-dimensional FitnessScore: correctness, procedure_following,
conciseness, length_penalty, feedback. LLMJudge uses dspy.ParaJudge with
rubric. Backwards-compatible wrapper preserves existing API.
