### PR TITLE
fix: runtime bugs + make skill text optimizable by DSPy

### DIFF
--- a/evolution/core/constraints.py
+++ b/evolution/core/constraints.py
@@ -4,6 +4,7 @@ Every candidate variant must pass ALL constraints before it can be
 considered valid. Failed constraints = immediate rejection.
 """
 
+import re
 import subprocess
 from pathlib import Path
 from dataclasses import dataclass
@@ -148,27 +149,34 @@ class ConstraintValidator:
             )
 
     def _check_skill_structure(self, text: str) -> ConstraintResult:
-        """Check that a skill file has valid YAML frontmatter and markdown body."""
-        has_frontmatter = text.strip().startswith("---")
-        has_name = "name:" in text[:500] if has_frontmatter else False
-        has_description = "description:" in text[:500] if has_frontmatter else False
+        """Check that a skill body has meaningful structure (headings, steps, etc.).
 
-        if has_frontmatter and has_name and has_description:
+        Note: This validates the BODY of a skill file, not the full file with frontmatter.
+        Frontmatter (name, description) is handled separately during reassembly.
+        """
+        # Check for common skill body structure markers
+        has_headings = bool(re.search(r'^#+\s', text, re.MULTILINE))
+        has_steps = any(marker in text.lower() for marker in ['step', '1.', 'procedure', 'how to', 'instructions'])
+        has_content = len(text.strip()) > 100  # Meaningful body, not just a stub
+
+        checks = {
+            'headings': has_headings,
+            'procedural content': has_steps,
+            'substantial content': has_content,
+        }
+        passed = sum(checks.values()) >= 2  # At least 2 of 3
+
+        if passed:
+            found = [k for k, v in checks.items() if v]
             return ConstraintResult(
                 passed=True,
                 constraint_name="skill_structure",
-                message="Skill has valid frontmatter (name + description)",
+                message=f"Skill body has valid structure ({', '.join(found)})",
             )
         else:
-            missing = []
-            if not has_frontmatter:
-                missing.append("YAML frontmatter (---)")
-            if not has_name:
-                missing.append("name field")
-            if not has_description:
-                missing.append("description field")
+            missing = [k for k, v in checks.items() if not v]
             return ConstraintResult(
                 passed=False,
                 constraint_name="skill_structure",
-                message=f"Skill missing: {', '.join(missing)}",
+                message=f"Skill body missing: {', '.join(missing)}",
             )

--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -132,17 +132,56 @@ class SyntheticDatasetBuilder:
                 num_cases=n,
             )
 
-        # Parse the generated test cases
-        try:
-            cases_raw = json.loads(result.test_cases)
-        except json.JSONDecodeError:
-            # Try to extract JSON from the response
-            import re
-            match = re.search(r'\[.*\]', result.test_cases, re.DOTALL)
+        # Parse the generated test cases — LLMs often produce slightly malformed JSON
+        import re
+        raw_text = result.test_cases
+
+        def _try_parse_json(text: str) -> list:
+            """Try multiple strategies to parse LLM JSON output."""
+            # Strategy 1: Direct JSON parse
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                pass
+
+            # Strategy 2: Python literal eval — handles single-quoted dicts
+            try:
+                import ast
+                result = ast.literal_eval(text.strip())
+                if isinstance(result, list):
+                    return result
+            except (ValueError, SyntaxError):
+                pass
+
+            # Strategy 3: Extract array from surrounding text
+            match = re.search(r'\[[\s\S]*\]', text)
             if match:
-                cases_raw = json.loads(match.group())
-            else:
-                raise ValueError(f"Could not parse test cases from LLM output: {result.test_cases[:200]}")
+                candidate = match.group()
+                try:
+                    return json.loads(candidate)
+                except json.JSONDecodeError:
+                    pass
+
+                # Try literal_eval on extracted array
+                try:
+                    import ast
+                    result = ast.literal_eval(candidate)
+                    if isinstance(result, list):
+                        return result
+                except (ValueError, SyntaxError):
+                    pass
+
+                # Fix common LLM JSON issues
+                fixed = re.sub(r',\s*([}\]])', r'\1', candidate)
+                fixed = re.sub(r"(?<!\\)'([^']+?)'(?=\s*[:,\]\}])", r'"\1"', fixed)
+                try:
+                    return json.loads(fixed)
+                except json.JSONDecodeError:
+                    pass
+
+            raise ValueError(f"Could not parse test cases from LLM output: {raw_text[:500]}")
+
+        cases_raw = _try_parse_json(raw_text)
 
         examples = [
             EvalExample(

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -156,7 +156,8 @@ def evolve(
     try:
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
-            max_steps=iterations,
+            max_metric_calls=iterations * 10,  # Convert iterations to metric call budget
+            auto="light",
         )
 
         optimized_module = optimizer.compile(
@@ -180,8 +181,43 @@ def evolve(
     console.print(f"\n  Optimization completed in {elapsed:.1f}s")
 
     # ── 6. Extract evolved skill text ───────────────────────────────────
-    # The optimized module's instructions contain the evolved skill text
-    evolved_body = optimized_module.skill_text
+    # MIPROv2/GEPA replaces the predictor's instruction. Extract the full instruction
+    # and separate the evolved skill text from the wrapper.
+    # The instruction was prepended with "Follow these skill instructions...\n\n{skill_text}\n\n---\n"
+    evolved_instruction = ""
+    for name, pred in optimized_module.predictor.named_predictors():
+        evolved_instruction = pred.signature.instructions
+        break
+    
+    if not evolved_instruction:
+        evolved_instruction = getattr(
+            optimized_module.predictor, 'signature', None
+        )
+        if evolved_instruction and hasattr(evolved_instruction, 'instructions'):
+            evolved_instruction = evolved_instruction.instructions
+        else:
+            evolved_instruction = skill["body"]
+    
+    # Parse out the skill text from the instruction wrapper
+    import re as _re
+    skill_header = "Follow these skill instructions to complete the task:\n\n"
+    separator = "\n\n---\n"
+    
+    if evolved_instruction.startswith(skill_header):
+        rest = evolved_instruction[len(skill_header):]
+        if separator in rest:
+            evolved_body = rest.split(separator, 1)[0]
+        else:
+            # No separator found — the optimizer may have reformulated
+            evolved_body = rest
+    else:
+        # Optimizer completely rewrote the instruction — treat as evolved body
+        evolved_body = evolved_instruction
+    
+    # If the evolved body is empty or just whitespace, fall back to original
+    if not evolved_body.strip():
+        evolved_body = skill["body"]
+    
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
     # ── 7. Validate evolved skill ───────────────────────────────────────

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -84,11 +84,8 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
 class SkillModule(dspy.Module):
     """A DSPy module that wraps a skill file for optimization.
 
-    The skill text (body) is the parameter that GEPA optimizes.
-    On each forward pass, the module:
-    1. Uses the skill text as instructions
-    2. Processes the task input
-    3. Returns the agent's response
+    The skill text is embedded in the instruction template so that
+    DSPy's optimizer (MIPROv2) can propose improved versions of it.
     """
 
     class TaskWithSkill(dspy.Signature):
@@ -97,18 +94,26 @@ class SkillModule(dspy.Module):
         You are an AI agent following specific skill instructions to complete a task.
         Read the skill instructions carefully and follow the procedure described.
         """
-        skill_instructions: str = dspy.InputField(desc="The skill instructions to follow")
         task_input: str = dspy.InputField(desc="The task to complete")
         output: str = dspy.OutputField(desc="Your response following the skill instructions")
 
     def __init__(self, skill_text: str):
         super().__init__()
         self.skill_text = skill_text
-        self.predictor = dspy.ChainOfThought(self.TaskWithSkill)
+        # Create a custom signature that embeds the skill text in the instructions
+        # so the optimizer can propose modifications to it
+        base_sig = self.TaskWithSkill
+        base_instructions = base_sig.__doc__ or ""
+        enriched_instructions = (
+            f"Follow these skill instructions to complete the task:\n\n"
+            f"{skill_text}\n\n---\n"
+            + base_instructions
+        )
+        custom_sig = base_sig.with_instructions(enriched_instructions)
+        self.predictor = dspy.ChainOfThought(custom_sig)
 
     def forward(self, task_input: str) -> dspy.Prediction:
         result = self.predictor(
-            skill_instructions=self.skill_text,
             task_input=task_input,
         )
         return dspy.Prediction(output=result.output)


### PR DESCRIPTION
## What this fixes

The pipeline crashes on a fresh install with DSPy 3.1.3. Three bugs + one architectural improvement:

### Bug fixes

1. **JSON parsing crash** (`dataset_builder.py`): LLMs return Python-style dicts with single quotes, not valid JSON. The parser only tried `json.loads()` and a regex fallback — both failed on single-quoted output. Added `ast.literal_eval` as a fallback strategy before the regex approach, plus trailing-comma cleanup.

2. **GEPA API mismatch** (`evolve_skill.py`): `GEPA.__init__()` uses `max_metric_calls` in DSPy 3.1.3, not `max_steps`. This caused an immediate TypeError, falling back to MIPROv2 every time. Fixed the parameter name and added `auto="light"`.

3. **False constraint failures** (`constraints.py`): `_check_skill_structure` was checking the skill BODY for YAML frontmatter, but the body (after splitting from frontmatter) never has it — every skill failed this constraint. Rewrote to validate body structure (headings, procedural content, substance) instead.

### Architectural improvement

4. **Skill text as optimizable instruction** (`skill_module.py` + `evolve_skill.py`): The original code passed skill text as an input field (`skill_instructions`), so the optimizer could never mutate it — it only optimized the wrapper instruction. Restructured to embed the skill text in the instruction template via `with_instructions()`, allowing MIPROv2/GEPA to propose improved skill bodies. Updated extraction logic to pull the evolved text from the compiled predictor's instruction.

### Testing

Ran end-to-end evolution on the `arxiv` skill with `--eval-source synthetic` using gemini-2.5-flash. Pipeline completes successfully: generates 20 synthetic eval cases, runs MIPROv2 optimization (10 trials), passes all constraints, and produces a mutated skill body (+2.4% growth, 232 chars added).

```
Holdout Score:  0.356 → 0.346 (-0.011 with keyword-overlap metric)
Skill Size:     9,773 → 10,005 chars (+2.4%)
```

The holdout dip is expected — the keyword-overlap metric is a weak proxy. The real improvement needs an LLM-as-judge metric for holdout eval, which the existing `LLMJudge` class supports but isn't wired into the holdout scoring yet.