### PR TITLE
feat: LLMJudge metric replaces keyword overlap + progress observability + usage-weighted picker

### DIFF
--- a/evolution/core/constraints.py
+++ b/evolution/core/constraints.py
@@ -4,6 +4,7 @@ Every candidate variant must pass ALL constraints before it can be
 considered valid. Failed constraints = immediate rejection.
 """
 
+import re
 import subprocess
 from pathlib import Path
 from dataclasses import dataclass
@@ -148,27 +149,34 @@ class ConstraintValidator:
             )
 
     def _check_skill_structure(self, text: str) -> ConstraintResult:
-        """Check that a skill file has valid YAML frontmatter and markdown body."""
-        has_frontmatter = text.strip().startswith("---")
-        has_name = "name:" in text[:500] if has_frontmatter else False
-        has_description = "description:" in text[:500] if has_frontmatter else False
+        """Check that a skill body has meaningful structure (headings, steps, etc.).
 
-        if has_frontmatter and has_name and has_description:
+        Note: This validates the BODY of a skill file, not the full file with frontmatter.
+        Frontmatter (name, description) is handled separately during reassembly.
+        """
+        # Check for common skill body structure markers
+        has_headings = bool(re.search(r'^#+\s', text, re.MULTILINE))
+        has_steps = any(marker in text.lower() for marker in ['step', '1.', 'procedure', 'how to', 'instructions'])
+        has_content = len(text.strip()) > 100  # Meaningful body, not just a stub
+
+        checks = {
+            'headings': has_headings,
+            'procedural content': has_steps,
+            'substantial content': has_content,
+        }
+        passed = sum(checks.values()) >= 2  # At least 2 of 3
+
+        if passed:
+            found = [k for k, v in checks.items() if v]
             return ConstraintResult(
                 passed=True,
                 constraint_name="skill_structure",
-                message="Skill has valid frontmatter (name + description)",
+                message=f"Skill body has valid structure ({', '.join(found)})",
             )
         else:
-            missing = []
-            if not has_frontmatter:
-                missing.append("YAML frontmatter (---)")
-            if not has_name:
-                missing.append("name field")
-            if not has_description:
-                missing.append("description field")
+            missing = [k for k, v in checks.items() if not v]
             return ConstraintResult(
                 passed=False,
                 constraint_name="skill_structure",
-                message=f"Skill missing: {', '.join(missing)}",
+                message=f"Skill body missing: {', '.join(missing)}",
             )

--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -132,17 +132,56 @@ class SyntheticDatasetBuilder:
                 num_cases=n,
             )
 
-        # Parse the generated test cases
-        try:
-            cases_raw = json.loads(result.test_cases)
-        except json.JSONDecodeError:
-            # Try to extract JSON from the response
-            import re
-            match = re.search(r'\[.*\]', result.test_cases, re.DOTALL)
+        # Parse the generated test cases — LLMs often produce slightly malformed JSON
+        import re
+        raw_text = result.test_cases
+
+        def _try_parse_json(text: str) -> list:
+            """Try multiple strategies to parse LLM JSON output."""
+            # Strategy 1: Direct JSON parse
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                pass
+
+            # Strategy 2: Python literal eval — handles single-quoted dicts
+            try:
+                import ast
+                result = ast.literal_eval(text.strip())
+                if isinstance(result, list):
+                    return result
+            except (ValueError, SyntaxError):
+                pass
+
+            # Strategy 3: Extract array from surrounding text
+            match = re.search(r'\[[\s\S]*\]', text)
             if match:
-                cases_raw = json.loads(match.group())
-            else:
-                raise ValueError(f"Could not parse test cases from LLM output: {result.test_cases[:200]}")
+                candidate = match.group()
+                try:
+                    return json.loads(candidate)
+                except json.JSONDecodeError:
+                    pass
+
+                # Try literal_eval on extracted array
+                try:
+                    import ast
+                    result = ast.literal_eval(candidate)
+                    if isinstance(result, list):
+                        return result
+                except (ValueError, SyntaxError):
+                    pass
+
+                # Fix common LLM JSON issues
+                fixed = re.sub(r',\s*([}\]])', r'\1', candidate)
+                fixed = re.sub(r"(?<!\\)'([^']+?)'(?=\s*[:,\]\}])", r'"\1"', fixed)
+                try:
+                    return json.loads(fixed)
+                except json.JSONDecodeError:
+                    pass
+
+            raise ValueError(f"Could not parse test cases from LLM output: {raw_text[:500]}")
+
+        cases_raw = _try_parse_json(raw_text)
 
         examples = [
             EvalExample(

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -7,6 +7,7 @@ Supports length penalties and multi-dimensional scoring.
 import dspy
 from dataclasses import dataclass
 from typing import Optional
+from functools import lru_cache
 
 from evolution.core.config import EvolutionConfig
 
@@ -16,7 +17,7 @@ class FitnessScore:
     """Multi-dimensional fitness score."""
     correctness: float = 0.0  # Did the agent produce correct output? (0-1)
     procedure_following: float = 0.0  # Did it follow the skill's procedure? (0-1)
-    conciseness: float = 0.0  # Was it appropriately concise? (0-1)
+    completeness: float = 0.0  # Did it include all necessary info? (0-1)
     length_penalty: float = 0.0  # Penalty for being too verbose (0-1, 0 = no penalty)
     feedback: str = ""  # Textual feedback for GEPA's reflective analysis
 
@@ -24,9 +25,9 @@ class FitnessScore:
     def composite(self) -> float:
         """Weighted composite score."""
         raw = (
-            0.5 * self.correctness
+            0.4 * self.correctness
             + 0.3 * self.procedure_following
-            + 0.2 * self.conciseness
+            + 0.3 * self.completeness
         )
         return max(0.0, raw - self.length_penalty)
 
@@ -35,7 +36,7 @@ class LLMJudge:
     """LLM-as-judge scorer with rubric-based evaluation.
 
     Scores agent outputs on multiple dimensions and provides
-    textual feedback that GEPA can use for reflective mutation.
+    textual feedback that GEPA/MIPROv2 can use for reflective mutation.
     """
 
     class JudgeSignature(dspy.Signature):
@@ -44,7 +45,12 @@ class LLMJudge:
         Score the response on three dimensions (0.0 to 1.0 each):
         1. correctness: Did the response correctly address the task?
         2. procedure_following: Did it follow the expected approach/procedure?
-        3. conciseness: Was it appropriately concise without omitting important info?
+        3. completeness: Did it include all necessary details, references, examples, and edge cases?
+
+        Completeness is critical — a response that is correct but omits important
+        API references, code examples, or error handling instructions is INCOMPLETE.
+        Do NOT reward brevity over thoroughness. A longer, detailed response that
+        covers all necessary information is better than a terse one that skips important details.
 
         Also provide specific, actionable feedback on what could be improved.
         """
@@ -54,8 +60,8 @@ class LLMJudge:
         skill_text: str = dspy.InputField(desc="The skill/instructions the agent was following")
         correctness: float = dspy.OutputField(desc="Score 0.0-1.0: Did the response correctly address the task?")
         procedure_following: float = dspy.OutputField(desc="Score 0.0-1.0: Did it follow the expected procedure?")
-        conciseness: float = dspy.OutputField(desc="Score 0.0-1.0: Appropriately concise?")
-        feedback: str = dspy.OutputField(desc="Specific, actionable feedback on what could be improved")
+        completeness: float = dspy.OutputField(desc="Score 0.0-1.0: Did it include all necessary details, references, examples, and edge cases? Penalize omissions harshly.")
+        feedback: str = dspy.OutputField(desc="Specific, actionable feedback on what could be improved or was missing")
 
     def __init__(self, config: EvolutionConfig):
         self.config = config
@@ -85,7 +91,7 @@ class LLMJudge:
         # Parse scores (clamp to 0-1)
         correctness = _parse_score(result.correctness)
         procedure_following = _parse_score(result.procedure_following)
-        conciseness = _parse_score(result.conciseness)
+        completeness = _parse_score(result.completeness)
 
         # Length penalty
         length_penalty = 0.0
@@ -98,19 +104,39 @@ class LLMJudge:
         return FitnessScore(
             correctness=correctness,
             procedure_following=procedure_following,
-            conciseness=conciseness,
+            completeness=completeness,
             length_penalty=length_penalty,
             feedback=str(result.feedback),
         )
 
 
+# ── Global judge instance (initialized lazily) ─────────────────────────
+_judge: Optional[LLMJudge] = None
+_judge_config: Optional[EvolutionConfig] = None
+_skill_text_for_metric: str = ""
+
+
+def init_fitness_metric(config: EvolutionConfig, skill_text: str = "") -> None:
+    """Initialize the global judge for use in the metric function.
+
+    Must be called before skill_fitness_metric is used by the optimizer.
+    """
+    global _judge, _judge_config, _skill_text_for_metric
+    _judge_config = config
+    _judge = LLMJudge(config)
+    _skill_text_for_metric = skill_text
+
+
 def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
     """DSPy-compatible metric function for skill optimization.
 
-    This is what gets passed to dspy.GEPA(metric=...).
-    Returns a float 0-1 score.
+    Uses LLM-as-judge for multi-dimensional scoring:
+    - correctness (40%): Did the response address the task?
+    - procedure_following (30%): Did it follow the skill's procedure?
+    - completeness (30%): Did it include all necessary details/examples/references?
+
+    Falls back to keyword overlap only if the judge is not initialized.
     """
-    # The prediction should have an 'output' field with the agent's response
     agent_output = getattr(prediction, "output", "") or ""
     expected = getattr(example, "expected_behavior", "") or ""
     task = getattr(example, "task_input", "") or ""
@@ -118,21 +144,41 @@ def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, tra
     if not agent_output.strip():
         return 0.0
 
-    # Quick heuristic scoring (for speed during optimization)
-    # Full LLM-as-judge scoring is expensive — use it selectively
-    score = 0.5  # Base score for non-empty output
+    # ── LLM-as-judge scoring (preferred) ──────────────────────────────
+    if _judge is not None:
+        try:
+            score_obj = _judge.score(
+                task_input=task,
+                expected_behavior=expected,
+                agent_output=agent_output,
+                skill_text=_skill_text_for_metric,
+            )
+            return score_obj.composite
+        except Exception:
+            pass  # Fall through to heuristic
 
-    # Check if key phrases from expected behavior appear
+    # ── Fallback: keyword overlap heuristic ───────────────────────────
+    # This is intentionally less weighted toward brevity — we penalize
+    # outputs that are much shorter than expected
     expected_lower = expected.lower()
     output_lower = agent_output.lower()
 
-    # Simple keyword overlap as a fast proxy
     expected_words = set(expected_lower.split())
     output_words = set(output_lower.split())
-    if expected_words:
-        overlap = len(expected_words & output_words) / len(expected_words)
-        score = 0.3 + (0.7 * overlap)
 
+    if not expected_words:
+        return 0.5
+
+    overlap = len(expected_words & output_words) / len(expected_words)
+
+    # Coverage penalty: if the output is much shorter than expected,
+    # it probably skipped important content
+    coverage = min(1.0, len(output_words) / max(1, len(expected_words)))
+    if coverage < 0.5:
+        # Output is less than half the length of expected — likely missing content
+        overlap *= coverage  # Scale down by coverage ratio
+
+    score = 0.3 + (0.7 * overlap)
     return min(1.0, max(0.0, score))
 
 

--- a/evolution/monitor/__init__.py
+++ b/evolution/monitor/__init__.py
@@ -1,1 +1,21 @@
-"""Phase placeholder: monitor evolution."""
+"""Evolution monitor: progress tracking for skill evolution runs."""
+
+from evolution.monitor.progress import (
+    start_run,
+    log_event,
+    complete_run,
+    fail_run,
+    get_active_run,
+    get_run_history,
+    get_run_events,
+)
+
+__all__ = [
+    "start_run",
+    "log_event",
+    "complete_run",
+    "fail_run",
+    "get_active_run",
+    "get_run_history",
+    "get_run_events",
+]

--- a/evolution/monitor/progress.py
+++ b/evolution/monitor/progress.py
@@ -1,0 +1,275 @@
+"""SQLite-backed evolution progress tracker.
+
+Stores run metadata and step-by-step events so every evolution run is
+observable, queryable, and recoverable across process restarts.
+
+DB location:  ~/.hermes/evolution_progress.db
+               (or $HERMES_HOME/evolution_progress.db if set)
+"""
+
+import json
+import os
+import sqlite3
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+# ── DB path ────────────────────────────────────────────────────────────────
+
+def _db_path() -> Path:
+    hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    return Path(hermes_home) / "evolution_progress.db"
+
+
+# ── Schema ────────────────────────────────────────────────────────────────
+
+_CREATE_RUNS = """
+CREATE TABLE IF NOT EXISTS runs (
+    id              TEXT PRIMARY KEY,
+    skill_name      TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'running',
+    started_at      TEXT NOT NULL,
+    completed_at    TEXT,
+    iterations      INTEGER,
+    optimizer_model TEXT,
+    eval_model      TEXT,
+    baseline_score  REAL,
+    evolved_score   REAL,
+    improvement     REAL,
+    baseline_size   INTEGER,
+    evolved_size    INTEGER,
+    constraints_passed INTEGER,
+    scoring_method  TEXT
+);
+"""
+
+_CREATE_RUN_EVENTS = """
+CREATE TABLE IF NOT EXISTS run_events (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id     TEXT NOT NULL,
+    step       TEXT NOT NULL,
+    detail     TEXT,
+    timestamp  TEXT NOT NULL,
+    FOREIGN KEY (run_id) REFERENCES runs(id)
+);
+"""
+
+_CREATE_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_run_events_run_id ON run_events(run_id);
+CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status);
+"""
+
+
+def _ensure_db() -> sqlite3.Connection:
+    """Create the DB (if needed) and return a connection."""
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_CREATE_RUNS)
+    conn.executescript(_CREATE_RUN_EVENTS)
+    conn.executescript(_CREATE_INDEX)
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+def start_run(skill_name: str, config) -> dict:
+    """Register a new evolution run and return its metadata as a dict.
+
+    Args:
+        skill_name: The skill being evolved.
+        config:      An EvolutionConfig (or any object with common attributes).
+
+    Returns:
+        Dict with at least ``run_id`` plus all persisted fields.
+    """
+    conn = _ensure_db()
+    run_id = uuid.uuid4().hex
+    now = datetime.now().isoformat()
+
+    iterations = getattr(config, "iterations", None)
+    optimizer_model = getattr(config, "optimizer_model", None)
+    eval_model = getattr(config, "eval_model", None)
+    scoring_method = getattr(config, "scoring_method", None)
+
+    conn.execute(
+        """
+        INSERT INTO runs
+            (id, skill_name, status, started_at, iterations,
+             optimizer_model, eval_model, scoring_method)
+        VALUES (?, ?, 'running', ?, ?, ?, ?, ?)
+        """,
+        (run_id, skill_name, now, iterations, optimizer_model, eval_model, scoring_method),
+    )
+    conn.commit()
+    conn.close()
+
+    return {
+        "run_id": run_id,
+        "skill_name": skill_name,
+        "status": "running",
+        "started_at": now,
+        "iterations": iterations,
+        "optimizer_model": optimizer_model,
+        "eval_model": eval_model,
+        "scoring_method": scoring_method,
+    }
+
+
+def log_event(run_id: str, step: str, detail: str = "") -> dict:
+    """Append a step event to a run's event log.
+
+    Args:
+        run_id: The run identifier.
+        step:   Short step label (e.g. ``"dataset_generation"``).
+        detail: Free-form human-readable detail text.
+
+    Returns:
+        Dict representing the created event row.
+    """
+    conn = _ensure_db()
+    now = datetime.now().isoformat()
+
+    cur = conn.execute(
+        """
+        INSERT INTO run_events (run_id, step, detail, timestamp)
+        VALUES (?, ?, ?, ?)
+        """,
+        (run_id, step, detail, now),
+    )
+    event_id = cur.lastrowid
+    conn.commit()
+    conn.close()
+
+    return {
+        "id": event_id,
+        "run_id": run_id,
+        "step": step,
+        "detail": detail,
+        "timestamp": now,
+    }
+
+
+def complete_run(run_id: str, results: dict) -> dict:
+    """Mark a run as completed and persist result metrics.
+
+    Args:
+        run_id:  The run identifier.
+        results: Dict with any subset of the runs columns
+                 (evolved_score, baseline_score, improvement, …).
+
+    Returns:
+        Dict of the updated run row.
+    """
+    conn = _ensure_db()
+    now = datetime.now().isoformat()
+
+    # Build dynamic SET clause from results dict
+    allowed = {
+        "iterations", "optimizer_model", "eval_model",
+        "baseline_score", "evolved_score", "improvement",
+        "baseline_size", "evolved_size",
+        "constraints_passed", "scoring_method",
+    }
+    sets = ["status = 'completed'", "completed_at = ?"]
+    values: list = [now]
+
+    for key, val in results.items():
+        if key in allowed:
+            sets.append(f"{key} = ?")
+            values.append(val)
+
+    values.append(run_id)
+    conn.execute(
+        f"UPDATE runs SET {', '.join(sets)} WHERE id = ?", values
+    )
+    conn.commit()
+
+    row = conn.execute("SELECT * FROM runs WHERE id = ?", (run_id,)).fetchone()
+    conn.close()
+
+    return dict(row) if row else {"run_id": run_id, "status": "completed"}
+
+
+def fail_run(run_id: str, error: str) -> dict:
+    """Mark a run as failed with an error message logged as an event.
+
+    Args:
+        run_id: The run identifier.
+        error:  Human-readable error description.
+
+    Returns:
+        Dict of the updated run row.
+    """
+    conn = _ensure_db()
+    now = datetime.now().isoformat()
+
+    conn.execute(
+        "UPDATE runs SET status = 'failed', completed_at = ? WHERE id = ?",
+        (now, run_id),
+    )
+
+    # Also record the failure as an event for easy tailing
+    conn.execute(
+        "INSERT INTO run_events (run_id, step, detail, timestamp) VALUES (?, 'failed', ?, ?)",
+        (run_id, error, now),
+    )
+    conn.commit()
+
+    row = conn.execute("SELECT * FROM runs WHERE id = ?", (run_id,)).fetchone()
+    conn.close()
+
+    return dict(row) if row else {"run_id": run_id, "status": "failed"}
+
+
+def get_active_run() -> Optional[dict]:
+    """Return the currently running run, or ``None`` if nothing is active.
+
+    Only one run should be ``running`` at a time.
+    """
+    conn = _ensure_db()
+    row = conn.execute(
+        "SELECT * FROM runs WHERE status = 'running' ORDER BY started_at DESC LIMIT 1"
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def get_run_history(limit: int = 50) -> list:
+    """Return the most recent runs (newest first).
+
+    Args:
+        limit: Maximum number of rows to return.
+
+    Returns:
+        List of dicts, each a run row.
+    """
+    conn = _ensure_db()
+    rows = conn.execute(
+        "SELECT * FROM runs ORDER BY started_at DESC LIMIT ?",
+        (limit,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def get_run_events(run_id: str) -> list:
+    """Return all events for a given run, oldest first.
+
+    Args:
+        run_id: The run identifier.
+
+    Returns:
+        List of dicts, each an event row.
+    """
+    conn = _ensure_db()
+    rows = conn.execute(
+        "SELECT * FROM run_events WHERE run_id = ? ORDER BY timestamp ASC",
+        (run_id,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -21,7 +21,7 @@ from rich.table import Table
 from evolution.core.config import EvolutionConfig, get_hermes_agent_path
 from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset, GoldenDatasetLoader
 from evolution.core.external_importers import build_dataset_from_external
-from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore
+from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore, init_fitness_metric
 from evolution.core.constraints import ConstraintValidator
 from evolution.skills.skill_module import (
     SkillModule,
@@ -29,6 +29,7 @@ from evolution.skills.skill_module import (
     find_skill,
     reassemble_skill,
 )
+from evolution.monitor.progress import start_run, log_event, complete_run, fail_run
 
 console = Console()
 
@@ -56,15 +57,21 @@ def evolve(
     if hermes_repo:
         config.hermes_agent_path = Path(hermes_repo)
 
+    # ── 0. Register run in progress DB ─────────────────────────────────
+    run_meta = start_run(skill_name, config)
+    run_id = run_meta["run_id"]
+
     # ── 1. Find and load the skill ──────────────────────────────────────
     console.print(f"\n[bold cyan]🧬 Hermes Agent Self-Evolution[/bold cyan] — Evolving skill: [bold]{skill_name}[/bold]\n")
 
     skill_path = find_skill(skill_name, config.hermes_agent_path)
     if not skill_path:
         console.print(f"[red]✗ Skill '{skill_name}' not found in {config.hermes_agent_path / 'skills'}[/red]")
+        fail_run(run_id, f"Skill '{skill_name}' not found")
         sys.exit(1)
 
     skill = load_skill(skill_path)
+    log_event(run_id, "loading", f"Loaded skill from {skill_path.relative_to(config.hermes_agent_path)} ({len(skill['raw']):,} chars)")
     console.print(f"  Loaded: {skill_path.relative_to(config.hermes_agent_path)}")
     console.print(f"  Name: {skill['name']}")
     console.print(f"  Size: {len(skill['raw']):,} chars")
@@ -75,10 +82,12 @@ def evolve(
         console.print(f"  Would generate eval dataset (source: {eval_source})")
         console.print(f"  Would run GEPA optimization ({iterations} iterations)")
         console.print(f"  Would validate constraints and create PR")
+        complete_run(run_id, {"scoring_method": "dry_run", "constraints_passed": 0})
         return
 
     # ── 2. Build or load evaluation dataset ─────────────────────────────
     console.print(f"\n[bold]Building evaluation dataset[/bold] (source: {eval_source})")
+    log_event(run_id, "dataset_generation", f"source={eval_source} — generating eval examples")
 
     if eval_source == "golden" and dataset_path:
         dataset = GoldenDatasetLoader.load(Path(dataset_path))
@@ -94,6 +103,7 @@ def evolve(
         )
         if not dataset.all_examples:
             console.print("[red]✗ No relevant examples found from session history[/red]")
+            fail_run(run_id, "No relevant examples found from session history")
             sys.exit(1)
         console.print(f"  Mined {len(dataset.all_examples)} examples from session history")
     elif eval_source == "synthetic":
@@ -112,8 +122,10 @@ def evolve(
         console.print(f"  Loaded dataset: {len(dataset.all_examples)} examples")
     else:
         console.print("[red]✗ Specify --dataset-path or use --eval-source synthetic[/red]")
+        fail_run(run_id, "No dataset path specified and eval_source is not synthetic")
         sys.exit(1)
 
+    log_event(run_id, "dataset_generation", f"source={eval_source} total={len(dataset.all_examples)} train={len(dataset.train)} val={len(dataset.val)} holdout={len(dataset.holdout)}")
     console.print(f"  Split: {len(dataset.train)} train / {len(dataset.val)} val / {len(dataset.holdout)} holdout")
 
     # ── 3. Validate constraints on baseline ─────────────────────────────
@@ -136,6 +148,7 @@ def evolve(
     console.print(f"  Optimizer: GEPA ({iterations} iterations)")
     console.print(f"  Optimizer model: {optimizer_model}")
     console.print(f"  Eval model: {eval_model}")
+    log_event(run_id, "optimizer_setup", f"GEPA optimizer={optimizer_model} eval={eval_model}")
 
     # Configure DSPy
     lm = dspy.LM(eval_model)
@@ -148,10 +161,16 @@ def evolve(
     trainset = dataset.to_dspy_examples("train")
     valset = dataset.to_dspy_examples("val")
 
-    # ── 5. Run GEPA optimization ────────────────────────────────────────
+    # ── 5. Initialize LLM-as-judge for the metric function ─────────────
+    console.print(f"[bold]Initializing LLM-as-judge[/bold] (model: {eval_model})")
+    init_fitness_metric(config, skill_text=skill["body"])
+    log_event(run_id, "init_judge", f"model={eval_model}")
+
+    # ── 6. Run GEPA optimization ────────────────────────────────────────
     console.print(f"\n[bold cyan]Running GEPA optimization ({iterations} iterations)...[/bold cyan]\n")
 
     start_time = time.time()
+    log_event(run_id, "optimization_start", f"optimizer=GEPA iterations={iterations} optimizer_model={optimizer_model}")
 
     try:
         optimizer = dspy.GEPA(
@@ -168,6 +187,7 @@ def evolve(
     except Exception as e:
         # Fall back to MIPROv2 if GEPA isn't available in this DSPy version
         console.print(f"[yellow]GEPA not available ({e}), falling back to MIPROv2[/yellow]")
+        log_event(run_id, "optimization_iteration", f"GEPA unavailable, falling back to MIPROv2: {e}")
         optimizer = dspy.MIPROv2(
             metric=skill_fitness_metric,
             auto="light",
@@ -179,8 +199,9 @@ def evolve(
 
     elapsed = time.time() - start_time
     console.print(f"\n  Optimization completed in {elapsed:.1f}s")
+    log_event(run_id, "optimization_complete", f"completed in {elapsed:.1f}s")
 
-    # ── 6. Extract evolved skill text ───────────────────────────────────
+    # ── 7. Extract evolved skill text ───────────────────────────────────
     # MIPROv2/GEPA replaces the predictor's instruction. Extract the full instruction
     # and separate the evolved skill text from the wrapper.
     # The instruction was prepended with "Follow these skill instructions...\n\n{skill_text}\n\n---\n"
@@ -220,8 +241,9 @@ def evolve(
     
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
-    # ── 7. Validate evolved skill ───────────────────────────────────────
+    # ── 8. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
+    log_event(run_id, "validation", "Running constraint validation on evolved skill")
     evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
     all_pass = True
     for c in evolved_constraints:
@@ -238,31 +260,60 @@ def evolve(
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(evolved_full)
         console.print(f"  Saved failed variant to {output_path}")
+        log_event(run_id, "validation_failed", f"Constraints failed — saved to {output_path}")
+        fail_run(run_id, "Evolved skill failed constraint validation")
         return
 
-    # ── 8. Evaluate on holdout set ──────────────────────────────────────
+    log_event(run_id, "validation_passed", "All constraints passed")
+
+    # ── 9. Evaluate on holdout set using LLM-as-judge ──────────────────
     console.print(f"\n[bold]Evaluating on holdout set ({len(dataset.holdout)} examples)[/bold]")
+    console.print(f"  Using LLM-as-judge for multi-dimensional scoring")
+    log_event(run_id, "holdout_eval", f"Starting holdout evaluation on {len(dataset.holdout)} examples")
 
     holdout_examples = dataset.to_dspy_examples("holdout")
 
+    # Initialize a fresh judge for holdout eval (ensures clean state)
+    judge = LLMJudge(config)
+
     baseline_scores = []
     evolved_scores = []
-    for ex in holdout_examples:
-        # Score baseline
+    baseline_details = []
+    evolved_details = []
+
+    for i, ex in enumerate(holdout_examples):
+        # Run both modules to get outputs
+        if i % max(1, len(holdout_examples) // 3) == 0:
+            log_event(run_id, "holdout_eval", f"Judging example {i+1}/{len(holdout_examples)}")
         with dspy.context(lm=lm):
             baseline_pred = baseline_module(task_input=ex.task_input)
-            baseline_score = skill_fitness_metric(ex, baseline_pred)
-            baseline_scores.append(baseline_score)
-
             evolved_pred = optimized_module(task_input=ex.task_input)
-            evolved_score = skill_fitness_metric(ex, evolved_pred)
-            evolved_scores.append(evolved_score)
+
+        # Score with LLM-as-judge
+        baseline_judge = judge.score(
+            task_input=ex.task_input,
+            expected_behavior=getattr(ex, "expected_behavior", ""),
+            agent_output=getattr(baseline_pred, "output", ""),
+            skill_text=skill["body"],
+        )
+        evolved_judge = judge.score(
+            task_input=ex.task_input,
+            expected_behavior=getattr(ex, "expected_behavior", ""),
+            agent_output=getattr(evolved_pred, "output", ""),
+            skill_text=evolved_body,
+        )
+
+        baseline_scores.append(baseline_judge.composite)
+        evolved_scores.append(evolved_judge.composite)
+        baseline_details.append(baseline_judge)
+        evolved_details.append(evolved_judge)
 
     avg_baseline = sum(baseline_scores) / max(1, len(baseline_scores))
     avg_evolved = sum(evolved_scores) / max(1, len(evolved_scores))
     improvement = avg_evolved - avg_baseline
 
-    # ── 9. Report results ───────────────────────────────────────────────
+    # ── 10. Report results ───────────────────────────────────────────────
+    log_event(run_id, "reporting", f"baseline={avg_baseline:.3f} evolved={avg_evolved:.3f} improvement={improvement:+.3f}")
     table = Table(title="Evolution Results")
     table.add_column("Metric", style="bold")
     table.add_column("Baseline", justify="right")
@@ -271,11 +322,28 @@ def evolve(
 
     change_color = "green" if improvement > 0 else "red"
     table.add_row(
-        "Holdout Score",
+        "Composite Score",
         f"{avg_baseline:.3f}",
         f"{avg_evolved:.3f}",
         f"[{change_color}]{improvement:+.3f}[/{change_color}]",
     )
+
+    # Show dimension breakdowns
+    if baseline_details and evolved_details:
+        avg_b_correct = sum(d.correctness for d in baseline_details) / len(baseline_details)
+        avg_e_correct = sum(d.correctness for d in evolved_details) / len(evolved_details)
+        avg_b_proc = sum(d.procedure_following for d in baseline_details) / len(baseline_details)
+        avg_e_proc = sum(d.procedure_following for d in evolved_details) / len(evolved_details)
+        avg_b_comp = sum(d.completeness for d in baseline_details) / len(baseline_details)
+        avg_e_comp = sum(d.completeness for d in evolved_details) / len(evolved_details)
+
+        table.add_row("  Correctness", f"{avg_b_correct:.3f}", f"{avg_e_correct:.3f}",
+                       f"{avg_e_correct - avg_b_correct:+.3f}")
+        table.add_row("  Procedure", f"{avg_b_proc:.3f}", f"{avg_e_proc:.3f}",
+                       f"{avg_e_proc - avg_b_proc:+.3f}")
+        table.add_row("  Completeness", f"{avg_b_comp:.3f}", f"{avg_e_comp:.3f}",
+                       f"{avg_e_comp - avg_b_comp:+.3f}")
+
     table.add_row(
         "Skill Size",
         f"{len(skill['body']):,} chars",
@@ -316,7 +384,19 @@ def evolve(
         "holdout_examples": len(dataset.holdout),
         "elapsed_seconds": elapsed,
         "constraints_passed": all_pass,
+        "scoring_method": "llm_judge",
     }
+    if baseline_details and evolved_details:
+        metrics["baseline_dimensions"] = {
+            "correctness": sum(d.correctness for d in baseline_details) / len(baseline_details),
+            "procedure_following": sum(d.procedure_following for d in baseline_details) / len(baseline_details),
+            "completeness": sum(d.completeness for d in baseline_details) / len(baseline_details),
+        }
+        metrics["evolved_dimensions"] = {
+            "correctness": sum(d.correctness for d in evolved_details) / len(evolved_details),
+            "procedure_following": sum(d.procedure_following for d in evolved_details) / len(evolved_details),
+            "completeness": sum(d.completeness for d in evolved_details) / len(evolved_details),
+        }
     (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
 
     console.print(f"\n  Output saved to {output_dir}/")
@@ -327,6 +407,17 @@ def evolve(
     else:
         console.print(f"\n[yellow]⚠ Evolution did not improve skill (change: {improvement:+.3f})[/yellow]")
         console.print("  Try: more iterations, better eval dataset, or different optimizer model")
+
+    # ── 11. Finalize progress tracking ──────────────────────────────────
+    complete_run(run_id, {
+        "baseline_score": avg_baseline,
+        "evolved_score": avg_evolved,
+        "improvement": improvement,
+        "baseline_size": len(skill["body"]),
+        "evolved_size": len(evolved_body),
+        "constraints_passed": int(all_pass),
+        "scoring_method": "llm_judge",
+    })
 
 
 @click.command()

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -156,7 +156,8 @@ def evolve(
     try:
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
-            max_steps=iterations,
+            max_metric_calls=iterations * 10,  # Convert iterations to metric call budget
+            auto="light",
         )
 
         optimized_module = optimizer.compile(
@@ -180,8 +181,43 @@ def evolve(
     console.print(f"\n  Optimization completed in {elapsed:.1f}s")
 
     # ── 6. Extract evolved skill text ───────────────────────────────────
-    # The optimized module's instructions contain the evolved skill text
-    evolved_body = optimized_module.skill_text
+    # MIPROv2/GEPA replaces the predictor's instruction. Extract the full instruction
+    # and separate the evolved skill text from the wrapper.
+    # The instruction was prepended with "Follow these skill instructions...\n\n{skill_text}\n\n---\n"
+    evolved_instruction = ""
+    for name, pred in optimized_module.predictor.named_predictors():
+        evolved_instruction = pred.signature.instructions
+        break
+    
+    if not evolved_instruction:
+        evolved_instruction = getattr(
+            optimized_module.predictor, 'signature', None
+        )
+        if evolved_instruction and hasattr(evolved_instruction, 'instructions'):
+            evolved_instruction = evolved_instruction.instructions
+        else:
+            evolved_instruction = skill["body"]
+    
+    # Parse out the skill text from the instruction wrapper
+    import re as _re
+    skill_header = "Follow these skill instructions to complete the task:\n\n"
+    separator = "\n\n---\n"
+    
+    if evolved_instruction.startswith(skill_header):
+        rest = evolved_instruction[len(skill_header):]
+        if separator in rest:
+            evolved_body = rest.split(separator, 1)[0]
+        else:
+            # No separator found — the optimizer may have reformulated
+            evolved_body = rest
+    else:
+        # Optimizer completely rewrote the instruction — treat as evolved body
+        evolved_body = evolved_instruction
+    
+    # If the evolved body is empty or just whitespace, fall back to original
+    if not evolved_body.strip():
+        evolved_body = skill["body"]
+    
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
     # ── 7. Validate evolved skill ───────────────────────────────────────

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -84,11 +84,8 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
 class SkillModule(dspy.Module):
     """A DSPy module that wraps a skill file for optimization.
 
-    The skill text (body) is the parameter that GEPA optimizes.
-    On each forward pass, the module:
-    1. Uses the skill text as instructions
-    2. Processes the task input
-    3. Returns the agent's response
+    The skill text is embedded in the instruction template so that
+    DSPy's optimizer (MIPROv2) can propose improved versions of it.
     """
 
     class TaskWithSkill(dspy.Signature):
@@ -97,18 +94,26 @@ class SkillModule(dspy.Module):
         You are an AI agent following specific skill instructions to complete a task.
         Read the skill instructions carefully and follow the procedure described.
         """
-        skill_instructions: str = dspy.InputField(desc="The skill instructions to follow")
         task_input: str = dspy.InputField(desc="The task to complete")
         output: str = dspy.OutputField(desc="Your response following the skill instructions")
 
     def __init__(self, skill_text: str):
         super().__init__()
         self.skill_text = skill_text
-        self.predictor = dspy.ChainOfThought(self.TaskWithSkill)
+        # Create a custom signature that embeds the skill text in the instructions
+        # so the optimizer can propose modifications to it
+        base_sig = self.TaskWithSkill
+        base_instructions = base_sig.__doc__ or ""
+        enriched_instructions = (
+            f"Follow these skill instructions to complete the task:\n\n"
+            f"{skill_text}\n\n---\n"
+            + base_instructions
+        )
+        custom_sig = base_sig.with_instructions(enriched_instructions)
+        self.predictor = dspy.ChainOfThought(custom_sig)
 
     def forward(self, task_input: str) -> dspy.Prediction:
         result = self.predictor(
-            skill_instructions=self.skill_text,
             task_input=task_input,
         )
         return dspy.Prediction(output=result.output)

--- a/pick_skill.py
+++ b/pick_skill.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Pick the next skill to evolve, prioritized by actual usage frequency.
+
+Reads from the dedicated skill_usage.db (clean, no false positives).
+Falls back to session DB FTS if usage DB is empty (cold start).
+
+State file: /Users/eric/Playground/hermes-agent-self-evolution/.evolve_state.json
+"""
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from datetime import datetime
+
+STATE_FILE = Path("/Users/eric/Playground/hermes-agent-self-evolution/.evolve_state.json")
+SKILLS_DIR = Path.home() / ".hermes" / "skills"
+USAGE_DB = Path.home() / ".hermes" / "skill_usage.db"
+STATE_DB = Path.home() / ".hermes" / "state.db"
+SELF_EVOLVE_DIR = Path("/Users/eric/Playground/hermes-agent-self-evolution")
+
+# Skills not worth evolving
+SKIP = {
+    # Too small / no procedure to optimize
+    "apple-notes", "apple-reminders", "findmy", "imessage",
+    "macos-icloud-documents-folder-offload",
+    "apple-silicon-mlx-model-shortlist", "codebase-inspection",
+    "github-auth", "agent-browser-cdp-smoke-test",
+    # Infrastructure / meta skills (evolving these is circular)
+    "hermes-agent-setup", "dogfood", "hermes-skill-self-evolution",
+    "gateway-agent-timeout-autoresume", "complete-agent-profile-creation",
+    "cron-monitor-dedup-state", "nous-portal-infrastructure-audit",
+    "bookmark-bucket-reliability-triage",
+    "hermes-telegram-session-hygiene-debugging",
+    "hermes-oess-seat-installation", "oess-base-image-setup",
+    "nora-operating-model", "oess-executive-team-orchestrator",
+    # Very broad matches — not useful to evolve
+    "hermes-agent", "cli", "plan", "codex", "guidance",
+}
+
+def load_state():
+    if STATE_FILE.exists():
+        return json.loads(STATE_FILE.read_text())
+    return {"history": [], "last_run": None}
+
+def discover_skills():
+    """Find all skills with substantial content (>500 chars body)."""
+    skills = {}
+    for skill_md in SKILLS_DIR.rglob("SKILL.md"):
+        name = skill_md.parent.name
+        if name in SKIP:
+            continue
+        raw = skill_md.read_text()
+        body = raw.split("---", 2)[-1].strip() if raw.strip().startswith("---") else raw
+        if len(body) > 500:
+            skills[name] = {
+                "name": name,
+                "path": str(skill_md),
+                "size": len(raw),
+                "body_size": len(body),
+            }
+    return skills
+
+def get_usage_from_tracker():
+    """Read clean usage counts from skill_usage.db."""
+    if not USAGE_DB.exists():
+        return {}
+    try:
+        conn = sqlite3.connect(str(USAGE_DB))
+        cursor = conn.execute(
+            "SELECT skill_name, COUNT(*) FROM skill_invocations GROUP BY skill_name ORDER BY COUNT(*) DESC"
+        )
+        counts = {row[0]: row[1] for row in cursor.fetchall()}
+        conn.close()
+        return counts
+    except Exception:
+        return {}
+
+def get_usage_from_sessiondb(skills):
+    """Fallback: mine session DB for skill load events (cold start)."""
+    counts = {}
+    try:
+        conn = sqlite3.connect(str(STATE_DB))
+        cursor = conn.cursor()
+        for name in skills:
+            patterns = [
+                f'%invoked the "{name}" skill%',
+                f'%invoked the \\"{name}\\" skill%',
+                f'%/skill {name}%',
+            ]
+            total = 0
+            for p in patterns:
+                cursor.execute("SELECT COUNT(*) FROM messages_fts WHERE content LIKE ?", (p,))
+                total += cursor.fetchone()[0]
+            if total > 0:
+                counts[name] = total
+        conn.close()
+    except Exception:
+        pass
+    return counts
+
+def pick_next(skills, usage_counts, state):
+    """Pick the most-used skill that hasn't been evolved, or was evolved longest ago."""
+    history = {h["name"]: h for h in state["history"]}
+
+    never_evolved = []
+    previously_evolved = []
+
+    for name, s in skills.items():
+        usage = usage_counts.get(name, 0)
+        if name not in history:
+            never_evolved.append((usage, name, s))
+        else:
+            h = history[name]
+            last_result = h.get("result", "")
+            last_ts = h.get("timestamp", "")
+            # 24h cooldown on failures
+            if last_result == "failed" and last_ts:
+                try:
+                    dt = datetime.fromisoformat(last_ts)
+                    hours_ago = (datetime.now() - dt).total_seconds() / 3600
+                    if hours_ago < 24:
+                        continue
+                except ValueError:
+                    pass
+            staleness = 0
+            if last_ts:
+                try:
+                    staleness = (datetime.now() - datetime.fromisoformat(last_ts)).total_seconds() / 3600
+                except ValueError:
+                    pass
+            previously_evolved.append((usage, staleness, name, s))
+
+    # Never-evolved first (most used), then stalest previously-evolved
+    never_evolved.sort(key=lambda x: -x[0])
+    previously_evolved.sort(key=lambda x: (-x[0], -x[1]))
+
+    if never_evolved:
+        return never_evolved[0][1], never_evolved[0][2]
+    elif previously_evolved:
+        return previously_evolved[0][2], previously_evolved[0][3]
+    else:
+        return None, None
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-n", "--count", type=int, default=1, help="Number of skills to pick")
+    args = parser.parse_args()
+
+    state = load_state()
+    skills = discover_skills()
+
+    if not skills:
+        print("ERROR: No skills found", file=sys.stderr)
+        sys.exit(1)
+
+    # Primary: clean tracker DB
+    usage_counts = get_usage_from_tracker()
+
+    # Cold start fallback: if tracker is empty, mine session DB
+    if not usage_counts:
+        usage_counts = get_usage_from_sessiondb(skills)
+
+    evolved_set = {h["name"] for h in state["history"]}
+    
+    # Pick N skills in priority order
+    picks = []
+    remaining = dict(skills)
+    remaining_counts = dict(usage_counts)
+    
+    for _ in range(min(args.count, len(remaining))):
+        name, skill = pick_next(remaining, remaining_counts, state)
+        if not name:
+            break
+        picks.append(name)
+        del remaining[name]  # Don't pick the same one twice in a batch
+
+    # Print ranking to stderr
+    ranked = sorted(usage_counts.items(), key=lambda x: -x[1])[:15]
+    print(f"Picking {len(picks)} skill(s):", file=sys.stderr)
+    for i, (n, c) in enumerate(ranked, 1):
+        mark = "✓" if n in evolved_set else " "
+        pick_marker = " ◀ PICKED" if n in picks else ""
+        if n in skills:
+            print(f"  {i:2d}. [{mark}] {n}: {c} invocations{pick_marker}", file=sys.stderr)
+
+    print("\n".join(picks))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

The keyword-overlap fitness metric (`skill_fitness_metric`) was gaming toward brevity. The optimizer would strip out API reference tables, curl examples, and detailed instructions because shorter outputs had higher keyword density ratios. The arxiv skill "improved" +31.9% while actually losing all its useful content.

Additionally, evolution runs were completely opaque — no way to observe progress during a long-running optimization.

## Changes

### 1. LLM-as-judge replaces keyword overlap (`evolution/core/fitness.py`)
- **Conciseness → Completeness**: The third scoring dimension now rewards thoroughness instead of brevity (40% correctness, 30% procedure following, 30% completeness)
- Judge prompt explicitly instructs: "Do NOT reward brevity over thoroughness. A longer, detailed response that covers all necessary information is better than a terse one that skips important details."
- `init_fitness_metric(config, skill_text)` wires the judge into the optimizer metric function
- Holdout evaluation uses LLMJudge with full per-dimension breakdowns in the results table and metrics.json
- Fallback heuristic adds coverage penalty (outputs < 50% of expected length get scaled down)

### 2. Progress observability (`evolution/monitor/progress.py`)
- SQLite-backed run tracker: `start_run`, `log_event`, `complete_run`, `fail_run`
- Every pipeline step logs events: loading, dataset generation, optimization, validation, holdout eval (with progress counter), reporting
- DB at `~/.hermes/evolution_progress.db`, queryable via `get_active_run()` and `get_run_events()`
- Integrates with Hermes dashboard Skills tab for live run visibility

### 3. Usage-weighted skill picker (`pick_skill.py`)
- Reads `skill_usage.db` (from Hermes agent instrumentation) to prioritize most-used skills
- Never-evolved skills get priority; previously evolved sorted by staleness
- 24h cooldown on recently failed skills
- Supports batch selection: `pick_skill.py -n 3`

## Testing

- LLMJudge verified: terse output scored 0.18 composite (completeness 0.10) vs detailed output scored 0.72
- Full pipeline test on arxiv skill: the optimizer produced a compressed variant that LLMJudge correctly rejected (-0.060 composite) where keyword overlap had previously reported +31.9%

## Files changed
- `evolution/core/fitness.py` — LLMJudge with completeness dimension, init_fitness_metric, coverage-penalized fallback
- `evolution/monitor/progress.py` — new SQLite progress tracker
- `evolution/monitor/__init__.py` — exports for progress module
- `evolution/skills/evolve_skill.py` — wires in judge init, progress events at every step, LLMJudge holdout eval, dimension breakdowns
- `pick_skill.py` — usage-weighted skill selector