### PR TITLE
Real session data evolution: fix GEPA + expand sessiondb filter

### DIFF
--- a/evolution/core/codex_lm.py
+++ b/evolution/core/codex_lm.py
@@ -1,0 +1,70 @@
+"""DSPy LM provider that delegates to Codex CLI (GPT-5.4 via ChatGPT auth)."""
+
+import json
+import subprocess
+
+import dspy
+
+
+class CodexLM(dspy.BaseLM):
+    """Wraps `codex exec --json` as a DSPy language model.
+
+    Uses the local codex CLI which authenticates via ChatGPT Plus OAuth,
+    giving access to GPT-5.4 without needing an API key.
+    """
+
+    def __init__(self, timeout: int = 300, **kwargs):
+        self.timeout = timeout
+        self.model = "codex/gpt-5.4"
+        self.model_type = "chat"
+        self.cache = kwargs.get("cache", True)
+        self.history = []
+        self.kwargs = kwargs
+
+    def __call__(self, prompt=None, messages=None, **kwargs) -> list[str]:
+        if messages:
+            # Convert chat messages to a single prompt string
+            text = "\n\n".join(f"[{m.get('role', 'user')}]: {m.get('content', '')}" for m in messages)
+        elif prompt:
+            text = prompt if isinstance(prompt, str) else str(prompt)
+        else:
+            return [""]
+
+        try:
+            result = subprocess.run(
+                ["codex", "exec", "--json", text],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                stdin=subprocess.DEVNULL,
+            )
+
+            if result.returncode != 0:
+                return [f"Error: codex exec failed: {result.stderr[:200]}"]
+
+            # Parse NDJSON output, find the agent_message
+            response_text = ""
+            for line in result.stdout.strip().split("\n"):
+                try:
+                    obj = json.loads(line)
+                    if obj.get("type") == "item.completed":
+                        item = obj.get("item", {})
+                        if item.get("type") == "agent_message":
+                            response_text = item.get("text", "")
+                except json.JSONDecodeError:
+                    continue
+
+            self.history.append({"prompt": text[:200], "response": response_text[:200]})
+            return [response_text]
+
+        except subprocess.TimeoutExpired:
+            return ["Error: codex exec timed out"]
+        except Exception as e:
+            return [f"Error: {e}"]
+
+    def inspect_history(self, n: int = 1):
+        return self.history[-n:]
+
+    @property
+    def provider(self):
+        return "codex"

--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -43,29 +43,29 @@ console = Console()
 # Each pattern is intentionally anchored to known key formats to minimize
 # false positives on normal prose.
 SECRET_PATTERNS = re.compile(
-    r'('
-    r'sk-ant-api\S+'           # Anthropic API keys
-    r'|sk-or-v1-\S+'          # OpenRouter API keys
-    r'|sk-\S{20,}'            # Generic OpenAI-style keys (20+ chars after sk-)
-    r'|ghp_\S+'               # GitHub personal access tokens
-    r'|ghu_\S+'               # GitHub user tokens
-    r'|xoxb-\S+'              # Slack bot tokens
-    r'|xapp-\S+'              # Slack app tokens
-    r'|ntn_\S+'               # Notion integration tokens
-    r'|AKIA[0-9A-Z]{16}'      # AWS access key IDs
-    r'|Bearer\s+\S{20,}'      # Bearer auth headers (20+ char tokens)
-    r'|-----BEGIN\s+(RSA\s+)?PRIVATE\sKEY-----'  # PEM private keys
-    r'|ANTHROPIC_API_KEY'      # Known env var names (exact match)
-    r'|OPENAI_API_KEY'
-    r'|OPENROUTER_API_KEY'
-    r'|SLACK_BOT_TOKEN'
-    r'|GITHUB_TOKEN'
-    r'|AWS_SECRET_ACCESS_KEY'
-    r'|DATABASE_URL'
-    r'|\bpassword\s*[=:]\s*\S+' # password assignments (password=xxx, password: xxx)
-    r'|\bsecret\s*[=:]\s*\S+'   # secret assignments (secret=xxx, secret: xxx)
-    r'|\btoken\s*[=:]\s*\S{10,}' # token assignments with 10+ char values
-    r')',
+    r"("
+    r"sk-ant-api\S+"  # Anthropic API keys
+    r"|sk-or-v1-\S+"  # OpenRouter API keys
+    r"|sk-\S{20,}"  # Generic OpenAI-style keys (20+ chars after sk-)
+    r"|ghp_\S+"  # GitHub personal access tokens
+    r"|ghu_\S+"  # GitHub user tokens
+    r"|xoxb-\S+"  # Slack bot tokens
+    r"|xapp-\S+"  # Slack app tokens
+    r"|ntn_\S+"  # Notion integration tokens
+    r"|AKIA[0-9A-Z]{16}"  # AWS access key IDs
+    r"|Bearer\s+\S{20,}"  # Bearer auth headers (20+ char tokens)
+    r"|-----BEGIN\s+(RSA\s+)?PRIVATE\sKEY-----"  # PEM private keys
+    r"|ANTHROPIC_API_KEY"  # Known env var names (exact match)
+    r"|OPENAI_API_KEY"
+    r"|OPENROUTER_API_KEY"
+    r"|SLACK_BOT_TOKEN"
+    r"|GITHUB_TOKEN"
+    r"|AWS_SECRET_ACCESS_KEY"
+    r"|DATABASE_URL"
+    r"|\bpassword\s*[=:]\s*\S+"  # password assignments (password=xxx, password: xxx)
+    r"|\bsecret\s*[=:]\s*\S+"  # secret assignments (secret=xxx, secret: xxx)
+    r"|\btoken\s*[=:]\s*\S{10,}"  # token assignments with 10+ char values
+    r")",
     re.IGNORECASE,
 )
 
@@ -141,12 +141,12 @@ def _is_relevant_to_skill(text: str, skill_name: str, skill_text: str) -> bool:
     # Extract meaningful keywords from skill text (first 500 chars)
     skill_keywords = set()
     for word in skill_text[:500].lower().split():
-        word = re.sub(r'[^a-z]', '', word)
+        word = re.sub(r"[^a-z]", "", word)
         if len(word) > 4:
             skill_keywords.add(word)
 
     # Require at least 2 keyword matches
-    message_words = set(re.sub(r'[^a-z\s]', '', text_lower).split())
+    message_words = set(re.sub(r"[^a-z\s]", "", text_lower).split())
     overlap = message_words & skill_keywords
     return len(overlap) >= 2
 
@@ -193,13 +193,15 @@ class ClaudeCodeImporter:
                 if _contains_secret(text):
                     continue
 
-                messages.append({
-                    "source": "claude-code",
-                    "task_input": text,
-                    "project": entry.get("project", ""),
-                    "session_id": entry.get("sessionId", ""),
-                    "timestamp": entry.get("timestamp", 0),
-                })
+                messages.append(
+                    {
+                        "source": "claude-code",
+                        "task_input": text,
+                        "project": entry.get("project", ""),
+                        "session_id": entry.get("sessionId", ""),
+                        "timestamp": entry.get("timestamp", 0),
+                    }
+                )
 
                 if limit and len(messages) >= limit:
                     break
@@ -265,13 +267,15 @@ def _read_copilot_workspace(workspace_path: Path) -> str:
         for line in workspace_path.read_text().split("\n"):
             if line.startswith("cwd:"):
                 return line.split(":", 1)[1].strip()
-    except Exception:
-        pass
+    except Exception as e:
+        console.print(f"[dim]Could not read {workspace_path}: {e}[/dim]")
     return ""
 
 
 def _parse_copilot_events(
-    events_path: Path, session_id: str, project: str,
+    events_path: Path,
+    session_id: str,
+    project: str,
 ) -> list[dict]:
     """Parse a single Copilot events.jsonl into user/assistant pairs."""
     pairs = []
@@ -295,13 +299,15 @@ def _parse_copilot_events(
                     # Save previous pair before starting new one
                     if current_user_msg and current_assistant_msg:
                         if not _contains_secret(current_user_msg) and not _contains_secret(current_assistant_msg):
-                            pairs.append({
-                                "source": "copilot",
-                                "task_input": current_user_msg,
-                                "assistant_response": current_assistant_msg,
-                                "project": project,
-                                "session_id": session_id,
-                            })
+                            pairs.append(
+                                {
+                                    "source": "copilot",
+                                    "task_input": current_user_msg,
+                                    "assistant_response": current_assistant_msg,
+                                    "project": project,
+                                    "session_id": session_id,
+                                }
+                            )
 
                     current_user_msg = data.get("content", "")
                     current_assistant_msg = None
@@ -317,13 +323,15 @@ def _parse_copilot_events(
         # Don't forget the last pair in the file
         if current_user_msg and current_assistant_msg:
             if not _contains_secret(current_user_msg) and not _contains_secret(current_assistant_msg):
-                pairs.append({
-                    "source": "copilot",
-                    "task_input": current_user_msg,
-                    "assistant_response": current_assistant_msg,
-                    "project": project,
-                    "session_id": session_id,
-                })
+                pairs.append(
+                    {
+                        "source": "copilot",
+                        "task_input": current_user_msg,
+                        "assistant_response": current_assistant_msg,
+                        "project": project,
+                        "session_id": session_id,
+                    }
+                )
 
     except Exception as e:
         console.print(f"[dim]Skipped {session_id}: {e}[/dim]")
@@ -403,12 +411,14 @@ class HermesSessionImporter:
                 if assistant_text and _contains_secret(assistant_text):
                     continue
 
-                messages.append({
-                    "source": "hermes",
-                    "task_input": user_text,
-                    "assistant_response": assistant_text,
-                    "session_id": session_id,
-                })
+                messages.append(
+                    {
+                        "source": "hermes",
+                        "task_input": user_text,
+                        "assistant_response": assistant_text,
+                        "session_id": session_id,
+                    }
+                )
 
                 if limit and len(messages) >= limit:
                     return messages
@@ -422,10 +432,26 @@ class HermesSessionImporter:
 class RelevanceFilter:
     """Use LLM-as-judge to determine which messages are relevant to a skill.
 
-    Two-stage pipeline:
-      1. Cheap heuristic pre-filter (_is_relevant_to_skill)
-      2. LLM scoring for final relevance + eval metadata generation
+    Three-stage pipeline:
+      1. LLM generates ~40 skill-specific keywords/phrases (one call, once).
+      2. Substring pre-filter against the entire corpus using expanded keywords.
+      3. LLM scores each pre-filtered candidate for relevance + metadata.
     """
+
+    class ExpandKeywords(dspy.Signature):
+        """Generate relevance keywords/phrases for a skill.
+
+        List 30-50 words and short phrases that indicate a user message is
+        relevant to this skill's domain. Include synonyms, abbreviations
+        (e.g., "PR" for "pull request"), action verbs ("review", "audit"),
+        and concrete artifacts (file types, tools, commands).
+
+        Output as a JSON array of lowercase strings. No explanation, no code fences.
+        """
+
+        skill_name: str = dspy.InputField(desc="Name of the skill")
+        skill_text: str = dspy.InputField(desc="Full SKILL.md content")
+        keywords: str = dspy.OutputField(desc="JSON array of 30-50 lowercase keyword strings")
 
     class ScoreRelevance(dspy.Signature):
         """Score whether a user message is relevant to a specific agent skill.
@@ -436,6 +462,7 @@ class RelevanceFilter:
         - difficulty: string (easy, medium, or hard)
         - category: string (what aspect of the skill this tests)
         """
+
         skill_name: str = dspy.InputField(desc="Name of the skill")
         skill_description: str = dspy.InputField(desc="First 800 chars of the skill file")
         user_message: str = dspy.InputField(desc="The user's message to evaluate")
@@ -443,8 +470,47 @@ class RelevanceFilter:
         scoring: str = dspy.OutputField(desc="JSON object with: relevant, expected_behavior, difficulty, category")
 
     def __init__(self, model: str):
+        self.expander = dspy.ChainOfThought(self.ExpandKeywords)
         self.scorer = dspy.ChainOfThought(self.ScoreRelevance)
         self.model = model
+
+    def _expand_keywords(self, skill_name: str, skill_text: str) -> list[str]:
+        """Ask the LLM for skill-specific keywords/phrases (one call, cached by caller)."""
+        lm = dspy.LM(self.model)
+        try:
+            with dspy.context(lm=lm):
+                result = self.expander(
+                    skill_name=skill_name,
+                    skill_text=skill_text[:6000],
+                )
+            parsed = _parse_scoring_json(result.keywords)
+            if isinstance(parsed, list):
+                keywords = [str(k).lower().strip() for k in parsed if isinstance(k, str) and str(k).strip()]
+            else:
+                # Try direct array parse
+                try:
+                    arr = json.loads(result.keywords)
+                    keywords = [str(k).lower().strip() for k in arr if str(k).strip()]
+                except (json.JSONDecodeError, TypeError):
+                    keywords = []
+        except Exception as e:
+            console.print(f"  [yellow]Keyword expansion failed ({e}); falling back to name-based filter[/yellow]")
+            keywords = []
+
+        # Always seed with tokens from the skill name so absurd LLM output doesn't
+        # collapse the candidate pool to zero.
+        for token in skill_name.lower().replace("-", " ").replace("_", " ").split():
+            if token and token not in keywords:
+                keywords.append(token)
+
+        # Keep only meaningful keywords (length > 2) and de-duplicate while preserving order
+        seen = set()
+        cleaned = []
+        for k in keywords:
+            if len(k) > 2 and k not in seen:
+                seen.add(k)
+                cleaned.append(k)
+        return cleaned
 
     def filter_and_score(
         self,
@@ -469,21 +535,29 @@ class RelevanceFilter:
         # Stage 0: drop messages missing required fields
         messages = [m for m in messages if m.get("task_input") and m.get("source")]
 
-        # Stage 1: cheap heuristic pre-filter
-        candidates = [
-            m for m in messages
-            if _is_relevant_to_skill(m["task_input"], skill_name, skill_text)
-        ]
+        # Stage 1: LLM-expanded keywords (one call)
+        console.print(f"  Expanding skill keywords with LLM ({self.model})...")
+        keywords = self._expand_keywords(skill_name, skill_text)
+        console.print(f"  Using {len(keywords)} relevance keywords (e.g. {', '.join(keywords[:6])}...)")
 
-        # If heuristics found too few, sample remaining messages
-        if len(candidates) < max_examples:
+        # Stage 2: substring pre-filter against the ENTIRE corpus
+        candidates = []
+        for m in messages:
+            text_lower = m["task_input"].lower()
+            if any(kw in text_lower for kw in keywords):
+                candidates.append(m)
+
+        # Cap LLM scoring budget — sample if pre-filter produced too many
+        llm_budget = max_examples * 8  # 8x overscan to account for LLM rejecting borderline cases
+        if len(candidates) > llm_budget:
+            random.shuffle(candidates)
+            candidates = candidates[:llm_budget]
+        elif len(candidates) < max_examples:
+            # Pre-filter too strict — sample random messages to widen the net
             candidate_ids = {id(m) for m in candidates}
             remaining = [m for m in messages if id(m) not in candidate_ids]
             random.shuffle(remaining)
-            candidates.extend(remaining[:max_examples * 2])
-
-        # Cap candidates to control LLM costs
-        candidates = candidates[:max_examples * 3]
+            candidates.extend(remaining[: max_examples * 2])
 
         console.print(f"  Pre-filtered to {len(candidates)} candidates (from {len(messages)} total)")
 
@@ -519,10 +593,12 @@ class RelevanceFilter:
                             category=scoring.get("category", "general"),
                         )
                         if validated:
-                            examples.append(EvalExample(
-                                source=msg["source"],
-                                **validated,
-                            ))
+                            examples.append(
+                                EvalExample(
+                                    source=msg["source"],
+                                    **validated,
+                                )
+                            )
 
                 except Exception:
                     errors += 1
@@ -567,7 +643,7 @@ def _parse_scoring_json(text: str) -> Optional[dict]:
     # Slow path: find balanced {...} block using brace counting.
     # Simple regex like r'\{[^}]+\}' breaks on nested braces
     # (e.g. "handle {edge} cases" in a string value).
-    start = text.find('{')
+    start = text.find("{")
     if start == -1:
         return None
 
@@ -579,7 +655,7 @@ def _parse_scoring_json(text: str) -> Optional[dict]:
         if escape_next:
             escape_next = False
             continue
-        if ch == '\\' and in_string:
+        if ch == "\\" and in_string:
             escape_next = True
             continue
         if ch == '"':
@@ -587,13 +663,13 @@ def _parse_scoring_json(text: str) -> Optional[dict]:
             continue
         if in_string:
             continue
-        if ch == '{':
+        if ch == "{":
             depth += 1
-        elif ch == '}':
+        elif ch == "}":
             depth -= 1
             if depth == 0:
                 try:
-                    return json.loads(text[start:i + 1])
+                    return json.loads(text[start : i + 1])
                 except json.JSONDecodeError:
                     return None
 
@@ -653,7 +729,10 @@ def build_dataset_from_external(
 
     relevance_filter = RelevanceFilter(model=model)
     examples = relevance_filter.filter_and_score(
-        all_messages, skill_name, skill_text, max_examples=max_examples,
+        all_messages,
+        skill_name,
+        skill_text,
+        max_examples=max_examples,
     )
 
     console.print(f"\n[bold green]Found {len(examples)} relevant examples[/bold green]")
@@ -676,8 +755,8 @@ def build_dataset_from_external(
 
     dataset = EvalDataset(
         train=examples[:n_train],
-        val=examples[n_train:n_train + n_val],
-        holdout=examples[n_train + n_val:],
+        val=examples[n_train : n_train + n_val],
+        holdout=examples[n_train + n_val :],
     )
 
     dataset.save(output_path)
@@ -734,10 +813,10 @@ def _load_skill_text(skill_name: str, skills_dir: Optional[Path] = None) -> tupl
     help="Which tool to import from",
 )
 @click.option("--skill", required=True, help="Skill name to generate eval data for")
-@click.option("--output", type=click.Path(), default=None,
-              help="Output directory (default: datasets/skills/<skill>/)")
-@click.option("--model", default="openrouter/google/gemini-2.5-flash",
-              help="LiteLLM model string for relevance scoring")
+@click.option("--output", type=click.Path(), default=None, help="Output directory (default: datasets/skills/<skill>/)")
+@click.option(
+    "--model", default="openrouter/google/gemini-2.5-flash", help="LiteLLM model string for relevance scoring"
+)
 @click.option("--max-examples", default=50, help="Max eval examples to generate")
 @click.option("--dry-run", is_flag=True, help="Show message counts without LLM scoring")
 def main(source, skill, output, model, max_examples, dry_run):

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -14,6 +14,7 @@ from evolution.core.config import EvolutionConfig
 @dataclass
 class FitnessScore:
     """Multi-dimensional fitness score."""
+
     correctness: float = 0.0  # Did the agent produce correct output? (0-1)
     procedure_following: float = 0.0  # Did it follow the skill's procedure? (0-1)
     conciseness: float = 0.0  # Was it appropriately concise? (0-1)
@@ -23,11 +24,7 @@ class FitnessScore:
     @property
     def composite(self) -> float:
         """Weighted composite score."""
-        raw = (
-            0.5 * self.correctness
-            + 0.3 * self.procedure_following
-            + 0.2 * self.conciseness
-        )
+        raw = 0.5 * self.correctness + 0.3 * self.procedure_following + 0.2 * self.conciseness
         return max(0.0, raw - self.length_penalty)
 
 
@@ -48,6 +45,7 @@ class LLMJudge:
 
         Also provide specific, actionable feedback on what could be improved.
         """
+
         task_input: str = dspy.InputField(desc="The task the agent was given")
         expected_behavior: str = dspy.InputField(desc="Rubric describing what a good response looks like")
         agent_output: str = dspy.InputField(desc="The agent's actual response")
@@ -104,7 +102,9 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+def skill_fitness_metric(
+    example: dspy.Example, prediction: dspy.Prediction, trace=None, pred_name=None, pred_trace=None
+) -> float:
     """DSPy-compatible metric function for skill optimization.
 
     This is what gets passed to dspy.GEPA(metric=...).
@@ -113,7 +113,6 @@ def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, tra
     # The prediction should have an 'output' field with the agent's response
     agent_output = getattr(prediction, "output", "") or ""
     expected = getattr(example, "expected_behavior", "") or ""
-    task = getattr(example, "task_input", "") or ""
 
     if not agent_output.strip():
         return 0.0

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -15,13 +15,12 @@ from typing import Optional
 import click
 import dspy
 from rich.console import Console
-from rich.panel import Panel
 from rich.table import Table
 
-from evolution.core.config import EvolutionConfig, get_hermes_agent_path
+from evolution.core.config import EvolutionConfig
 from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset, GoldenDatasetLoader
 from evolution.core.external_importers import build_dataset_from_external
-from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore
+from evolution.core.fitness import skill_fitness_metric
 from evolution.core.constraints import ConstraintValidator
 from evolution.skills.skill_module import (
     SkillModule,
@@ -57,7 +56,9 @@ def evolve(
         config.hermes_agent_path = Path(hermes_repo)
 
     # ── 1. Find and load the skill ──────────────────────────────────────
-    console.print(f"\n[bold cyan]🧬 Hermes Agent Self-Evolution[/bold cyan] — Evolving skill: [bold]{skill_name}[/bold]\n")
+    console.print(
+        f"\n[bold cyan]🧬 Hermes Agent Self-Evolution[/bold cyan] — Evolving skill: [bold]{skill_name}[/bold]\n"
+    )
 
     skill_path = find_skill(skill_name, config.hermes_agent_path)
     if not skill_path:
@@ -71,10 +72,10 @@ def evolve(
     console.print(f"  Description: {skill['description'][:80]}...")
 
     if dry_run:
-        console.print(f"\n[bold green]DRY RUN — setup validated successfully.[/bold green]")
+        console.print("\n[bold green]DRY RUN — setup validated successfully.[/bold green]")
         console.print(f"  Would generate eval dataset (source: {eval_source})")
         console.print(f"  Would run GEPA optimization ({iterations} iterations)")
-        console.print(f"  Would validate constraints and create PR")
+        console.print("  Would validate constraints and create PR")
         return
 
     # ── 2. Build or load evaluation dataset ─────────────────────────────
@@ -117,9 +118,9 @@ def evolve(
     console.print(f"  Split: {len(dataset.train)} train / {len(dataset.val)} val / {len(dataset.holdout)} holdout")
 
     # ── 3. Validate constraints on baseline ─────────────────────────────
-    console.print(f"\n[bold]Validating baseline constraints[/bold]")
+    console.print("\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -132,14 +133,22 @@ def evolve(
         console.print("[yellow]⚠ Baseline skill has constraint violations — proceeding anyway[/yellow]")
 
     # ── 4. Set up DSPy + GEPA optimizer ─────────────────────────────────
-    console.print(f"\n[bold]Configuring optimizer[/bold]")
+    console.print("\n[bold]Configuring optimizer[/bold]")
     console.print(f"  Optimizer: GEPA ({iterations} iterations)")
     console.print(f"  Optimizer model: {optimizer_model}")
     console.print(f"  Eval model: {eval_model}")
 
     # Configure DSPy
-    lm = dspy.LM(eval_model)
-    dspy.configure(lm=lm)
+    def make_lm(model_str):
+        if model_str.startswith("codex"):
+            from evolution.core.codex_lm import CodexLM
+
+            return CodexLM()
+        return dspy.LM(model_str)
+
+    eval_lm = make_lm(eval_model)
+    optimizer_lm = make_lm(optimizer_model) if optimizer_model != eval_model else eval_lm
+    dspy.configure(lm=eval_lm)
 
     # Create the baseline skill module
     baseline_module = SkillModule(skill["body"])
@@ -156,7 +165,8 @@ def evolve(
     try:
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
-            max_steps=iterations,
+            max_metric_calls=iterations * 10,
+            reflection_lm=optimizer_lm,
         )
 
         optimized_module = optimizer.compile(
@@ -180,13 +190,13 @@ def evolve(
     console.print(f"\n  Optimization completed in {elapsed:.1f}s")
 
     # ── 6. Extract evolved skill text ───────────────────────────────────
-    # The optimized module's instructions contain the evolved skill text
-    evolved_body = optimized_module.skill_text
+    # The optimized module's predictor signature instruction IS the evolved skill
+    evolved_body = optimized_module.predictor.predict.signature.instructions
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
-    console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    console.print("\n[bold]Validating evolved skill[/bold]")
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"
@@ -213,7 +223,7 @@ def evolve(
     evolved_scores = []
     for ex in holdout_examples:
         # Score baseline
-        with dspy.context(lm=lm):
+        with dspy.context(lm=eval_lm):
             baseline_pred = baseline_module(task_input=ex.task_input)
             baseline_score = skill_fitness_metric(ex, baseline_pred)
             baseline_scores.append(baseline_score)
@@ -286,7 +296,9 @@ def evolve(
     console.print(f"\n  Output saved to {output_dir}/")
 
     if improvement > 0:
-        console.print(f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement/max(0.001, avg_baseline)*100:+.1f}%)[/bold green]")
+        console.print(
+            f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement / max(0.001, avg_baseline) * 100:+.1f}%)[/bold green]"
+        )
         console.print(f"  Review the diff: diff {output_dir}/baseline_skill.md {output_dir}/evolved_skill.md")
     else:
         console.print(f"\n[yellow]⚠ Evolution did not improve skill (change: {improvement:+.3f})[/yellow]")
@@ -296,8 +308,12 @@ def evolve(
 @click.command()
 @click.option("--skill", required=True, help="Name of the skill to evolve")
 @click.option("--iterations", default=10, help="Number of GEPA iterations")
-@click.option("--eval-source", default="synthetic", type=click.Choice(["synthetic", "golden", "sessiondb"]),
-              help="Source for evaluation dataset")
+@click.option(
+    "--eval-source",
+    default="synthetic",
+    type=click.Choice(["synthetic", "golden", "sessiondb"]),
+    help="Source for evaluation dataset",
+)
 @click.option("--dataset-path", default=None, help="Path to existing eval dataset (JSONL)")
 @click.option("--optimizer-model", default="openai/gpt-4.1", help="Model for GEPA reflections")
 @click.option("--eval-model", default="openai/gpt-4.1-mini", help="Model for evaluations")

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -5,7 +5,6 @@ where the skill text is the optimizable parameter. GEPA can then
 mutate the skill text and evaluate the results.
 """
 
-import re
 from pathlib import Path
 from typing import Optional
 
@@ -84,33 +83,33 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
 class SkillModule(dspy.Module):
     """A DSPy module that wraps a skill file for optimization.
 
-    The skill text (body) is the parameter that GEPA optimizes.
-    On each forward pass, the module:
-    1. Uses the skill text as instructions
-    2. Processes the task input
-    3. Returns the agent's response
+    The skill text IS the signature instruction — the optimizable parameter
+    that GEPA mutates. On each forward pass, the module uses the skill text
+    as the system instruction and processes the task input.
     """
-
-    class TaskWithSkill(dspy.Signature):
-        """Complete a task following the provided skill instructions.
-
-        You are an AI agent following specific skill instructions to complete a task.
-        Read the skill instructions carefully and follow the procedure described.
-        """
-        skill_instructions: str = dspy.InputField(desc="The skill instructions to follow")
-        task_input: str = dspy.InputField(desc="The task to complete")
-        output: str = dspy.OutputField(desc="Your response following the skill instructions")
 
     def __init__(self, skill_text: str):
         super().__init__()
         self.skill_text = skill_text
-        self.predictor = dspy.ChainOfThought(self.TaskWithSkill)
+
+        # Build a signature where the skill text is the docstring (instruction).
+        # GEPA optimizes signature instructions directly.
+        sig = dspy.Signature(
+            "task_input -> output",
+            instructions=skill_text,
+        )
+        sig = sig.with_updated_fields(
+            "task_input",
+            desc="The task to complete using the skill",
+        )
+        sig = sig.with_updated_fields(
+            "output",
+            desc="Your response following the skill instructions",
+        )
+        self.predictor = dspy.ChainOfThought(sig)
 
     def forward(self, task_input: str) -> dspy.Prediction:
-        result = self.predictor(
-            skill_instructions=self.skill_text,
-            task_input=task_input,
-        )
+        result = self.predictor(task_input=task_input)
         return dspy.Prediction(output=result.output)
 
 


### PR DESCRIPTION
## Summary

Two fixes that unblocked evolution on real session history:

1. **GEPA wasn't mutating skill text** — `SkillModule` stored the skill as a plain attribute and passed it as an `InputField`. GEPA only optimizes signature instructions, so every mutation was a no-op (prior runs showed 0% improvement). Fixed: skill text is now the signature's `instructions` field.

2. **Sessiondb filter missed 96% of relevant messages** — the heuristic extracted keywords from only the first 500 chars of the skill (usually frontmatter), required 2 exact-word matches, and capped candidates at `max_examples * 3`. For github-code-review that filter found **17 relevant examples from 2482 messages**. New three-stage pipeline: one LLM call expands 30-50 relevance keywords (synonyms, abbreviations, domain verbs), then substring pre-filter scans the **entire corpus** before LLM relevance scoring.

Also adds `CodexLM` — a DSPy LM provider that delegates to `codex exec --json`, using ChatGPT Plus OAuth. Lets GEPA use GPT-5.4 as the reflection model without an API key.

## Expected outcomes

| Metric | Before | After |
|---|---|---|
| Sessiondb relevant examples (github-code-review) | 17 | 44 (2.6x) |
| Pre-filter corpus coverage | capped at 150 | 2590 (full corpus) |
| Expanded relevance keywords | 0 | 51 (e.g. "code review", "pull request", "git diff", "code audit") |
| GEPA holdout score — synthetic data | 0.414 → 0.414 (no-op) | 0.414 → 0.564 (+36.2%) |
| GEPA holdout score — real session data | N/A (couldn't get enough data) | 0.481 → 0.536 (+11.5%) |
| Train/val/holdout split on real data | 10/5/5 | 22/11/11 |

## Test plan

- [x] `python -m evolution.core.external_importers --skill github-code-review --source all --model cerebras/zai-glm-4.7 --max-examples 100` → 44 examples, 22/11/11 split
- [x] `python -m evolution.skills.evolve_skill --skill github-code-review --iterations 20 --eval-source golden --dataset-path datasets/skills/github-code-review --optimizer-model cerebras/zai-glm-4.7 --eval-model cerebras/zai-glm-4.7` → +11.5% holdout improvement
- [x] `python -m evolution.skills.evolve_skill --skill github-code-review --iterations 15 --eval-source synthetic ...` → +36.2% holdout improvement on synthetic (sanity check)
- [ ] Repeat on a second skill to confirm generality

## Merge strategy

Please use **merge-commit** (not squash). Each commit is a logical unit.