### PR TITLE
Add guarded codex-batched self-evolution path with explicit budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,12 @@ conservative runtime guardrails.
 
 ```bash
 # Conservative cached-dataset run with hard limits
-mkdir -p ./datasets/plan-smoke
+# Dataset directory must already contain: train.jsonl, val.jsonl, holdout.jsonl
 
 HERMES_EVOLUTION_MAX_CODEX_CALLS=2 \
 HERMES_EVOLUTION_PHASE_TIMEOUT_SECONDS=90 \
 HERMES_EVOLUTION_MAX_RUN_SECONDS=180 \
-HERMES_EVOLUTION_MAX_CANDIDATES_PER_ITERATION=1 \
-HERMES_EVOLUTION_ALLOW_LIVE_MODEL=0 \
+HERMES_EVOLUTION_MAX_EXAMPLES=4 \
 python -m evolution.skills.evolve_skill_codex \
     --skill plan \
     --eval-source cached \
@@ -100,12 +99,16 @@ python -m evolution.skills.evolve_skill \
 
 ## Guardrails
 
-Every evolved variant must pass:
-1. **Full test suite** — `pytest tests/ -q` must pass 100%
-2. **Size limits** — Skills ≤15KB, tool descriptions ≤500 chars
-3. **Caching compatibility** — No mid-conversation changes
-4. **Semantic preservation** — Must not drift from original purpose
-5. **PR review** — All changes go through human review, never direct commit
+Current codex-batched runs enforce:
+1. **Explicit runtime/call budgets** before each Codex phase starts
+2. **Cached-dataset evaluation only**
+3. **Size/growth/structure constraints** on the candidate skill
+4. **Evaluation acceptance gating** — candidates are rejected unless evaluation prefers them with positive improvement
+5. **Human review** — changes are still intended to go through PR review rather than unattended promotion
+
+Recommended validation before merging any evolved change:
+- run the relevant project tests explicitly
+- inspect the structured evaluation output and generated diff
 
 ## Full Plan
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,46 @@ pip install -e ".[dev]"
 
 # Point at your hermes-agent repo
 export HERMES_AGENT_REPO=~/.hermes/hermes-agent
+```
 
-# Evolve a skill (synthetic eval data)
-python -m evolution.skills.evolve_skill \
-    --skill github-code-review \
-    --iterations 10 \
-    --eval-source synthetic
+### Recommended safe path: codex-batched
 
-# Or use real session history from Claude Code, Copilot, and Hermes
+Use the bounded Codex CLI path when you want explicit model invocations and
+conservative runtime guardrails.
+
+```bash
+# Conservative cached-dataset run with hard limits
+mkdir -p ./datasets/plan-smoke
+
+HERMES_EVOLUTION_MAX_CODEX_CALLS=2 \
+HERMES_EVOLUTION_PHASE_TIMEOUT_SECONDS=90 \
+HERMES_EVOLUTION_MAX_RUN_SECONDS=180 \
+HERMES_EVOLUTION_MAX_CANDIDATES_PER_ITERATION=1 \
+HERMES_EVOLUTION_ALLOW_LIVE_MODEL=0 \
+python -m evolution.skills.evolve_skill_codex \
+    --skill plan \
+    --eval-source cached \
+    --dataset-path ./datasets/plan-smoke \
+    --iterations 1 \
+    --hermes-repo "$HERMES_AGENT_REPO"
+```
+
+This path is currently the safer option because it:
+- uses explicit `codex exec` subprocess phases instead of hidden DSPy call trees
+- enforces explicit call/time budgets before each phase starts
+- prefers cached datasets over live generation
+- currently supports cached datasets and `iterations=1` only
+- writes structured metrics including per-example results and recommendation metadata
+
+### Legacy DSPy path
+
+The original `evolve_skill` entrypoint is still present for compatibility and
+experiments, but it is not the recommended path when running against a local
+OpenAI-compatible provider. In that configuration, it is intentionally blocked
+because the DSPy-based flow can fan out into too many hidden calls.
+
+```bash
+# Legacy / experimental path
 python -m evolution.skills.evolve_skill \
     --skill github-code-review \
     --iterations 10 \

--- a/evolution/core/budget.py
+++ b/evolution/core/budget.py
@@ -1,8 +1,4 @@
-"""Hard budget enforcement for codex-batched evolution runs.
-
-This module is intentionally standalone and additive so it can survive upstream
-repo updates with minimal merge friction.
-"""
+"""Hard budget enforcement for codex-batched evolution runs."""
 
 from __future__ import annotations
 
@@ -23,8 +19,6 @@ class RunBudget:
     phase_timeout_seconds: float
     max_examples: int | None = None
     max_iterations: int | None = None
-    max_candidates_per_iteration: int | None = None
-    budget_strict: bool = True
     calls_used: int = 0
     started_at: float | None = field(default=None, init=False)
 

--- a/evolution/core/budget.py
+++ b/evolution/core/budget.py
@@ -1,0 +1,79 @@
+"""Hard budget enforcement for codex-batched evolution runs.
+
+This module is intentionally standalone and additive so it can survive upstream
+repo updates with minimal merge friction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import time
+
+
+class BudgetExceeded(RuntimeError):
+    """Raised when a run budget would be exceeded by starting a phase."""
+
+
+@dataclass
+class RunBudget:
+    """Track hard execution limits for a single evolution run."""
+
+    max_codex_calls: int
+    max_run_seconds: float
+    phase_timeout_seconds: float
+    max_examples: int | None = None
+    max_iterations: int | None = None
+    max_candidates_per_iteration: int | None = None
+    budget_strict: bool = True
+    calls_used: int = 0
+    started_at: float | None = field(default=None, init=False)
+
+    def start_run(self) -> None:
+        self.started_at = time.monotonic()
+
+    def remaining_calls(self) -> int:
+        return max(0, self.max_codex_calls - self.calls_used)
+
+    def register_call(self, name: str) -> None:
+        self.enforce_or_raise(name)
+        self.calls_used += 1
+
+    def can_start_phase(self, name: str) -> bool:
+        if self.calls_used >= self.max_codex_calls:
+            return False
+        if self.started_at is None:
+            return True
+        elapsed = time.monotonic() - self.started_at
+        if elapsed > self.max_run_seconds:
+            return False
+        remaining = self.max_run_seconds - elapsed
+        if remaining < self.phase_timeout_seconds:
+            return False
+        return True
+
+    def enforce_or_raise(self, name: str) -> None:
+        if self.can_start_phase(name):
+            return
+        reason = self._failure_reason(name)
+        raise BudgetExceeded(reason)
+
+    def _failure_reason(self, name: str) -> str:
+        if self.calls_used >= self.max_codex_calls:
+            return (
+                f"Cannot start phase '{name}': codex call budget exhausted "
+                f"({self.calls_used}/{self.max_codex_calls})."
+            )
+        if self.started_at is not None:
+            elapsed = time.monotonic() - self.started_at
+            if elapsed > self.max_run_seconds:
+                return (
+                    f"Cannot start phase '{name}': run time budget exceeded "
+                    f"({elapsed:.2f}s > {self.max_run_seconds}s)."
+                )
+            remaining = self.max_run_seconds - elapsed
+            if remaining < self.phase_timeout_seconds:
+                return (
+                    f"Cannot start phase '{name}': remaining runtime budget {remaining:.2f}s "
+                    f"is below required phase timeout {self.phase_timeout_seconds}s."
+                )
+        return f"Cannot start phase '{name}': budget restriction violated."

--- a/evolution/core/cached_dataset.py
+++ b/evolution/core/cached_dataset.py
@@ -1,0 +1,39 @@
+"""Cached dataset helpers for codex-batched evolution.
+
+This module is additive and intentionally independent of the legacy DSPy entry
+point so it can survive upstream repo updates with minimal merge friction.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from evolution.core.dataset_builder import EvalDataset
+
+
+def _has_complete_dataset(path: Path) -> bool:
+    return all((path / f"{split}.jsonl").exists() for split in ("train", "val", "holdout"))
+
+
+def load_or_create_dataset(
+    dataset_dir: Path | str,
+    creator: Callable[[], EvalDataset],
+    *,
+    allow_live_generation: bool,
+) -> tuple[EvalDataset, bool]:
+    """Load a cached dataset or create it if explicitly allowed."""
+    path = Path(dataset_dir)
+
+    if _has_complete_dataset(path):
+        return EvalDataset.load(path), False
+
+    if not allow_live_generation:
+        raise RuntimeError(
+            f"Cached dataset missing at {path}. Live generation is disabled; "
+            "set allow_live_generation to create a dataset."
+        )
+
+    dataset = creator()
+    dataset.save(path)
+    return dataset, True

--- a/evolution/core/cached_dataset.py
+++ b/evolution/core/cached_dataset.py
@@ -1,15 +1,11 @@
-"""Cached dataset helpers for codex-batched evolution.
-
-This module is additive and intentionally independent of the legacy DSPy entry
-point so it can survive upstream repo updates with minimal merge friction.
-"""
+"""Cached dataset helpers for codex-batched evolution."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Callable
 
-from evolution.core.dataset_builder import EvalDataset
+from evolution.core.eval_dataset import EvalDataset
 
 
 def _has_complete_dataset(path: Path) -> bool:

--- a/evolution/core/codex_protocol.py
+++ b/evolution/core/codex_protocol.py
@@ -1,8 +1,4 @@
-"""Prompt/protocol builders for codex-batched self-evolution.
-
-Kept separate from the CLI entrypoint so prompt evolution stays isolated and
-merge-friendly across upstream updates.
-"""
+"""Prompt/protocol builders for codex-batched self-evolution."""
 
 from __future__ import annotations
 

--- a/evolution/core/codex_protocol.py
+++ b/evolution/core/codex_protocol.py
@@ -1,0 +1,35 @@
+"""Prompt/protocol builders for codex-batched self-evolution.
+
+Kept separate from the CLI entrypoint so prompt evolution stays isolated and
+merge-friendly across upstream updates.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def build_mutation_prompt(skill_name: str, baseline_skill: str, iterations: int) -> str:
+    return (
+        f"Mutation phase for skill {skill_name}. Return only a JSON object with key "
+        f"candidate_skill_markdown. Iterations={iterations}. "
+        "Make only minimal, surgical edits. Do not rewrite the whole skill. "
+        "Preserve structure, tone, frontmatter fields, and overall intent. "
+        "Keep growth under 20% versus the baseline and prefer zero or near-zero size growth. "
+        "If no clearly better compact variant exists, return a very small edit rather than a broad rewrite. "
+        f"Baseline skill:\n{baseline_skill}"
+    )
+
+
+def build_evaluation_prompt(
+    skill_name: str,
+    baseline_skill: str,
+    candidate_skill: str,
+    holdout_examples: list[dict],
+) -> str:
+    return (
+        f"Evaluation phase for skill {skill_name}. Return only a JSON object with keys "
+        f"baseline_score, candidate_score, improvement, per_example, recommendation. "
+        "The recommendation field must be an object with keys winner, reason, confidence. "
+        f"Baseline:\n{baseline_skill}\nCandidate:\n{candidate_skill}\nHoldout: {json.dumps(holdout_examples)}"
+    )

--- a/evolution/core/codex_runner.py
+++ b/evolution/core/codex_runner.py
@@ -1,0 +1,62 @@
+"""Codex CLI subprocess runner for batched evolution phases.
+
+Kept isolated from the legacy DSPy path so upstream updates can replace the old
+optimizer logic without colliding with this adapter.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+
+
+class CodexRunTimeout(RuntimeError):
+    """Raised when a codex subprocess exceeds its timeout."""
+
+
+def build_codex_command(workdir: Path | str, codex_bin: str = "codex") -> list[str]:
+    """Build the Codex CLI command using stdin prompt mode."""
+    _ = workdir
+    return [codex_bin, "exec", "-"]
+
+
+def _run_subprocess(command: list[str], workdir: Path | str, timeout_seconds: float, prompt: str) -> str:
+    """Run a subprocess and return stdout text."""
+    completed = subprocess.run(
+        command,
+        cwd=str(workdir),
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        input=prompt,
+    )
+    return completed.stdout.strip()
+
+
+@dataclass
+class CodexRunner:
+    """Run bounded Codex CLI tasks in a repository worktree."""
+
+    workdir: Path | str
+    codex_bin: str = "codex"
+
+    def run_json_task(self, prompt: str, timeout_seconds: float) -> dict:
+        command = build_codex_command(workdir=self.workdir, codex_bin=self.codex_bin)
+        try:
+            stdout = _run_subprocess(command, self.workdir, timeout_seconds, prompt)
+        except TimeoutError as exc:
+            raise CodexRunTimeout(f"Codex timed out after {timeout_seconds}s") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise CodexRunTimeout(f"Codex timed out after {timeout_seconds}s") from exc
+
+        try:
+            parsed = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Codex output was not valid JSON: {stdout!r}") from exc
+
+        if not isinstance(parsed, dict):
+            raise ValueError(f"Codex output must be a JSON object, got {type(parsed).__name__}")
+        return parsed

--- a/evolution/core/codex_runner.py
+++ b/evolution/core/codex_runner.py
@@ -1,8 +1,4 @@
-"""Codex CLI subprocess runner for batched evolution phases.
-
-Kept isolated from the legacy DSPy path so upstream updates can replace the old
-optimizer logic without colliding with this adapter.
-"""
+"""Codex CLI subprocess runner for batched evolution phases."""
 
 from __future__ import annotations
 
@@ -16,9 +12,8 @@ class CodexRunTimeout(RuntimeError):
     """Raised when a codex subprocess exceeds its timeout."""
 
 
-def build_codex_command(workdir: Path | str, codex_bin: str = "codex") -> list[str]:
+def build_codex_command(codex_bin: str = "codex") -> list[str]:
     """Build the Codex CLI command using stdin prompt mode."""
-    _ = workdir
     return [codex_bin, "exec", "-"]
 
 
@@ -44,7 +39,7 @@ class CodexRunner:
     codex_bin: str = "codex"
 
     def run_json_task(self, prompt: str, timeout_seconds: float) -> dict:
-        command = build_codex_command(workdir=self.workdir, codex_bin=self.codex_bin)
+        command = build_codex_command(codex_bin=self.codex_bin)
         try:
             stdout = _run_subprocess(command, self.workdir, timeout_seconds, prompt)
         except TimeoutError as exc:

--- a/evolution/core/codex_schema.py
+++ b/evolution/core/codex_schema.py
@@ -63,5 +63,26 @@ def _parse_recommendation(payload: dict) -> Recommendation:
     return Recommendation(
         winner=str(payload["winner"]),
         reason=str(payload["reason"]),
-        confidence=float(payload["confidence"]),
+        confidence=_parse_confidence(payload["confidence"]),
     )
+
+
+def _parse_confidence(value) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        qualitative = {
+            "low": 0.3,
+            "medium": 0.6,
+            "med": 0.6,
+            "high": 0.9,
+        }
+        if normalized in qualitative:
+            return qualitative[normalized]
+        if normalized.endswith("%"):
+            return float(normalized[:-1].strip()) / 100.0
+        return float(normalized)
+
+    raise ValueError(f"Unsupported confidence value: {value!r}")

--- a/evolution/core/codex_schema.py
+++ b/evolution/core/codex_schema.py
@@ -1,0 +1,67 @@
+"""Structured schema parsing for codex-batched result payloads."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+
+@dataclass
+class MutationResult:
+    candidate_skill_markdown: str
+
+
+@dataclass
+class Recommendation:
+    winner: str
+    reason: str
+    confidence: float
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class EvaluationResult:
+    baseline_score: float
+    candidate_score: float
+    improvement: float
+    per_example: list[dict]
+    recommendation: Recommendation
+
+
+def parse_mutation_result(payload: dict) -> MutationResult:
+    if "candidate_skill_markdown" not in payload:
+        raise ValueError("Mutation result missing required key: candidate_skill_markdown")
+    value = payload["candidate_skill_markdown"]
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("Mutation result candidate_skill_markdown must be a non-empty string")
+    return MutationResult(candidate_skill_markdown=value)
+
+
+def parse_evaluation_result(payload: dict) -> EvaluationResult:
+    required = ["baseline_score", "candidate_score", "improvement", "per_example", "recommendation"]
+    missing = [key for key in required if key not in payload]
+    if missing:
+        raise ValueError(f"Evaluation result missing required keys: {', '.join(missing)}")
+    rec = _parse_recommendation(payload["recommendation"])
+    return EvaluationResult(
+        baseline_score=float(payload["baseline_score"]),
+        candidate_score=float(payload["candidate_score"]),
+        improvement=float(payload["improvement"]),
+        per_example=[dict(item) for item in payload["per_example"]],
+        recommendation=rec,
+    )
+
+
+def _parse_recommendation(payload: dict) -> Recommendation:
+    if not isinstance(payload, dict):
+        raise ValueError("Evaluation result recommendation must be an object")
+    required = ["winner", "reason", "confidence"]
+    missing = [key for key in required if key not in payload]
+    if missing:
+        raise ValueError(f"Evaluation result recommendation missing required keys: {', '.join(missing)}")
+    return Recommendation(
+        winner=str(payload["winner"]),
+        reason=str(payload["reason"]),
+        confidence=float(payload["confidence"]),
+    )

--- a/evolution/core/config.py
+++ b/evolution/core/config.py
@@ -16,15 +16,11 @@ class EvolutionConfig:
     iterations: int = 10
     population_size: int = 5
 
-    # Execution backend
-    execution_backend: str = field(default_factory=lambda: os.getenv("HERMES_EVOLUTION_EXECUTION_BACKEND", "codex-batch"))
-    allow_live_model: bool = field(default_factory=lambda: _env_bool("HERMES_EVOLUTION_ALLOW_LIVE_MODEL", False))
+    # Codex-batched execution limits
     max_codex_calls: int = field(default_factory=lambda: int(os.getenv("HERMES_EVOLUTION_MAX_CODEX_CALLS", "3")))
     max_examples: int = field(default_factory=lambda: int(os.getenv("HERMES_EVOLUTION_MAX_EXAMPLES", "8")))
     phase_timeout_seconds: int = field(default_factory=lambda: int(os.getenv("HERMES_EVOLUTION_PHASE_TIMEOUT_SECONDS", "180")))
     max_run_seconds: int = field(default_factory=lambda: int(os.getenv("HERMES_EVOLUTION_MAX_RUN_SECONDS", "600")))
-    max_candidates_per_iteration: int = field(default_factory=lambda: int(os.getenv("HERMES_EVOLUTION_MAX_CANDIDATES_PER_ITERATION", "1")))
-    budget_strict: bool = field(default_factory=lambda: _env_bool("HERMES_EVOLUTION_BUDGET_STRICT", True))
     codex_bin: str = field(default_factory=lambda: os.getenv("HERMES_EVOLUTION_CODEX_BIN", "codex"))
 
     # LLM configuration
@@ -76,13 +72,6 @@ def _first_set_env(*names: str) -> str:
         if value:
             return value
     return ""
-
-
-def _env_bool(name: str, default: bool) -> bool:
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _maybe_get_hermes_agent_path() -> Path | None:

--- a/evolution/core/config.py
+++ b/evolution/core/config.py
@@ -3,7 +3,6 @@
 import os
 from pathlib import Path
 from dataclasses import dataclass, field
-from typing import Optional
 
 
 @dataclass
@@ -11,37 +10,86 @@ class EvolutionConfig:
     """Configuration for a self-evolution optimization run."""
 
     # hermes-agent repo path
-    hermes_agent_path: Path = field(default_factory=lambda: get_hermes_agent_path())
+    hermes_agent_path: Path | None = field(default_factory=lambda: _maybe_get_hermes_agent_path())
 
     # Optimization parameters
     iterations: int = 10
     population_size: int = 5
 
+    # Execution backend
+    execution_backend: str = field(default_factory=lambda: os.getenv("HERMES_EVOLUTION_EXECUTION_BACKEND", "codex-batch"))
+    allow_live_model: bool = field(default_factory=lambda: _env_bool("HERMES_EVOLUTION_ALLOW_LIVE_MODEL", False))
+    max_codex_calls: int = field(default_factory=lambda: int(os.getenv("HERMES_EVOLUTION_MAX_CODEX_CALLS", "3")))
+    max_examples: int = field(default_factory=lambda: int(os.getenv("HERMES_EVOLUTION_MAX_EXAMPLES", "8")))
+    phase_timeout_seconds: int = field(default_factory=lambda: int(os.getenv("HERMES_EVOLUTION_PHASE_TIMEOUT_SECONDS", "180")))
+    max_run_seconds: int = field(default_factory=lambda: int(os.getenv("HERMES_EVOLUTION_MAX_RUN_SECONDS", "600")))
+    max_candidates_per_iteration: int = field(default_factory=lambda: int(os.getenv("HERMES_EVOLUTION_MAX_CANDIDATES_PER_ITERATION", "1")))
+    budget_strict: bool = field(default_factory=lambda: _env_bool("HERMES_EVOLUTION_BUDGET_STRICT", True))
+    codex_bin: str = field(default_factory=lambda: os.getenv("HERMES_EVOLUTION_CODEX_BIN", "codex"))
+
     # LLM configuration
-    optimizer_model: str = "openai/gpt-4.1"  # Model for GEPA reflections
-    eval_model: str = "openai/gpt-4.1-mini"  # Model for LLM-as-judge scoring
-    judge_model: str = "openai/gpt-4.1"  # Model for dataset generation
+    optimizer_model: str = "openai/gpt-4.1"
+    eval_model: str = "openai/gpt-4.1-mini"
+    judge_model: str = "openai/gpt-4.1"
+    lm_api_base: str = field(default_factory=lambda: _first_set_env(
+        "HERMES_EVOLUTION_OPENAI_BASE_URL",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_BASE",
+    ))
+    lm_api_key: str = field(default_factory=lambda: _first_set_env(
+        "HERMES_EVOLUTION_OPENAI_API_KEY",
+        "OPENAI_API_KEY",
+    ))
+    lm_timeout_seconds: float = field(default_factory=lambda: float(os.getenv("HERMES_EVOLUTION_LM_TIMEOUT", "180")))
 
     # Constraints
-    max_skill_size: int = 15_000  # 15KB default
-    max_tool_desc_size: int = 500  # chars
-    max_param_desc_size: int = 200  # chars
-    max_prompt_growth: float = 0.2  # 20% max growth over baseline
+    max_skill_size: int = 15_000
+    max_tool_desc_size: int = 500
+    max_param_desc_size: int = 200
+    max_prompt_growth: float = 0.2
 
     # Eval dataset
-    eval_dataset_size: int = 20  # Total examples to generate
+    eval_dataset_size: int = 20
     train_ratio: float = 0.5
     val_ratio: float = 0.25
     holdout_ratio: float = 0.25
 
     # Benchmark gating
     run_pytest: bool = True
-    run_tblite: bool = False  # Expensive — opt-in
-    tblite_regression_threshold: float = 0.02  # Max 2% regression allowed
+    run_tblite: bool = False
+    tblite_regression_threshold: float = 0.02
 
     # Output
     output_dir: Path = field(default_factory=lambda: Path("./output"))
     create_pr: bool = True
+
+    def resolve_hermes_agent_path(self) -> Path:
+        """Return a usable hermes-agent path or raise a clear error."""
+        if self.hermes_agent_path is not None:
+            return self.hermes_agent_path
+        return get_hermes_agent_path()
+
+
+def _first_set_env(*names: str) -> str:
+    for name in names:
+        value = os.getenv(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _maybe_get_hermes_agent_path() -> Path | None:
+    try:
+        return get_hermes_agent_path()
+    except FileNotFoundError:
+        return None
 
 
 def get_hermes_agent_path() -> Path:

--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -15,6 +15,7 @@ from typing import Optional
 import dspy
 
 from evolution.core.config import EvolutionConfig
+from evolution.core.lm import build_lm
 
 
 @dataclass
@@ -123,7 +124,7 @@ class SyntheticDatasetBuilder:
         n = num_cases or self.config.eval_dataset_size
 
         # Configure DSPy to use the judge model for generation
-        lm = dspy.LM(self.config.judge_model)
+        lm = build_lm(self.config.judge_model, self.config)
 
         with dspy.context(lm=lm):
             result = self.generator(

--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -9,82 +9,13 @@ C) Golden sets — hand-curated JSONL files
 import json
 import random
 from pathlib import Path
-from dataclasses import dataclass, field
 from typing import Optional
 
 import dspy
 
 from evolution.core.config import EvolutionConfig
+from evolution.core.eval_dataset import EvalDataset, EvalExample
 from evolution.core.lm import build_lm
-
-
-@dataclass
-class EvalExample:
-    """A single evaluation example."""
-    task_input: str  # What the user asks
-    expected_behavior: str  # Rubric — what a good response looks like
-    difficulty: str = "medium"  # easy, medium, hard
-    category: str = "general"  # Category for stratified eval
-    source: str = "synthetic"  # synthetic, sessiondb, golden
-
-    def to_dict(self) -> dict:
-        return {
-            "task_input": self.task_input,
-            "expected_behavior": self.expected_behavior,
-            "difficulty": self.difficulty,
-            "category": self.category,
-            "source": self.source,
-        }
-
-    @classmethod
-    def from_dict(cls, d: dict) -> "EvalExample":
-        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
-
-
-@dataclass
-class EvalDataset:
-    """Train/val/holdout split of evaluation examples."""
-    train: list[EvalExample] = field(default_factory=list)
-    val: list[EvalExample] = field(default_factory=list)
-    holdout: list[EvalExample] = field(default_factory=list)
-
-    @property
-    def all_examples(self) -> list[EvalExample]:
-        return self.train + self.val + self.holdout
-
-    def save(self, path: Path):
-        """Save dataset splits to JSONL files."""
-        path.mkdir(parents=True, exist_ok=True)
-        for split_name, split_data in [("train", self.train), ("val", self.val), ("holdout", self.holdout)]:
-            with open(path / f"{split_name}.jsonl", "w") as f:
-                for ex in split_data:
-                    f.write(json.dumps(ex.to_dict()) + "\n")
-
-    @classmethod
-    def load(cls, path: Path) -> "EvalDataset":
-        """Load dataset splits from JSONL files."""
-        dataset = cls()
-        for split_name in ["train", "val", "holdout"]:
-            split_file = path / f"{split_name}.jsonl"
-            if split_file.exists():
-                examples = []
-                with open(split_file) as f:
-                    for line in f:
-                        if line.strip():
-                            examples.append(EvalExample.from_dict(json.loads(line)))
-                setattr(dataset, split_name, examples)
-        return dataset
-
-    def to_dspy_examples(self, split: str = "train") -> list[dspy.Example]:
-        """Convert a split to DSPy Example objects."""
-        data = getattr(self, split)
-        return [
-            dspy.Example(
-                task_input=ex.task_input,
-                expected_behavior=ex.expected_behavior,
-            ).with_inputs("task_input")
-            for ex in data
-        ]
 
 
 class SyntheticDatasetBuilder:

--- a/evolution/core/eval_dataset.py
+++ b/evolution/core/eval_dataset.py
@@ -1,0 +1,77 @@
+"""Lightweight evaluation dataset models used by both legacy and codex paths."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class EvalExample:
+    """A single evaluation example."""
+
+    task_input: str
+    expected_behavior: str
+    difficulty: str = "medium"
+    category: str = "general"
+    source: str = "synthetic"
+
+    def to_dict(self) -> dict:
+        return {
+            "task_input": self.task_input,
+            "expected_behavior": self.expected_behavior,
+            "difficulty": self.difficulty,
+            "category": self.category,
+            "source": self.source,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "EvalExample":
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class EvalDataset:
+    """Train/val/holdout split of evaluation examples."""
+
+    train: list[EvalExample] = field(default_factory=list)
+    val: list[EvalExample] = field(default_factory=list)
+    holdout: list[EvalExample] = field(default_factory=list)
+
+    @property
+    def all_examples(self) -> list[EvalExample]:
+        return self.train + self.val + self.holdout
+
+    def save(self, path: Path):
+        path.mkdir(parents=True, exist_ok=True)
+        for split_name, split_data in (("train", self.train), ("val", self.val), ("holdout", self.holdout)):
+            with open(path / f"{split_name}.jsonl", "w") as f:
+                for ex in split_data:
+                    f.write(json.dumps(ex.to_dict()) + "\n")
+
+    @classmethod
+    def load(cls, path: Path) -> "EvalDataset":
+        dataset = cls()
+        for split_name in ("train", "val", "holdout"):
+            split_file = path / f"{split_name}.jsonl"
+            if split_file.exists():
+                examples = []
+                with open(split_file) as f:
+                    for line in f:
+                        if line.strip():
+                            examples.append(EvalExample.from_dict(json.loads(line)))
+                setattr(dataset, split_name, examples)
+        return dataset
+
+    def to_dspy_examples(self, split: str = "train") -> list:
+        import dspy
+
+        data = getattr(self, split)
+        return [
+            dspy.Example(
+                task_input=ex.task_input,
+                expected_behavior=ex.expected_behavior,
+            ).with_inputs("task_input")
+            for ex in data
+        ]

--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -34,6 +34,7 @@ from rich.console import Console
 from rich.progress import Progress
 
 from evolution.core.dataset_builder import EvalExample, EvalDataset
+from evolution.core.lm import build_lm
 
 console = Console()
 
@@ -490,7 +491,7 @@ class RelevanceFilter:
         # Stage 2: LLM relevance scoring
         examples = []
         errors = 0
-        lm = dspy.LM(self.model)
+        lm = build_lm(self.model)
 
         with Progress() as progress:
             task = progress.add_task("Scoring relevance...", total=len(candidates))

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from evolution.core.config import EvolutionConfig
+from evolution.core.lm import build_lm
 
 
 @dataclass
@@ -72,7 +73,7 @@ class LLMJudge:
     ) -> FitnessScore:
         """Score an agent output using LLM-as-judge."""
 
-        lm = dspy.LM(self.config.eval_model)
+        lm = build_lm(self.config.eval_model, self.config)
 
         with dspy.context(lm=lm):
             result = self.judge(

--- a/evolution/core/lm.py
+++ b/evolution/core/lm.py
@@ -1,0 +1,25 @@
+"""Centralized DSPy LM construction for self-evolution runs.
+
+This repo often runs against non-default OpenAI-compatible backends, especially
+local Hermes API instances. Centralizing LM creation keeps that wiring in one
+place and avoids each module silently falling back to the wrong provider.
+"""
+
+from __future__ import annotations
+
+from evolution.core.config import EvolutionConfig
+import dspy
+
+
+def build_lm(model: str, config: EvolutionConfig | None = None, *, model_type: str = "chat") -> dspy.LM:
+    """Construct a DSPy LM with optional OpenAI-compatible backend overrides."""
+    config = config or EvolutionConfig()
+    kwargs: dict[str, object] = {
+        "model_type": model_type,
+        "timeout": config.lm_timeout_seconds,
+    }
+    if config.lm_api_base:
+        kwargs["api_base"] = config.lm_api_base
+    if config.lm_api_key:
+        kwargs["api_key"] = config.lm_api_key
+    return dspy.LM(model, **kwargs)

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -1,4 +1,9 @@
-"""Evolve a Hermes Agent skill using DSPy + GEPA.
+"""Legacy DSPy-based self-evolution entrypoint.
+
+WARNING: This path is retained only for compatibility and experiments against
+non-local providers. It is not safe for unattended runs against the local
+Hermes API on this host because DSPy can fan out into many hidden model calls.
+Use `evolve_skill_codex.py` for the new guarded codex-batched path.
 
 Usage:
     python -m evolution.skills.evolve_skill --skill github-code-review --iterations 10
@@ -19,6 +24,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from evolution.core.config import EvolutionConfig, get_hermes_agent_path
+from evolution.core.lm import build_lm
 from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset, GoldenDatasetLoader
 from evolution.core.external_importers import build_dataset_from_external
 from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore
@@ -33,6 +39,15 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+def enforce_legacy_backend_guard(lm_api_base: str) -> None:
+    """Hard-block the legacy DSPy path when pointed at the local Hermes API."""
+    normalized = (lm_api_base or "").strip().lower()
+    if normalized.startswith("http://127.0.0.1:8642") or normalized.startswith("http://localhost:8642"):
+        raise RuntimeError(
+            "Legacy DSPy path is blocked for the local Hermes API; use the codex-batched path instead."
+        )
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -43,6 +58,7 @@ def evolve(
     hermes_repo: Optional[str] = None,
     run_tests: bool = False,
     dry_run: bool = False,
+    dataset_size: Optional[int] = None,
 ):
     """Main evolution function — orchestrates the full optimization loop."""
 
@@ -53,19 +69,24 @@ def evolve(
         judge_model=eval_model,  # Use same model for dataset generation
         run_pytest=run_tests,
     )
+    if dataset_size is not None:
+        config.eval_dataset_size = dataset_size
     if hermes_repo:
         config.hermes_agent_path = Path(hermes_repo)
+    enforce_legacy_backend_guard(config.lm_api_base)
+
+    hermes_path = config.resolve_hermes_agent_path()
 
     # ── 1. Find and load the skill ──────────────────────────────────────
     console.print(f"\n[bold cyan]🧬 Hermes Agent Self-Evolution[/bold cyan] — Evolving skill: [bold]{skill_name}[/bold]\n")
 
-    skill_path = find_skill(skill_name, config.hermes_agent_path)
+    skill_path = find_skill(skill_name, hermes_path)
     if not skill_path:
-        console.print(f"[red]✗ Skill '{skill_name}' not found in {config.hermes_agent_path / 'skills'}[/red]")
+        console.print(f"[red]✗ Skill '{skill_name}' not found in {hermes_path / 'skills'}[/red]")
         sys.exit(1)
 
     skill = load_skill(skill_path)
-    console.print(f"  Loaded: {skill_path.relative_to(config.hermes_agent_path)}")
+    console.print(f"  Loaded: {skill_path.relative_to(hermes_path)}")
     console.print(f"  Name: {skill['name']}")
     console.print(f"  Size: {len(skill['raw']):,} chars")
     console.print(f"  Description: {skill['description'][:80]}...")
@@ -119,7 +140,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -138,7 +159,7 @@ def evolve(
     console.print(f"  Eval model: {eval_model}")
 
     # Configure DSPy
-    lm = dspy.LM(eval_model)
+    lm = build_lm(eval_model, config)
     dspy.configure(lm=lm)
 
     # Create the baseline skill module
@@ -186,7 +207,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"
@@ -304,7 +325,8 @@ def evolve(
 @click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
 @click.option("--run-tests", is_flag=True, help="Run full pytest suite as constraint gate")
 @click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")
-def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run):
+@click.option("--dataset-size", default=None, type=int, help="Override number of generated evaluation cases")
+def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run, dataset_size):
     """Evolve a Hermes Agent skill using DSPy + GEPA optimization."""
     evolve(
         skill_name=skill,
@@ -316,6 +338,7 @@ def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_mod
         hermes_repo=hermes_repo,
         run_tests=run_tests,
         dry_run=dry_run,
+        dataset_size=dataset_size,
     )
 
 

--- a/evolution/skills/evolve_skill_codex.py
+++ b/evolution/skills/evolve_skill_codex.py
@@ -1,0 +1,158 @@
+"""Codex-batched self-evolution entrypoint.
+
+This module is intentionally additive and keeps the legacy DSPy path untouched.
+It provides a bounded orchestration path with explicit guardrails, cached dataset
+loading, and a small number of Codex subprocess phases.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import json
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+from evolution.core.budget import RunBudget
+from evolution.core.cached_dataset import load_or_create_dataset
+from evolution.core.codex_protocol import build_evaluation_prompt, build_mutation_prompt
+from evolution.core.codex_runner import CodexRunner
+from evolution.core.codex_schema import parse_evaluation_result, parse_mutation_result
+from evolution.core.config import EvolutionConfig
+from evolution.core.constraints import ConstraintValidator
+from evolution.skills.skill_module import find_skill, load_skill
+
+console = Console()
+
+
+def _build_config(iterations: int, hermes_repo: str | None) -> EvolutionConfig:
+    config = EvolutionConfig(iterations=iterations)
+    if hermes_repo:
+        config.hermes_agent_path = Path(hermes_repo)
+        config.output_dir = Path(hermes_repo) / "output"
+    return config
+
+
+def _load_dataset(dataset_path: str | None, *, allow_live_generation: bool):
+    if not dataset_path:
+        raise click.ClickException("cached eval-source requires --dataset-path")
+    return load_or_create_dataset(
+        Path(dataset_path),
+        creator=lambda: (_ for _ in ()).throw(RuntimeError("live dataset generation not implemented yet")),
+        allow_live_generation=allow_live_generation,
+    )
+
+
+def _save_run_artifacts(config: EvolutionConfig, skill_name: str, baseline_skill: str, candidate_skill: str, metrics: dict) -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = config.output_dir / skill_name / timestamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "baseline_skill.md").write_text(baseline_skill)
+    (output_dir / "evolved_skill.md").write_text(candidate_skill)
+    (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+    return output_dir
+
+
+@click.command()
+@click.option("--skill", required=True, help="Name of the skill to evolve")
+@click.option("--eval-source", default="cached", type=click.Choice(["cached", "synthetic"]), help="Dataset source for codex-batched evolution")
+@click.option("--dataset-path", default=None, help="Path to cached evaluation dataset")
+@click.option("--iterations", default=1, type=int, help="Number of mutation iterations")
+@click.option("--dry-run", is_flag=True, help="Validate configuration and guardrails without running Codex")
+@click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
+def main(skill: str, eval_source: str, dataset_path: str | None, iterations: int, dry_run: bool, hermes_repo: str | None):
+    """Run the new codex-batched self-evolution workflow."""
+    if iterations != 1:
+        raise click.ClickException("codex-batched path currently supports only iterations=1 until the multi-iteration loop exists")
+
+    if eval_source == "synthetic":
+        raise click.ClickException("synthetic eval-source is not implemented in the codex-batched path yet")
+
+    config = _build_config(iterations=iterations, hermes_repo=hermes_repo)
+
+    dataset, _created = _load_dataset(
+        dataset_path,
+        allow_live_generation=False,
+    )
+
+    if dry_run:
+        console.print("[bold green]DRY RUN[/bold green] — codex-batched guardrails validated.")
+        console.print(f"skill={skill}")
+        console.print(f"eval_source={eval_source}")
+        console.print(f"iterations={iterations}")
+        return
+
+    hermes_path = config.resolve_hermes_agent_path()
+    skill_path = find_skill(skill, hermes_path)
+    if not skill_path:
+        raise click.ClickException(f"Skill '{skill}' not found in {hermes_path / 'skills'}")
+    loaded_skill = load_skill(skill_path)
+
+    budget = RunBudget(
+        max_codex_calls=config.max_codex_calls,
+        max_run_seconds=config.max_run_seconds,
+        phase_timeout_seconds=config.phase_timeout_seconds,
+        max_examples=config.max_examples,
+        max_iterations=config.iterations,
+        max_candidates_per_iteration=config.max_candidates_per_iteration,
+        budget_strict=config.budget_strict,
+    )
+    budget.start_run()
+    runner = CodexRunner(workdir=hermes_path, codex_bin=config.codex_bin)
+
+    budget.register_call("mutation")
+    try:
+        mutation_payload = runner.run_json_task(
+            build_mutation_prompt(skill, loaded_skill["raw"], iterations),
+            timeout_seconds=config.phase_timeout_seconds,
+        )
+        mutation_result = parse_mutation_result(mutation_payload)
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    candidate_skill = mutation_result.candidate_skill_markdown
+
+    validator = ConstraintValidator(config)
+    results = validator.validate_all(candidate_skill, "skill", baseline_text=loaded_skill["raw"])
+    if not all(result.passed for result in results):
+        problems = "; ".join(result.message for result in results if not result.passed)
+        raise click.ClickException(f"Candidate failed constraints: {problems}")
+
+    holdout_examples = [example.to_dict() for example in dataset.holdout]
+    budget.register_call("evaluation")
+    try:
+        evaluation_payload = runner.run_json_task(
+            build_evaluation_prompt(skill, loaded_skill["raw"], candidate_skill, holdout_examples),
+            timeout_seconds=config.phase_timeout_seconds,
+        )
+        evaluation_result = parse_evaluation_result(evaluation_payload)
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    metrics = {
+        "skill_name": skill,
+        "iterations": iterations,
+        "baseline_score": evaluation_result.baseline_score,
+        "candidate_score": evaluation_result.candidate_score,
+        "improvement": evaluation_result.improvement,
+        "per_example": evaluation_result.per_example,
+        "recommendation": evaluation_result.recommendation.to_dict(),
+        "prompt_version": "v1",
+        "calls_used": budget.calls_used,
+        "holdout_examples": len(dataset.holdout),
+        "budget": {
+            "max_codex_calls": budget.max_codex_calls,
+            "phase_timeout_seconds": budget.phase_timeout_seconds,
+            "max_run_seconds": budget.max_run_seconds,
+            "max_examples": budget.max_examples,
+            "max_iterations": budget.max_iterations,
+            "max_candidates_per_iteration": budget.max_candidates_per_iteration,
+            "budget_strict": budget.budget_strict,
+        },
+    }
+    output_dir = _save_run_artifacts(config, skill, loaded_skill["raw"], candidate_skill, metrics)
+    console.print(f"Output saved to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/evolution/skills/evolve_skill_codex.py
+++ b/evolution/skills/evolve_skill_codex.py
@@ -1,9 +1,4 @@
-"""Codex-batched self-evolution entrypoint.
-
-This module is intentionally additive and keeps the legacy DSPy path untouched.
-It provides a bounded orchestration path with explicit guardrails, cached dataset
-loading, and a small number of Codex subprocess phases.
-"""
+"""Codex-batched self-evolution entrypoint."""
 
 from __future__ import annotations
 
@@ -18,10 +13,10 @@ from evolution.core.budget import RunBudget
 from evolution.core.cached_dataset import load_or_create_dataset
 from evolution.core.codex_protocol import build_evaluation_prompt, build_mutation_prompt
 from evolution.core.codex_runner import CodexRunner
-from evolution.core.codex_schema import parse_evaluation_result, parse_mutation_result
+from evolution.core.codex_schema import EvaluationResult, parse_evaluation_result, parse_mutation_result
 from evolution.core.config import EvolutionConfig
 from evolution.core.constraints import ConstraintValidator
-from evolution.skills.skill_module import find_skill, load_skill
+from evolution.skills.skill_io import find_skill, load_skill
 
 console = Console()
 
@@ -44,6 +39,26 @@ def _load_dataset(dataset_path: str | None, *, allow_live_generation: bool):
     )
 
 
+def _select_holdout_examples(dataset, max_examples: int) -> list[dict]:
+    if max_examples < 1:
+        raise click.ClickException("HERMES_EVOLUTION_MAX_EXAMPLES must be at least 1")
+    return [example.to_dict() for example in dataset.holdout[:max_examples]]
+
+
+def _ensure_candidate_is_accepted(evaluation_result: EvaluationResult) -> None:
+    if evaluation_result.recommendation.winner != "candidate":
+        raise click.ClickException(
+            "Candidate rejected by evaluation: "
+            f"winner={evaluation_result.recommendation.winner}; "
+            f"reason={evaluation_result.recommendation.reason}"
+        )
+    if evaluation_result.improvement <= 0:
+        raise click.ClickException(
+            "Candidate rejected by evaluation: "
+            f"improvement must be > 0, got {evaluation_result.improvement}"
+        )
+
+
 def _save_run_artifacts(config: EvolutionConfig, skill_name: str, baseline_skill: str, candidate_skill: str, metrics: dict) -> Path:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     output_dir = config.output_dir / skill_name / timestamp
@@ -56,7 +71,7 @@ def _save_run_artifacts(config: EvolutionConfig, skill_name: str, baseline_skill
 
 @click.command()
 @click.option("--skill", required=True, help="Name of the skill to evolve")
-@click.option("--eval-source", default="cached", type=click.Choice(["cached", "synthetic"]), help="Dataset source for codex-batched evolution")
+@click.option("--eval-source", default="cached", type=click.Choice(["cached"]), help="Dataset source for codex-batched evolution")
 @click.option("--dataset-path", default=None, help="Path to cached evaluation dataset")
 @click.option("--iterations", default=1, type=int, help="Number of mutation iterations")
 @click.option("--dry-run", is_flag=True, help="Validate configuration and guardrails without running Codex")
@@ -65,9 +80,6 @@ def main(skill: str, eval_source: str, dataset_path: str | None, iterations: int
     """Run the new codex-batched self-evolution workflow."""
     if iterations != 1:
         raise click.ClickException("codex-batched path currently supports only iterations=1 until the multi-iteration loop exists")
-
-    if eval_source == "synthetic":
-        raise click.ClickException("synthetic eval-source is not implemented in the codex-batched path yet")
 
     config = _build_config(iterations=iterations, hermes_repo=hermes_repo)
 
@@ -95,8 +107,6 @@ def main(skill: str, eval_source: str, dataset_path: str | None, iterations: int
         phase_timeout_seconds=config.phase_timeout_seconds,
         max_examples=config.max_examples,
         max_iterations=config.iterations,
-        max_candidates_per_iteration=config.max_candidates_per_iteration,
-        budget_strict=config.budget_strict,
     )
     budget.start_run()
     runner = CodexRunner(workdir=hermes_path, codex_bin=config.codex_bin)
@@ -118,7 +128,7 @@ def main(skill: str, eval_source: str, dataset_path: str | None, iterations: int
         problems = "; ".join(result.message for result in results if not result.passed)
         raise click.ClickException(f"Candidate failed constraints: {problems}")
 
-    holdout_examples = [example.to_dict() for example in dataset.holdout]
+    holdout_examples = _select_holdout_examples(dataset, config.max_examples)
     budget.register_call("evaluation")
     try:
         evaluation_payload = runner.run_json_task(
@@ -128,6 +138,8 @@ def main(skill: str, eval_source: str, dataset_path: str | None, iterations: int
         evaluation_result = parse_evaluation_result(evaluation_payload)
     except Exception as exc:
         raise click.ClickException(str(exc)) from exc
+
+    _ensure_candidate_is_accepted(evaluation_result)
 
     metrics = {
         "skill_name": skill,
@@ -139,15 +151,13 @@ def main(skill: str, eval_source: str, dataset_path: str | None, iterations: int
         "recommendation": evaluation_result.recommendation.to_dict(),
         "prompt_version": "v1",
         "calls_used": budget.calls_used,
-        "holdout_examples": len(dataset.holdout),
+        "holdout_examples": len(holdout_examples),
         "budget": {
             "max_codex_calls": budget.max_codex_calls,
             "phase_timeout_seconds": budget.phase_timeout_seconds,
             "max_run_seconds": budget.max_run_seconds,
             "max_examples": budget.max_examples,
             "max_iterations": budget.max_iterations,
-            "max_candidates_per_iteration": budget.max_candidates_per_iteration,
-            "budget_strict": budget.budget_strict,
         },
     }
     output_dir = _save_run_artifacts(config, skill, loaded_skill["raw"], candidate_skill, metrics)

--- a/evolution/skills/skill_io.py
+++ b/evolution/skills/skill_io.py
@@ -1,0 +1,59 @@
+"""Lightweight skill file I/O helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+def load_skill(skill_path: Path) -> dict:
+    raw = skill_path.read_text()
+
+    frontmatter = ""
+    body = raw
+    if raw.strip().startswith("---"):
+        parts = raw.split("---", 2)
+        if len(parts) >= 3:
+            frontmatter = parts[1].strip()
+            body = parts[2].strip()
+
+    name = ""
+    description = ""
+    for line in frontmatter.split("\n"):
+        if line.strip().startswith("name:"):
+            name = line.split(":", 1)[1].strip().strip("'\"")
+        elif line.strip().startswith("description:"):
+            description = line.split(":", 1)[1].strip().strip("'\"")
+
+    return {
+        "path": skill_path,
+        "raw": raw,
+        "frontmatter": frontmatter,
+        "body": body,
+        "name": name,
+        "description": description,
+    }
+
+
+def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
+    skills_dir = hermes_agent_path / "skills"
+    if not skills_dir.exists():
+        return None
+
+    for skill_md in skills_dir.rglob("SKILL.md"):
+        if skill_md.parent.name == skill_name:
+            return skill_md
+
+    for skill_md in skills_dir.rglob("SKILL.md"):
+        try:
+            content = skill_md.read_text()[:500]
+            if f"name: {skill_name}" in content or f'name: "{skill_name}"' in content:
+                return skill_md
+        except Exception:
+            continue
+
+    return None
+
+
+def reassemble_skill(frontmatter: str, evolved_body: str) -> str:
+    return f"---\n{frontmatter}\n---\n\n{evolved_body}\n"

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -5,80 +5,9 @@ where the skill text is the optimizable parameter. GEPA can then
 mutate the skill text and evaluate the results.
 """
 
-import re
-from pathlib import Path
-from typing import Optional
-
 import dspy
 
-
-def load_skill(skill_path: Path) -> dict:
-    """Load a skill file and parse its frontmatter + body.
-
-    Returns:
-        {
-            "path": Path,
-            "raw": str (full file content),
-            "frontmatter": str (YAML between --- markers),
-            "body": str (markdown after frontmatter),
-            "name": str,
-            "description": str,
-        }
-    """
-    raw = skill_path.read_text()
-
-    # Parse YAML frontmatter
-    frontmatter = ""
-    body = raw
-    if raw.strip().startswith("---"):
-        parts = raw.split("---", 2)
-        if len(parts) >= 3:
-            frontmatter = parts[1].strip()
-            body = parts[2].strip()
-
-    # Extract name and description from frontmatter
-    name = ""
-    description = ""
-    for line in frontmatter.split("\n"):
-        if line.strip().startswith("name:"):
-            name = line.split(":", 1)[1].strip().strip("'\"")
-        elif line.strip().startswith("description:"):
-            description = line.split(":", 1)[1].strip().strip("'\"")
-
-    return {
-        "path": skill_path,
-        "raw": raw,
-        "frontmatter": frontmatter,
-        "body": body,
-        "name": name,
-        "description": description,
-    }
-
-
-def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
-    """Find a skill by name in the hermes-agent skills directory.
-
-    Searches recursively for a SKILL.md in a directory matching the skill name.
-    """
-    skills_dir = hermes_agent_path / "skills"
-    if not skills_dir.exists():
-        return None
-
-    # Direct match: skills/<category>/<skill_name>/SKILL.md
-    for skill_md in skills_dir.rglob("SKILL.md"):
-        if skill_md.parent.name == skill_name:
-            return skill_md
-
-    # Fuzzy match: check the name field in frontmatter
-    for skill_md in skills_dir.rglob("SKILL.md"):
-        try:
-            content = skill_md.read_text()[:500]
-            if f"name: {skill_name}" in content or f'name: "{skill_name}"' in content:
-                return skill_md
-        except Exception:
-            continue
-
-    return None
+from evolution.skills.skill_io import find_skill, load_skill, reassemble_skill
 
 
 class SkillModule(dspy.Module):
@@ -113,11 +42,3 @@ class SkillModule(dspy.Module):
         )
         return dspy.Prediction(output=result.output)
 
-
-def reassemble_skill(frontmatter: str, evolved_body: str) -> str:
-    """Reassemble a skill file from frontmatter and evolved body.
-
-    Preserves the original YAML frontmatter (name, description, metadata)
-    and replaces only the body with the evolved version.
-    """
-    return f"---\n{frontmatter}\n---\n\n{evolved_body}\n"

--- a/tests/core/test_budget.py
+++ b/tests/core/test_budget.py
@@ -1,0 +1,58 @@
+"""Tests for hard run-budget enforcement in codex-batched evolution."""
+
+import time
+
+from evolution.core.budget import BudgetExceeded, RunBudget
+
+
+class TestRunBudget:
+    def test_budget_blocks_when_call_limit_reached(self):
+        budget = RunBudget(
+            max_codex_calls=2,
+            max_run_seconds=600,
+            phase_timeout_seconds=120,
+        )
+        budget.start_run()
+        budget.register_call("dataset")
+        budget.register_call("mutation")
+
+        assert budget.calls_used == 2
+        assert budget.remaining_calls() == 0
+        assert budget.can_start_phase("evaluation") is False
+
+    def test_budget_blocks_when_wall_clock_exceeded(self):
+        budget = RunBudget(
+            max_codex_calls=3,
+            max_run_seconds=0,
+            phase_timeout_seconds=120,
+        )
+        budget.start_run()
+        time.sleep(0.01)
+
+        assert budget.can_start_phase("mutation") is False
+
+    def test_budget_enforce_or_raise_raises_when_limit_hit(self):
+        budget = RunBudget(
+            max_codex_calls=1,
+            max_run_seconds=600,
+            phase_timeout_seconds=120,
+        )
+        budget.start_run()
+        budget.register_call("dataset")
+
+        try:
+            budget.enforce_or_raise("mutation")
+        except BudgetExceeded as exc:
+            assert "mutation" in str(exc)
+        else:
+            raise AssertionError("BudgetExceeded was not raised")
+
+    def test_budget_blocks_phase_when_remaining_time_is_below_phase_timeout(self):
+        budget = RunBudget(
+            max_codex_calls=3,
+            max_run_seconds=1,
+            phase_timeout_seconds=10,
+        )
+        budget.start_run()
+
+        assert budget.can_start_phase("mutation") is False

--- a/tests/core/test_cached_dataset.py
+++ b/tests/core/test_cached_dataset.py
@@ -1,0 +1,57 @@
+"""Tests for cached dataset loading in codex-batched evolution."""
+
+import pytest
+
+from evolution.core.cached_dataset import load_or_create_dataset
+from evolution.core.dataset_builder import EvalDataset, EvalExample
+
+
+class TestLoadOrCreateDataset:
+    def test_load_or_create_dataset_prefers_existing_files(self, tmp_path):
+        dataset_dir = tmp_path / "datasets" / "skills" / "obsidian"
+        dataset_dir.mkdir(parents=True)
+        (dataset_dir / "train.jsonl").write_text('{"task_input":"a","expected_behavior":"b"}\n')
+        (dataset_dir / "val.jsonl").write_text('{"task_input":"a","expected_behavior":"b"}\n')
+        (dataset_dir / "holdout.jsonl").write_text('{"task_input":"a","expected_behavior":"b"}\n')
+
+        dataset, created = load_or_create_dataset(
+            dataset_dir,
+            creator=lambda: (_ for _ in ()).throw(AssertionError("creator should not be called")),
+            allow_live_generation=False,
+        )
+
+        assert created is False
+        assert isinstance(dataset, EvalDataset)
+        assert len(dataset.train) == 1
+        assert len(dataset.val) == 1
+        assert len(dataset.holdout) == 1
+
+    def test_load_or_create_dataset_refuses_generation_when_disabled(self, tmp_path):
+        dataset_dir = tmp_path / "datasets" / "skills" / "obsidian"
+
+        with pytest.raises(RuntimeError):
+            load_or_create_dataset(
+                dataset_dir,
+                creator=lambda: EvalDataset(),
+                allow_live_generation=False,
+            )
+
+    def test_load_or_create_dataset_creates_and_saves_when_allowed(self, tmp_path):
+        dataset_dir = tmp_path / "datasets" / "skills" / "obsidian"
+        generated = EvalDataset(
+            train=[EvalExample(task_input="a", expected_behavior="b")],
+            val=[EvalExample(task_input="c", expected_behavior="d")],
+            holdout=[EvalExample(task_input="e", expected_behavior="f")],
+        )
+
+        dataset, created = load_or_create_dataset(
+            dataset_dir,
+            creator=lambda: generated,
+            allow_live_generation=True,
+        )
+
+        assert created is True
+        assert dataset is generated
+        assert (dataset_dir / "train.jsonl").exists()
+        assert (dataset_dir / "val.jsonl").exists()
+        assert (dataset_dir / "holdout.jsonl").exists()

--- a/tests/core/test_cached_dataset.py
+++ b/tests/core/test_cached_dataset.py
@@ -3,7 +3,7 @@
 import pytest
 
 from evolution.core.cached_dataset import load_or_create_dataset
-from evolution.core.dataset_builder import EvalDataset, EvalExample
+from evolution.core.eval_dataset import EvalDataset, EvalExample
 
 
 class TestLoadOrCreateDataset:

--- a/tests/core/test_codex_protocol.py
+++ b/tests/core/test_codex_protocol.py
@@ -1,0 +1,37 @@
+"""Tests for codex-batched prompt/protocol builders."""
+
+from evolution.core.codex_protocol import build_evaluation_prompt, build_mutation_prompt
+
+
+class TestCodexProtocol:
+    def test_build_mutation_prompt_mentions_required_json_key(self):
+        prompt = build_mutation_prompt(
+            skill_name="obsidian",
+            baseline_skill="baseline text",
+            iterations=2,
+        )
+
+        assert "candidate_skill_markdown" in prompt
+        assert "obsidian" in prompt
+        assert "Iterations=2" in prompt
+        assert "minimal" in prompt.lower()
+        assert "20%" in prompt
+        assert "do not rewrite the whole skill" in prompt.lower()
+        assert "preserve structure" in prompt.lower()
+
+    def test_build_evaluation_prompt_mentions_required_json_keys(self):
+        prompt = build_evaluation_prompt(
+            skill_name="obsidian",
+            baseline_skill="baseline text",
+            candidate_skill="candidate text",
+            holdout_examples=[{"task_input": "a", "expected_behavior": "b"}],
+        )
+
+        assert "baseline_score" in prompt
+        assert "candidate_score" in prompt
+        assert "improvement" in prompt
+        assert "recommendation" in prompt
+        assert "winner" in prompt
+        assert "reason" in prompt
+        assert "confidence" in prompt
+        assert '"task_input": "a"' in prompt

--- a/tests/core/test_codex_runner.py
+++ b/tests/core/test_codex_runner.py
@@ -1,0 +1,71 @@
+"""Tests for the codex subprocess runner."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from evolution.core.codex_runner import (
+    CodexRunTimeout,
+    CodexRunner,
+    build_codex_command,
+)
+
+
+class TestBuildCodexCommand:
+    def test_build_codex_command_uses_stdin_prompt_mode(self, tmp_path):
+        cmd = build_codex_command(workdir=tmp_path)
+
+        assert cmd[:3] == ["codex", "exec", "-"]
+
+
+class TestCodexRunner:
+    def test_runner_raises_on_timeout(self, monkeypatch, tmp_path):
+        runner = CodexRunner(workdir=tmp_path)
+
+        def fake_run_subprocess(*args, **kwargs):
+            raise TimeoutError()
+
+        monkeypatch.setattr("evolution.core.codex_runner._run_subprocess", fake_run_subprocess)
+
+        with pytest.raises(CodexRunTimeout):
+            runner.run_json_task("Return JSON", timeout_seconds=1)
+
+    def test_runner_parses_json_stdout(self, monkeypatch, tmp_path):
+        runner = CodexRunner(workdir=tmp_path)
+
+        def fake_run_subprocess(*args, **kwargs):
+            return '{"ok": true, "value": 3}'
+
+        monkeypatch.setattr("evolution.core.codex_runner._run_subprocess", fake_run_subprocess)
+
+        result = runner.run_json_task("Return JSON", timeout_seconds=1)
+
+        assert result == {"ok": True, "value": 3}
+
+    def test_runner_rejects_non_json_stdout(self, monkeypatch, tmp_path):
+        runner = CodexRunner(workdir=tmp_path)
+
+        def fake_run_subprocess(*args, **kwargs):
+            return 'not-json'
+
+        monkeypatch.setattr("evolution.core.codex_runner._run_subprocess", fake_run_subprocess)
+
+        with pytest.raises(ValueError):
+            runner.run_json_task("Return JSON", timeout_seconds=1)
+
+    def test_runner_passes_prompt_via_stdin(self, monkeypatch, tmp_path):
+        runner = CodexRunner(workdir=tmp_path)
+        captured = {}
+
+        def fake_run_subprocess(command, workdir, timeout_seconds, prompt):
+            captured["command"] = command
+            captured["prompt"] = prompt
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr("evolution.core.codex_runner._run_subprocess", fake_run_subprocess)
+
+        runner.run_json_task("Return JSON", timeout_seconds=1)
+
+        assert captured["command"][:3] == ["codex", "exec", "-"]
+        assert captured["prompt"] == "Return JSON"

--- a/tests/core/test_codex_runner.py
+++ b/tests/core/test_codex_runner.py
@@ -14,7 +14,7 @@ from evolution.core.codex_runner import (
 
 class TestBuildCodexCommand:
     def test_build_codex_command_uses_stdin_prompt_mode(self, tmp_path):
-        cmd = build_codex_command(workdir=tmp_path)
+        cmd = build_codex_command()
 
         assert cmd[:3] == ["codex", "exec", "-"]
 

--- a/tests/core/test_codex_schema.py
+++ b/tests/core/test_codex_schema.py
@@ -1,0 +1,66 @@
+"""Tests for codex-batched result schema parsing."""
+
+import pytest
+
+from evolution.core.codex_schema import (
+    EvaluationResult,
+    MutationResult,
+    Recommendation,
+    parse_evaluation_result,
+    parse_mutation_result,
+)
+
+
+class TestMutationSchema:
+    def test_parse_mutation_result_accepts_valid_payload(self):
+        result = parse_mutation_result({
+            "candidate_skill_markdown": "---\nname: obsidian\ndescription: test\n---\n\nBody\n"
+        })
+
+        assert isinstance(result, MutationResult)
+        assert result.candidate_skill_markdown.startswith("---")
+
+    def test_parse_mutation_result_rejects_missing_key(self):
+        with pytest.raises(ValueError):
+            parse_mutation_result({"wrong": "value"})
+
+
+class TestEvaluationSchema:
+    def test_parse_evaluation_result_accepts_valid_payload(self):
+        result = parse_evaluation_result({
+            "baseline_score": 0.4,
+            "candidate_score": 0.6,
+            "improvement": 0.2,
+            "per_example": [],
+            "recommendation": {
+                "winner": "candidate",
+                "reason": "candidate is clearer",
+                "confidence": 0.81,
+            },
+        })
+
+        assert isinstance(result, EvaluationResult)
+        assert result.baseline_score == 0.4
+        assert result.candidate_score == 0.6
+        assert result.improvement == 0.2
+        assert isinstance(result.recommendation, Recommendation)
+        assert result.recommendation.winner == "candidate"
+        assert result.recommendation.reason == "candidate is clearer"
+        assert result.recommendation.confidence == 0.81
+
+    def test_parse_evaluation_result_rejects_missing_keys(self):
+        with pytest.raises(ValueError):
+            parse_evaluation_result({
+                "baseline_score": 0.4,
+                "candidate_score": 0.6,
+            })
+
+    def test_parse_evaluation_result_rejects_incomplete_recommendation(self):
+        with pytest.raises(ValueError):
+            parse_evaluation_result({
+                "baseline_score": 0.4,
+                "candidate_score": 0.6,
+                "improvement": 0.2,
+                "per_example": [],
+                "recommendation": {"winner": "candidate"},
+            })

--- a/tests/core/test_codex_schema.py
+++ b/tests/core/test_codex_schema.py
@@ -64,3 +64,33 @@ class TestEvaluationSchema:
                 "per_example": [],
                 "recommendation": {"winner": "candidate"},
             })
+
+    def test_parse_evaluation_result_accepts_qualitative_confidence(self):
+        result = parse_evaluation_result({
+            "baseline_score": 0.4,
+            "candidate_score": 0.6,
+            "improvement": 0.2,
+            "per_example": [],
+            "recommendation": {
+                "winner": "candidate",
+                "reason": "candidate is clearer",
+                "confidence": "high",
+            },
+        })
+
+        assert result.recommendation.confidence == 0.9
+
+    def test_parse_evaluation_result_accepts_percentage_confidence(self):
+        result = parse_evaluation_result({
+            "baseline_score": 0.4,
+            "candidate_score": 0.6,
+            "improvement": 0.2,
+            "per_example": [],
+            "recommendation": {
+                "winner": "candidate",
+                "reason": "candidate is clearer",
+                "confidence": "78%",
+            },
+        })
+
+        assert result.recommendation.confidence == 0.78

--- a/tests/core/test_lm.py
+++ b/tests/core/test_lm.py
@@ -1,0 +1,73 @@
+"""Tests for centralized DSPy LM construction and additive codex-batch config."""
+
+from evolution.core.config import EvolutionConfig
+from evolution.core.lm import build_lm
+
+
+class TestBuildLm:
+    def test_build_lm_passes_openai_compatible_overrides(self, monkeypatch):
+        captured = {}
+
+        def fake_lm(model, **kwargs):
+            captured["model"] = model
+            captured["kwargs"] = kwargs
+            return {"model": model, "kwargs": kwargs}
+
+        monkeypatch.setattr("evolution.core.lm.dspy.LM", fake_lm)
+        config = EvolutionConfig(
+            lm_api_base="http://127.0.0.1:8642/v1",
+            lm_api_key="dummy",
+            lm_timeout_seconds=42,
+        )
+
+        result = build_lm("openai/hermes-agent", config)
+
+        assert result["model"] == "openai/hermes-agent"
+        assert captured["kwargs"]["api_base"] == "http://127.0.0.1:8642/v1"
+        assert captured["kwargs"]["api_key"] == "dummy"
+        assert captured["kwargs"]["timeout"] == 42
+        assert captured["kwargs"]["model_type"] == "chat"
+
+    def test_build_lm_omits_empty_backend_overrides(self, monkeypatch):
+        captured = {}
+
+        def fake_lm(model, **kwargs):
+            captured["kwargs"] = kwargs
+            return object()
+
+        monkeypatch.setattr("evolution.core.lm.dspy.LM", fake_lm)
+        config = EvolutionConfig(lm_api_base="", lm_api_key="", lm_timeout_seconds=30)
+
+        build_lm("openai/gpt-4.1", config)
+
+        assert "api_base" not in captured["kwargs"]
+        assert "api_key" not in captured["kwargs"]
+        assert captured["kwargs"]["timeout"] == 30
+
+
+class TestCodexBatchConfig:
+    def test_config_exposes_safe_codex_batch_defaults(self):
+        config = EvolutionConfig()
+
+        assert config.execution_backend == "codex-batch"
+        assert config.allow_live_model is False
+        assert config.max_codex_calls == 3
+        assert config.max_examples == 8
+        assert config.phase_timeout_seconds == 180
+        assert config.max_run_seconds == 600
+        assert config.max_candidates_per_iteration == 1
+        assert config.budget_strict is True
+        assert config.codex_bin == "codex"
+
+    def test_config_reads_codex_batch_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EVOLUTION_ALLOW_LIVE_MODEL", "1")
+        monkeypatch.setenv("HERMES_EVOLUTION_MAX_CODEX_CALLS", "7")
+        monkeypatch.setenv("HERMES_EVOLUTION_PHASE_TIMEOUT_SECONDS", "55")
+        monkeypatch.setenv("HERMES_EVOLUTION_MAX_RUN_SECONDS", "999")
+
+        config = EvolutionConfig()
+
+        assert config.allow_live_model is True
+        assert config.max_codex_calls == 7
+        assert config.phase_timeout_seconds == 55
+        assert config.max_run_seconds == 999

--- a/tests/core/test_lm.py
+++ b/tests/core/test_lm.py
@@ -49,25 +49,21 @@ class TestCodexBatchConfig:
     def test_config_exposes_safe_codex_batch_defaults(self):
         config = EvolutionConfig()
 
-        assert config.execution_backend == "codex-batch"
-        assert config.allow_live_model is False
         assert config.max_codex_calls == 3
         assert config.max_examples == 8
         assert config.phase_timeout_seconds == 180
         assert config.max_run_seconds == 600
-        assert config.max_candidates_per_iteration == 1
-        assert config.budget_strict is True
         assert config.codex_bin == "codex"
 
     def test_config_reads_codex_batch_env_overrides(self, monkeypatch):
-        monkeypatch.setenv("HERMES_EVOLUTION_ALLOW_LIVE_MODEL", "1")
         monkeypatch.setenv("HERMES_EVOLUTION_MAX_CODEX_CALLS", "7")
+        monkeypatch.setenv("HERMES_EVOLUTION_MAX_EXAMPLES", "5")
         monkeypatch.setenv("HERMES_EVOLUTION_PHASE_TIMEOUT_SECONDS", "55")
         monkeypatch.setenv("HERMES_EVOLUTION_MAX_RUN_SECONDS", "999")
 
         config = EvolutionConfig()
 
-        assert config.allow_live_model is True
         assert config.max_codex_calls == 7
+        assert config.max_examples == 5
         assert config.phase_timeout_seconds == 55
         assert config.max_run_seconds == 999

--- a/tests/skills/test_evolve_skill_codex.py
+++ b/tests/skills/test_evolve_skill_codex.py
@@ -1,0 +1,222 @@
+"""Tests for the codex-batched evolution CLI entrypoint."""
+
+import json
+
+from click.testing import CliRunner
+
+from evolution.skills.evolve_skill_codex import main
+
+
+class TestCodexEntrypoint:
+    def test_cli_rejects_live_generation_without_allow_flag(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "--skill", "obsidian",
+            "--eval-source", "synthetic",
+            "--iterations", "1",
+            "--hermes-repo", str(tmp_path),
+        ])
+
+        assert result.exit_code != 0
+        assert "not implemented" in result.output.lower()
+
+    def test_cli_requires_dataset_path_for_cached_mode(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "--skill", "obsidian",
+            "--eval-source", "cached",
+            "--iterations", "1",
+            "--hermes-repo", str(tmp_path),
+        ])
+
+        assert result.exit_code != 0
+        assert "dataset-path" in result.output
+
+    def test_cli_dry_run_succeeds_with_cached_dataset_path(self, tmp_path):
+        runner = CliRunner()
+        dataset_dir = tmp_path / "datasets" / "skills" / "obsidian"
+        dataset_dir.mkdir(parents=True)
+        (dataset_dir / "train.jsonl").write_text('{"task_input":"a","expected_behavior":"b"}\n')
+        (dataset_dir / "val.jsonl").write_text('{"task_input":"a","expected_behavior":"b"}\n')
+        (dataset_dir / "holdout.jsonl").write_text('{"task_input":"a","expected_behavior":"b"}\n')
+
+        result = runner.invoke(main, [
+            "--skill", "obsidian",
+            "--eval-source", "cached",
+            "--dataset-path", str(dataset_dir),
+            "--iterations", "1",
+            "--dry-run",
+            "--hermes-repo", str(tmp_path),
+        ])
+
+        assert result.exit_code == 0
+        assert "DRY RUN" in result.output
+
+    def test_cli_non_dry_run_writes_artifacts_with_mocked_dependencies(self, monkeypatch, tmp_path):
+        runner = CliRunner()
+        dataset_dir = tmp_path / "datasets" / "skills" / "obsidian"
+        dataset_dir.mkdir(parents=True)
+        sample = '{"task_input":"a","expected_behavior":"b"}\n'
+        (dataset_dir / "train.jsonl").write_text(sample)
+        (dataset_dir / "val.jsonl").write_text(sample)
+        (dataset_dir / "holdout.jsonl").write_text(sample)
+
+        skills_dir = tmp_path / "skills" / "note-taking" / "obsidian"
+        skills_dir.mkdir(parents=True)
+        skill_path = skills_dir / "SKILL.md"
+        skill_path.write_text(
+            "---\nname: obsidian\ndescription: test skill\n---\n\nOriginal body\n"
+        )
+
+        monkeypatch.setattr(
+            "evolution.skills.evolve_skill_codex.CodexRunner.run_json_task",
+            lambda self, prompt, timeout_seconds: (
+                {"candidate_skill_markdown": "---\nname: obsidian\ndescription: test skill\n---\n\nImproved body\n"}
+                if "mutation" in prompt.lower()
+                else {
+                    "baseline_score": 0.4,
+                    "candidate_score": 0.6,
+                    "improvement": 0.2,
+                    "per_example": [{"task_input": "a", "baseline_score": 0.4, "candidate_score": 0.6, "reason": "clearer"}],
+                    "recommendation": {
+                        "winner": "candidate",
+                        "reason": "candidate is clearer",
+                        "confidence": 0.81,
+                    },
+                }
+            ),
+        )
+
+        result = runner.invoke(main, [
+            "--skill", "obsidian",
+            "--eval-source", "cached",
+            "--dataset-path", str(dataset_dir),
+            "--iterations", "1",
+            "--hermes-repo", str(tmp_path),
+        ])
+
+        assert result.exit_code == 0, result.output
+        assert "Output saved to" in result.output
+
+        output_root = tmp_path / "output" / "obsidian"
+        runs = list(output_root.iterdir())
+        assert len(runs) == 1
+        run_dir = runs[0]
+
+        assert (run_dir / "baseline_skill.md").exists()
+        assert (run_dir / "evolved_skill.md").exists()
+        assert (run_dir / "metrics.json").exists()
+
+        metrics = json.loads((run_dir / "metrics.json").read_text())
+        assert metrics["baseline_score"] == 0.4
+        assert metrics["candidate_score"] == 0.6
+        assert metrics["improvement"] == 0.2
+        assert metrics["per_example"][0]["reason"] == "clearer"
+        assert metrics["recommendation"]["winner"] == "candidate"
+        assert metrics["recommendation"]["reason"] == "candidate is clearer"
+        assert metrics["recommendation"]["confidence"] == 0.81
+        assert metrics["prompt_version"] == "v1"
+        assert metrics["budget"]["max_codex_calls"] == 3
+        assert metrics["budget"]["phase_timeout_seconds"] == 180
+
+    def test_cli_rejects_iterations_above_one_until_loop_exists(self, tmp_path):
+        runner = CliRunner()
+        dataset_dir = tmp_path / "datasets" / "skills" / "obsidian"
+        dataset_dir.mkdir(parents=True)
+        sample = '{"task_input":"a","expected_behavior":"b"}\n'
+        (dataset_dir / "train.jsonl").write_text(sample)
+        (dataset_dir / "val.jsonl").write_text(sample)
+        (dataset_dir / "holdout.jsonl").write_text(sample)
+
+        result = runner.invoke(main, [
+            "--skill", "obsidian",
+            "--eval-source", "cached",
+            "--dataset-path", str(dataset_dir),
+            "--iterations", "2",
+            "--dry-run",
+            "--hermes-repo", str(tmp_path),
+        ])
+
+        assert result.exit_code != 0
+        assert "iterations=1" in result.output.lower()
+
+    def test_cli_reports_missing_skill_cleanly(self, tmp_path):
+        runner = CliRunner()
+        dataset_dir = tmp_path / "datasets" / "skills" / "obsidian"
+        dataset_dir.mkdir(parents=True)
+        sample = '{"task_input":"a","expected_behavior":"b"}\n'
+        (dataset_dir / "train.jsonl").write_text(sample)
+        (dataset_dir / "val.jsonl").write_text(sample)
+        (dataset_dir / "holdout.jsonl").write_text(sample)
+
+        result = runner.invoke(main, [
+            "--skill", "obsidian",
+            "--eval-source", "cached",
+            "--dataset-path", str(dataset_dir),
+            "--iterations", "1",
+            "--hermes-repo", str(tmp_path),
+        ])
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    def test_cli_reports_codex_timeout_cleanly(self, monkeypatch, tmp_path):
+        runner = CliRunner()
+        dataset_dir = tmp_path / "datasets" / "skills" / "obsidian"
+        dataset_dir.mkdir(parents=True)
+        sample = '{"task_input":"a","expected_behavior":"b"}\n'
+        (dataset_dir / "train.jsonl").write_text(sample)
+        (dataset_dir / "val.jsonl").write_text(sample)
+        (dataset_dir / "holdout.jsonl").write_text(sample)
+
+        skills_dir = tmp_path / "skills" / "note-taking" / "obsidian"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("---\nname: obsidian\ndescription: test skill\n---\n\nOriginal body\n")
+
+        def fake_run_json_task(self, prompt, timeout_seconds):
+            raise RuntimeError("Codex timed out after 180s")
+
+        monkeypatch.setattr(
+            "evolution.skills.evolve_skill_codex.CodexRunner.run_json_task",
+            fake_run_json_task,
+        )
+
+        result = runner.invoke(main, [
+            "--skill", "obsidian",
+            "--eval-source", "cached",
+            "--dataset-path", str(dataset_dir),
+            "--iterations", "1",
+            "--hermes-repo", str(tmp_path),
+        ])
+
+        assert result.exit_code != 0
+        assert "Codex timed out" in result.output
+
+    def test_cli_reports_constraint_failure_cleanly(self, monkeypatch, tmp_path):
+        runner = CliRunner()
+        dataset_dir = tmp_path / "datasets" / "skills" / "obsidian"
+        dataset_dir.mkdir(parents=True)
+        sample = '{"task_input":"a","expected_behavior":"b"}\n'
+        (dataset_dir / "train.jsonl").write_text(sample)
+        (dataset_dir / "val.jsonl").write_text(sample)
+        (dataset_dir / "holdout.jsonl").write_text(sample)
+
+        skills_dir = tmp_path / "skills" / "note-taking" / "obsidian"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("---\nname: obsidian\ndescription: test skill\n---\n\nOriginal body\n")
+
+        monkeypatch.setattr(
+            "evolution.skills.evolve_skill_codex.CodexRunner.run_json_task",
+            lambda self, prompt, timeout_seconds: {"candidate_skill_markdown": "broken"},
+        )
+
+        result = runner.invoke(main, [
+            "--skill", "obsidian",
+            "--eval-source", "cached",
+            "--dataset-path", str(dataset_dir),
+            "--iterations", "1",
+            "--hermes-repo", str(tmp_path),
+        ])
+
+        assert result.exit_code != 0
+        assert "failed constraints" in result.output.lower()

--- a/tests/skills/test_evolve_skill_codex.py
+++ b/tests/skills/test_evolve_skill_codex.py
@@ -1,6 +1,10 @@
 """Tests for the codex-batched evolution CLI entrypoint."""
 
 import json
+import os
+import subprocess
+from pathlib import Path
+import sys
 
 from click.testing import CliRunner
 
@@ -8,7 +12,31 @@ from evolution.skills.evolve_skill_codex import main
 
 
 class TestCodexEntrypoint:
-    def test_cli_rejects_live_generation_without_allow_flag(self, tmp_path):
+    def test_codex_entrypoint_imports_without_dspy_in_base_python(self, tmp_path):
+        base_python = Path(sys.base_prefix) / "bin" / "python3"
+        if not base_python.exists():
+            raise AssertionError(f"Base interpreter not found: {base_python}")
+
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(Path.cwd())
+
+        result = subprocess.run(
+            [
+                str(base_python),
+                "-c",
+                "import evolution.skills.evolve_skill_codex as m; print(m.__name__)",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=Path.cwd(),
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "evolution.skills.evolve_skill_codex"
+
+    def test_cli_rejects_unsupported_eval_source_at_parse_time(self, tmp_path):
         runner = CliRunner()
         result = runner.invoke(main, [
             "--skill", "obsidian",
@@ -18,7 +46,8 @@ class TestCodexEntrypoint:
         ])
 
         assert result.exit_code != 0
-        assert "not implemented" in result.output.lower()
+        assert "invalid value" in result.output.lower()
+        assert "cached" in result.output.lower()
 
     def test_cli_requires_dataset_path_for_cached_mode(self, tmp_path):
         runner = CliRunner()
@@ -118,6 +147,9 @@ class TestCodexEntrypoint:
         assert metrics["prompt_version"] == "v1"
         assert metrics["budget"]["max_codex_calls"] == 3
         assert metrics["budget"]["phase_timeout_seconds"] == 180
+        assert metrics["budget"]["max_examples"] == 8
+        assert "budget_strict" not in metrics["budget"]
+        assert "max_candidates_per_iteration" not in metrics["budget"]
 
     def test_cli_rejects_iterations_above_one_until_loop_exists(self, tmp_path):
         runner = CliRunner()
@@ -220,3 +252,102 @@ class TestCodexEntrypoint:
 
         assert result.exit_code != 0
         assert "failed constraints" in result.output.lower()
+
+    def test_cli_rejects_candidate_when_evaluation_prefers_baseline(self, monkeypatch, tmp_path):
+        runner = CliRunner()
+        dataset_dir = tmp_path / "datasets" / "skills" / "obsidian"
+        dataset_dir.mkdir(parents=True)
+        sample = '{"task_input":"a","expected_behavior":"b"}\n'
+        (dataset_dir / "train.jsonl").write_text(sample)
+        (dataset_dir / "val.jsonl").write_text(sample)
+        (dataset_dir / "holdout.jsonl").write_text(sample)
+
+        skills_dir = tmp_path / "skills" / "note-taking" / "obsidian"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("---\nname: obsidian\ndescription: test skill\n---\n\nOriginal body\n")
+
+        monkeypatch.setattr(
+            "evolution.skills.evolve_skill_codex.CodexRunner.run_json_task",
+            lambda self, prompt, timeout_seconds: (
+                {"candidate_skill_markdown": "---\nname: obsidian\ndescription: test skill\n---\n\nImproved body\n"}
+                if "mutation" in prompt.lower()
+                else {
+                    "baseline_score": 0.7,
+                    "candidate_score": 0.6,
+                    "improvement": -0.1,
+                    "per_example": [{"task_input": "a", "baseline_score": 0.7, "candidate_score": 0.6, "reason": "baseline clearer"}],
+                    "recommendation": {
+                        "winner": "baseline",
+                        "reason": "candidate regressed",
+                        "confidence": 0.82,
+                    },
+                }
+            ),
+        )
+
+        result = runner.invoke(main, [
+            "--skill", "obsidian",
+            "--eval-source", "cached",
+            "--dataset-path", str(dataset_dir),
+            "--iterations", "1",
+            "--hermes-repo", str(tmp_path),
+        ])
+
+        assert result.exit_code != 0
+        assert "rejected" in result.output.lower()
+        output_root = tmp_path / "output" / "obsidian"
+        assert not output_root.exists()
+
+    def test_cli_limits_holdout_examples_to_configured_max_examples(self, monkeypatch, tmp_path):
+        runner = CliRunner()
+        dataset_dir = tmp_path / "datasets" / "skills" / "obsidian"
+        dataset_dir.mkdir(parents=True)
+        sample = '{"task_input":"a","expected_behavior":"b"}\n'
+        (dataset_dir / "train.jsonl").write_text(sample)
+        (dataset_dir / "val.jsonl").write_text(sample)
+        (dataset_dir / "holdout.jsonl").write_text(
+            "".join(
+                json.dumps({"task_input": f"task-{idx}", "expected_behavior": "b"}) + "\n"
+                for idx in range(3)
+            )
+        )
+
+        skills_dir = tmp_path / "skills" / "note-taking" / "obsidian"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("---\nname: obsidian\ndescription: test skill\n---\n\nOriginal body\n")
+
+        captured = {}
+
+        def fake_run_json_task(self, prompt, timeout_seconds):
+            if "mutation" in prompt.lower():
+                return {"candidate_skill_markdown": "---\nname: obsidian\ndescription: test skill\n---\n\nImproved body\n"}
+            holdout_json = prompt.split("Holdout: ", 1)[1]
+            captured["holdout"] = json.loads(holdout_json)
+            return {
+                "baseline_score": 0.4,
+                "candidate_score": 0.6,
+                "improvement": 0.2,
+                "per_example": [{"task_input": "a", "baseline_score": 0.4, "candidate_score": 0.6, "reason": "clearer"}],
+                "recommendation": {
+                    "winner": "candidate",
+                    "reason": "candidate is clearer",
+                    "confidence": 0.81,
+                },
+            }
+
+        monkeypatch.setenv("HERMES_EVOLUTION_MAX_EXAMPLES", "1")
+        monkeypatch.setattr(
+            "evolution.skills.evolve_skill_codex.CodexRunner.run_json_task",
+            fake_run_json_task,
+        )
+
+        result = runner.invoke(main, [
+            "--skill", "obsidian",
+            "--eval-source", "cached",
+            "--dataset-path", str(dataset_dir),
+            "--iterations", "1",
+            "--hermes-repo", str(tmp_path),
+        ])
+
+        assert result.exit_code == 0, result.output
+        assert len(captured["holdout"]) == 1

--- a/tests/skills/test_evolve_skill_legacy_guard.py
+++ b/tests/skills/test_evolve_skill_legacy_guard.py
@@ -1,0 +1,16 @@
+"""Tests for legacy DSPy path safety guards."""
+
+import pytest
+
+from evolution.skills.evolve_skill import enforce_legacy_backend_guard
+
+
+class TestLegacyBackendGuard:
+    def test_legacy_guard_blocks_local_hermes_api(self):
+        with pytest.raises(RuntimeError) as exc:
+            enforce_legacy_backend_guard("http://127.0.0.1:8642/v1")
+
+        assert "local Hermes API" in str(exc.value)
+
+    def test_legacy_guard_allows_empty_api_base(self):
+        enforce_legacy_backend_guard("")

--- a/tests/skills/test_skill_validation_regression.py
+++ b/tests/skills/test_skill_validation_regression.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from evolution.core.config import EvolutionConfig
 from evolution.core.constraints import ConstraintValidator
-from evolution.skills.skill_module import load_skill, reassemble_skill
+from evolution.skills.skill_io import load_skill, reassemble_skill
 
 
 def _write_test_skill(tmp_path: Path) -> Path:

--- a/tests/skills/test_skill_validation_regression.py
+++ b/tests/skills/test_skill_validation_regression.py
@@ -1,0 +1,41 @@
+"""Regression tests for skill validation using full SKILL.md text."""
+
+from pathlib import Path
+
+from evolution.core.config import EvolutionConfig
+from evolution.core.constraints import ConstraintValidator
+from evolution.skills.skill_module import load_skill, reassemble_skill
+
+
+def _write_test_skill(tmp_path: Path) -> Path:
+    skill_path = tmp_path / "SKILL.md"
+    skill_path.write_text(
+        "---\n"
+        "name: obsidian\n"
+        "description: Test skill\n"
+        "---\n\n"
+        "# Test Skill\n\n"
+        "Use this skill for testing.\n"
+    )
+    return skill_path
+
+
+def test_baseline_skill_raw_passes_structure_check(tmp_path):
+    validator = ConstraintValidator(EvolutionConfig())
+    skill = load_skill(_write_test_skill(tmp_path))
+
+    results = validator.validate_all(skill["raw"], "skill")
+
+    structure = [r for r in results if r.constraint_name == "skill_structure"][0]
+    assert structure.passed
+
+
+def test_reassembled_skill_passes_structure_check(tmp_path):
+    validator = ConstraintValidator(EvolutionConfig())
+    skill = load_skill(_write_test_skill(tmp_path))
+    evolved_full = reassemble_skill(skill["frontmatter"], skill["body"])
+
+    results = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
+
+    structure = [r for r in results if r.constraint_name == "skill_structure"][0]
+    assert structure.passed


### PR DESCRIPTION
## Summary
- add a bounded `evolve_skill_codex` workflow that uses explicit `codex exec` phases
- move prompt transport to stdin and validate structured JSON outputs
- add runtime/call budgeting plus cached dataset support
- keep the legacy DSPy path available, but hard-block it for the local Hermes API case
- add regression tests for budget enforcement, schema/protocol parsing, skill validation, and legacy guardrails

## Why
The legacy DSPy path can fan out into many hidden model calls when aimed at a local OpenAI-compatible provider. The codex-batched path makes model invocations explicit, bounded, and easier to reason about.

## What changed
### Refactor
- centralize LM construction in `evolution.core.lm`
- make Hermes repo path resolution optional/lazy until actually needed
- route existing LM callers through the shared builder

### Legacy-path safety fixes
- validate full `SKILL.md` content rather than only the body when checking constraints
- block the legacy DSPy evolution path when pointed at the local Hermes API

### Codex-batched MVP path
- add `evolution.skills.evolve_skill_codex`
- add explicit run budgeting for call count and runtime windows
- send Codex prompts via stdin instead of argv
- load cached datasets for evaluation
- parse/validate structured mutation and evaluation results
- write structured output artifacts and metrics

## Current limits / non-goals
- this is not a full replacement for the legacy optimizer
- the codex path currently supports cached datasets only
- the codex path currently supports `iterations=1` only

## Validation
```bash
source .venv/bin/activate && pytest \
  tests/skills/test_evolve_skill_legacy_guard.py \
  tests/skills/test_evolve_skill_codex.py \
  tests/skills/test_skill_validation_regression.py \
  tests/core/test_lm.py \
  tests/core/test_budget.py \
  tests/core/test_codex_runner.py \
  tests/core/test_cached_dataset.py \
  tests/core/test_codex_protocol.py \
  tests/core/test_codex_schema.py -q
```

Result: `35 passed`
