### PR TITLE
fix: validate full skill files during evolution

### DIFF
--- a/evolution/core/constraints.py
+++ b/evolution/core/constraints.py
@@ -40,7 +40,7 @@ class ConstraintValidator:
         results.append(self._check_size(artifact_text, artifact_type))
 
         # 2. Growth limit (if baseline provided)
-        if baseline_text:
+        if baseline_text is not None:
             results.append(self._check_growth(artifact_text, baseline_text, artifact_type))
 
         # 3. Non-empty

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -33,6 +33,43 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+def _baseline_validation_text(skill: dict) -> str:
+    """Return the full baseline skill text for structural validation."""
+    return skill["raw"]
+
+
+def _evolved_validation_text(skill: dict, evolved_body: str) -> str:
+    """Return the reassembled evolved skill for structural validation."""
+    return reassemble_skill(skill["frontmatter"], evolved_body)
+
+
+def validate_skill_constraints(
+    validator: ConstraintValidator,
+    skill: dict,
+    evolved_body: Optional[str] = None,
+) -> list:
+    """Validate a skill while keeping budget checks on the body only.
+
+    Size, growth, and non-empty checks should apply to the mutable markdown body.
+    Structural validation should apply to the full SKILL.md file with frontmatter.
+    """
+    artifact_body = skill["body"] if evolved_body is None else evolved_body
+    baseline_body = None if evolved_body is None else skill["body"]
+    full_skill_text = (
+        _baseline_validation_text(skill)
+        if evolved_body is None
+        else _evolved_validation_text(skill, evolved_body)
+    )
+
+    results = [
+        result
+        for result in validator.validate_all(artifact_body, "skill", baseline_text=baseline_body)
+        if result.constraint_name != "skill_structure"
+    ]
+    results.append(validator._check_skill_structure(full_skill_text))
+    return results
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -119,7 +156,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validate_skill_constraints(validator, skill)
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -186,7 +223,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validate_skill_constraints(validator, skill, evolved_body=evolved_body)
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"

--- a/tests/skills/test_evolve_skill.py
+++ b/tests/skills/test_evolve_skill.py
@@ -1,0 +1,103 @@
+"""Regression tests for skill evolution validation behavior."""
+
+from evolution.core.config import EvolutionConfig
+from evolution.core.constraints import ConstraintValidator
+from evolution.skills.evolve_skill import validate_skill_constraints
+from evolution.skills.skill_module import load_skill
+
+
+SAMPLE_SKILL = """---
+name: sample-skill
+description: Sample description
+version: 1.0.0
+---
+
+# Sample Skill
+
+## Procedure
+1. Do the thing
+"""
+
+
+FRONTMATTER_HEAVY_SKILL = """---
+name: sample-skill
+description: This description is intentionally very long to make the frontmatter dominate total file size during regression testing for growth-limit behavior.
+version: 1.0.0
+author: Test Author
+license: MIT
+metadata:
+  hermes:
+    tags: [testing, growth, regression, validation]
+    related_skills: [example-one, example-two, example-three]
+---
+
+# Sample Skill
+
+short body
+"""
+
+
+EMPTY_BODY_SKILL = """---
+name: empty-body-skill
+description: Skill with valid frontmatter but no body content.
+version: 1.0.0
+---
+"""
+
+
+def _result_map(results):
+    return {result.constraint_name: result for result in results}
+
+
+def test_baseline_validation_uses_full_skill_file_for_structure(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(SAMPLE_SKILL)
+    skill = load_skill(skill_file)
+
+    validator = ConstraintValidator(EvolutionConfig())
+    results = validate_skill_constraints(validator, skill)
+
+    assert all(r.passed for r in results)
+
+
+def test_evolved_validation_reassembles_frontmatter_before_structure_check(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(SAMPLE_SKILL)
+    skill = load_skill(skill_file)
+
+    evolved_body = "# Sample Skill\n\n## Procedure\n1. Do the task\n"
+
+    validator = ConstraintValidator(EvolutionConfig())
+    results = validate_skill_constraints(validator, skill, evolved_body=evolved_body)
+
+    assert all(r.passed for r in results)
+
+
+def test_growth_limit_still_applies_to_body_not_full_file(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(FRONTMATTER_HEAVY_SKILL)
+    skill = load_skill(skill_file)
+
+    evolved_body = "# Sample Skill\n\nshort body now much longer than before\n"
+
+    config = EvolutionConfig(max_prompt_growth=0.2)
+    validator = ConstraintValidator(config)
+    results = _result_map(validate_skill_constraints(validator, skill, evolved_body=evolved_body))
+
+    assert not results["growth_limit"].passed
+    assert results["skill_structure"].passed
+
+
+def test_growth_limit_still_runs_when_baseline_body_is_empty(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(EMPTY_BODY_SKILL)
+    skill = load_skill(skill_file)
+
+    evolved_body = "# Empty Body Skill\n\nNow there is substantial body content.\n"
+
+    validator = ConstraintValidator(EvolutionConfig(max_prompt_growth=0.2))
+    results = _result_map(validate_skill_constraints(validator, skill, evolved_body=evolved_body))
+
+    assert "growth_limit" in results
+    assert not results["growth_limit"].passed
+    assert results["skill_structure"].passed


### PR DESCRIPTION
## Summary
- validate skill structure against the full reassembled `SKILL.md`, not just the markdown body
- preserve size/growth/non-empty checks on the mutable skill body so budget guardrails remain intact
- ensure growth checks still run when the baseline body is empty
- add regression tests covering structure validation and body-based growth enforcement

## Root cause
`evolve_skill.py` was calling `ConstraintValidator.validate_all()` on `skill["body"]` and `evolved_body`, but `skill_structure` validation expects a full skill file with YAML frontmatter. This caused false constraint failures like `Skill missing: YAML frontmatter (---), name field, description field` even when the reassembled evolved skill was structurally valid.

A naive switch to validating the full file fixed structure checks but weakened growth validation by measuring against the full file instead of the mutable body. This patch separates those concerns.

## What changed
- introduced `validate_skill_constraints()` in `evolution/skills/evolve_skill.py`
- kept size/growth/non-empty checks on the skill body
- ran `skill_structure` on the full baseline or reassembled evolved skill
- updated `ConstraintValidator.validate_all()` to treat `baseline_text=""` as a provided baseline so growth checks still run for empty-body skills
- added focused regression tests for:
  - baseline structure validation
  - evolved structure validation
  - body-only growth enforcement when frontmatter dominates file size
  - growth enforcement when the baseline body is empty

## Verification
- `pytest tests/ -q` → `143 passed`
- reproduced the original false-failure behavior before the fix
- reran a real optimization command after the fix and confirmed evolved skills now pass constraints instead of failing spuriously:
  - `python -m evolution.skills.evolve_skill --skill github-auth --iterations 1 --eval-source synthetic ...`

## Notes
This PR intentionally does not change the separate GEPA compatibility issue (`max_steps` / metric signature mismatch). That looks like a follow-up PR.
