### PR TITLE
fix: correct GEPA arg, constraint input, and rate limit handling in evolve_skill

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -119,7 +119,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -138,7 +138,7 @@ def evolve(
     console.print(f"  Eval model: {eval_model}")
 
     # Configure DSPy
-    lm = dspy.LM(eval_model)
+    lm = dspy.LM(eval_model, num_retries=8)
     dspy.configure(lm=lm)
 
     # Create the baseline skill module
@@ -156,7 +156,7 @@ def evolve(
     try:
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
-            max_steps=iterations,
+            max_metric_calls=iterations,
         )
 
         optimized_module = optimizer.compile(
@@ -170,6 +170,7 @@ def evolve(
         optimizer = dspy.MIPROv2(
             metric=skill_fitness_metric,
             auto="light",
+            num_threads=1,
         )
         optimized_module = optimizer.compile(
             baseline_module,
@@ -186,7 +187,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"


### PR DESCRIPTION
## Summary

Three bugs in `evolution/skills/evolve_skill.py` that together cause every optimization run to (a) never actually use GEPA, (b) always reject the evolved skill as invalid, and (c) accumulate 0.0-scored trials from rate limit errors.

### Bug 1 — GEPA called with wrong keyword argument

`dspy.GEPA(metric=..., max_steps=N)` raises `TypeError: GEPA.__init__() got an unexpected keyword argument 'max_steps'` on every run in DSPy 3.1.3. The optimizer silently falls back to MIPROv2. The correct parameter is `max_metric_calls`.

```python
# Before
optimizer = dspy.GEPA(metric=skill_fitness_metric, max_steps=iterations)
# After
optimizer = dspy.GEPA(metric=skill_fitness_metric, max_metric_calls=iterations)
```

### Bug 2 — Constraint validator receives body-only text

`_check_skill_structure` checks that text starts with `---` and contains `name:`/`description:`. Both call sites passed `skill["body"]` (the markdown after frontmatter is stripped), which never has frontmatter. The constraint therefore always fails and rejects every evolved skill — even valid ones — writing to `evolved_FAILED.md` instead of deploying.

Fix: pass `skill["raw"]` for the baseline check and `evolved_full` (the reassembled skill with frontmatter, already computed at line 185) for the evolved check.

```python
# Before
validator.validate_all(skill["body"], "skill")
validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
# After
validator.validate_all(skill["raw"], "skill")
validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
```

### Bug 3 — Concurrent calls saturate OpenAI free-tier rate limits

DSPy's parallelizer fires all evaluation calls simultaneously. On a free-tier OpenAI account (3 RPM / 60 K TPM for `gpt-4.1-mini`), the majority of calls in each trial fail with `RateLimitError`. DSPy records those trials as 0.0, poisoning MIPROv2's Bayesian optimizer (trials 4, 5, and 6 all scored 0.0 in the observed run despite the underlying prompt being reasonable).

Fix: add `num_retries=8` to the LM so litellm retries transient limit hits, and `num_threads=1` to MIPROv2 to serialize evaluation and eliminate concurrent burst pressure.

```python
# Before
lm = dspy.LM(eval_model)
optimizer = dspy.MIPROv2(metric=skill_fitness_metric, auto="light")
# After
lm = dspy.LM(eval_model, num_retries=8)
optimizer = dspy.MIPROv2(metric=skill_fitness_metric, auto="light", num_threads=1)
```

## Test plan

- [ ] `python -m evolution.skills.evolve_skill --skill github-code-review --dry-run` — setup validates without errors
- [ ] `python -m evolution.skills.evolve_skill --skill github-code-review --iterations 3 --eval-source synthetic` — baseline constraint check shows all `✓` including `skill_structure`; evolved skill saves to `output/<skill>/<timestamp>/` instead of `evolved_FAILED.md`; no 0.0-scored MIPROv2 trials from rate limit errors
- [ ] With a valid DSPy GEPA install, the GEPA fallback message no longer appears

🤖 Generated with [Claude Code](https://claude.ai/claude-code)