### PR TITLE
fix: install missing optuna dep and add LLM request timeout

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -6,6 +6,7 @@ Usage:
 """
 
 import json
+import os
 import sys
 import time
 from pathlib import Path
@@ -14,6 +15,7 @@ from typing import Optional
 
 import click
 import dspy
+import litellm
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -31,6 +33,14 @@ from evolution.skills.skill_module import (
 )
 
 console = Console()
+
+
+# Default per-request timeout for every LLM call DSPy makes. Without an explicit
+# value, litellm waits forever on silent connection drops (some providers /
+# corporate gateways drop long-poll requests without sending a TCP RST), and the
+# whole optimization loop hangs. 90s is generous for sonnet/opus reasoning calls
+# while still cutting a hung connection. Override with LITELLM_REQUEST_TIMEOUT.
+litellm.request_timeout = float(os.environ.get("LITELLM_REQUEST_TIMEOUT", "90"))
 
 
 def evolve(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,12 @@ authors = [
 keywords = ["llm", "optimization", "evolution", "dspy", "gepa", "hermes", "agent"]
 
 dependencies = [
-    "dspy>=3.0.0",
+    # dspy[optuna] pulls in optuna, which MIPROv2 requires. MIPROv2 is the
+    # automatic fallback path in evolve_skill.py when GEPA fails to initialize
+    # (e.g. on DSPy >=3.0 where GEPA's __init__ signature changed). Without
+    # the [optuna] extra the fallback crashes with ModuleNotFoundError, so the
+    # whole pipeline is broken on stock installs.
+    "dspy[optuna]>=3.0.0",
     "openai>=1.0.0",
     "pyyaml>=6.0",
     "click>=8.0",

--- a/tests/skills/test_evolve_skill_setup.py
+++ b/tests/skills/test_evolve_skill_setup.py
@@ -1,0 +1,51 @@
+"""Tests for module-level setup in evolve_skill.
+
+Currently covers the litellm request-timeout configuration installed at import
+time. Without the timeout, any silent upstream drop hangs every LLM call in the
+optimization loop forever.
+"""
+
+import importlib
+import os
+from unittest.mock import patch
+
+import litellm
+import pytest
+
+
+@pytest.fixture
+def reload_evolve_skill():
+    """Reload the module so the env-var-driven timeout is re-read."""
+
+    def _reload():
+        import evolution.skills.evolve_skill as mod
+
+        return importlib.reload(mod)
+
+    return _reload
+
+
+class TestLitellmRequestTimeout:
+    """The module sets litellm.request_timeout at import time."""
+
+    def test_default_timeout_is_90s(self, reload_evolve_skill):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LITELLM_REQUEST_TIMEOUT", None)
+            reload_evolve_skill()
+            assert litellm.request_timeout == 90.0
+
+    def test_env_var_overrides_default(self, reload_evolve_skill):
+        with patch.dict(os.environ, {"LITELLM_REQUEST_TIMEOUT": "30"}):
+            reload_evolve_skill()
+            assert litellm.request_timeout == 30.0
+
+    def test_env_var_accepts_float(self, reload_evolve_skill):
+        with patch.dict(os.environ, {"LITELLM_REQUEST_TIMEOUT": "12.5"}):
+            reload_evolve_skill()
+            assert litellm.request_timeout == 12.5
+
+    def test_invalid_env_var_raises_at_import(self, reload_evolve_skill):
+        """Bad values fail fast rather than silently disable the timeout."""
+        with patch.dict(os.environ, {"LITELLM_REQUEST_TIMEOUT": "not-a-number"}):
+            with pytest.raises(ValueError):
+                reload_evolve_skill()


### PR DESCRIPTION
## Summary

Two unrelated stock-install bugs that together prevent the optimization loop from completing on a fresh clone. Both surfaced while running `evolve_skill --eval-source synthetic --iterations 3` end-to-end.

### 1. Missing optuna dependency

`evolve_skill.py` falls back to **MIPROv2** automatically when GEPA fails to initialize, which currently happens on every DSPy ≥3.0 install because `GEPA.__init__()` no longer accepts `max_steps` (see open PRs #14, #35, #39 for the GEPA-side fix).

MIPROv2 imports `optuna` lazily inside `_optimize_prompt_parameters`. So the fallback runs through Steps 1 and 2 (bootstrap + instruction proposal — already a few minutes of LLM calls and dollars spent) and then crashes:

```
ModuleNotFoundError: No module named 'optuna'
ImportError: MIPROv2 requires optional dependency 'optuna'.
            Install it with `pip install dspy[optuna]`.
```

DSPy already declares the right version pin in its `optuna` extra, so the simplest fix is `dspy>=3.0.0` → `dspy[optuna]>=3.0.0`. No version drift risk.

### 2. No request timeout on LLM calls

`litellm.request_timeout` is unset by default, so every DSPy LM call inherits a no-deadline httpx client. When an upstream provider silently drops a long-lived POST without sending a TCP RST (we hit this on a corporate proxy gateway), the python process keeps the dead socket in `ESTABLISHED` and waits forever. The optimization loop blocks at 0% CPU on a single hung call. We measured **14+ minutes** of total stall before manually killing the run.

This PR sets `litellm.request_timeout` at module import time, with an env-var override:

```python
litellm.request_timeout = float(os.environ.get("LITELLM_REQUEST_TIMEOUT", "90"))
```

90 seconds is generous for sonnet/opus reasoning tokens but short enough to detect a dead socket and let litellm's retry logic recover. Override with `LITELLM_REQUEST_TIMEOUT=N` for slow models.

## Verification

```
$ pytest tests/ -q
143 passed, 11 warnings in 1.07s
```

(139 existing + 4 new tests covering: default 90s, env override, float parsing, fail-fast on invalid value.)

End-to-end run of `evolve_skill --skill llm-wiki-extract --eval-source synthetic --iterations 3 --optimizer-model anthropic/claude-sonnet-4-6 --eval-model anthropic/claude-sonnet-4-6` against a flaky upstream gateway now completes the full loop (baseline 35.04 → best 36.18 across 10 trials in 12 min). Before this fix the same command hung indefinitely on a silent gateway drop.

## Out of scope

This PR deliberately does NOT touch:
- The GEPA `max_steps` API mismatch (#14, #35, #39 in flight)
- The constraint-validator-on-body bug (#11, #34 → fixed by #32, #35, #39 in flight)
- The skill-body write-back / SkillModule architecture (#38, addressed in #14, #25, #28, #32, #39)

These three areas already have multiple competing PRs; adding a fourth attempt would just add review noise.

## Why ship this separately

The two bugs here have **zero overlap with any open PR or issue** — verified by searching the issue tracker and reading every open PR diff. Both are install-time / robustness fixes that any of the other PRs would benefit from being merged on top of.