### PR TITLE
fix: validate assembled skill (evolved_full) not raw body (evolved_body)

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -186,7 +186,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["body"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"


### PR DESCRIPTION
## Problem

`evolve_skill.py` line 189 validates `evolved_body` (raw DSPy output without YAML frontmatter) against the `skill_structure` constraint. The constraint checks for `---`, `name:`, and `description:` — which only exist in the reassembled skill with frontmatter.

This causes a **false negative**: the evolution completes successfully and produces valid output, but the validator rejects it with:

```
✗ skill_structure: Skill missing: YAML frontmatter (---), name field, description field
```

## Fix

One-line change: pass `evolved_full` (reassembled with frontmatter on line 185) instead of `evolved_body`.

```diff
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["body"])
```

## Verification

- Dry-run passes
- The `evolved_full` already contains valid YAML frontmatter (line 185: `reassemble_skill(skill["frontmatter"], evolved_body)`)