### PR TITLE
fix: load_skill handles dir paths; validate evolved_full not body

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -186,7 +186,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"
@@ -204,27 +204,32 @@ def evolve(
         console.print(f"  Saved failed variant to {output_path}")
         return
 
-    # ── 8. Evaluate on holdout set ──────────────────────────────────────
+    # ── 8. Evaluate on holdout set ───────────────────────────────────────
     console.print(f"\n[bold]Evaluating on holdout set ({len(dataset.holdout)} examples)[/bold]")
 
     holdout_examples = dataset.to_dspy_examples("holdout")
 
     baseline_scores = []
     evolved_scores = []
-    for ex in holdout_examples:
-        # Score baseline
-        with dspy.context(lm=lm):
-            baseline_pred = baseline_module(task_input=ex.task_input)
-            baseline_score = skill_fitness_metric(ex, baseline_pred)
-            baseline_scores.append(baseline_score)
+    try:
+        for ex in holdout_examples:
+            # Score baseline
+            with dspy.context(lm=lm):
+                baseline_pred = baseline_module(task_input=ex.task_input)
+                baseline_score = skill_fitness_metric(ex, baseline_pred)
+                baseline_scores.append(baseline_score)
 
-            evolved_pred = optimized_module(task_input=ex.task_input)
-            evolved_score = skill_fitness_metric(ex, evolved_pred)
-            evolved_scores.append(evolved_score)
-
-    avg_baseline = sum(baseline_scores) / max(1, len(baseline_scores))
-    avg_evolved = sum(evolved_scores) / max(1, len(evolved_scores))
-    improvement = avg_evolved - avg_baseline
+                evolved_pred = optimized_module(task_input=ex.task_input)
+                evolved_score = skill_fitness_metric(ex, evolved_pred)
+                evolved_scores.append(evolved_score)
+    except Exception as e:
+        console.print(f"[yellow]⚠ Holdout evaluation failed (DSPy adapter error): {e}[/yellow]")
+        console.print("  Constraints passed — skill is valid but holdout scores unavailable.")
+        avg_baseline = avg_evolved = improvement = 0.0
+    else:
+        avg_baseline = sum(baseline_scores) / max(1, len(baseline_scores))
+        avg_evolved = sum(evolved_scores) / max(1, len(evolved_scores))
+        improvement = avg_evolved - avg_baseline
 
     # ── 9. Report results ───────────────────────────────────────────────
     table = Table(title="Evolution Results")

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -25,6 +25,13 @@ def load_skill(skill_path: Path) -> dict:
             "description": str,
         }
     """
+    # If skill_path is a directory, find SKILL.md inside it
+    if skill_path.is_dir():
+        skill_md = skill_path / "SKILL.md"
+        if not skill_md.exists():
+            raise FileNotFoundError(f"No SKILL.md found in {skill_path}")
+        skill_path = skill_md
+
     raw = skill_path.read_text()
 
     # Parse YAML frontmatter


### PR DESCRIPTION
## Summary

Two bugs prevented the self-evolution pipeline from completing:

### Bug 1: `load_skill()` receives directory path, reads empty content
In `evolution/skills/skill_module.py`, `find_skill()` returns a directory path (e.g. `/skills/github/github-code-review/`). `load_skill()` tried to read this path as a file directly, got empty content, and all constraint checks failed silently.

**Fix:** detect when path is a directory and append `/SKILL.md`.

### Bug 2: `validate_all()` called on `evolved_body` instead of `evolved_full`
In `evolution/skills/evolve_skill.py`, constraint validation was called on `evolved_body` (markdown body only, no frontmatter), so `skill_structure` constraint always failed because it checks for YAML frontmatter `---` and `name:` field.

**Fix:** validate `evolved_full` (frontmatter + body) instead.

### Bonus: holdout eval crash now caught
DSPy JSONAdapter crashes when the skill outputs bash commands. This is now wrapped in try/except so constraints-passed skills are always saved.

## Testing
- Dry run passes: `✓ skill_structure: Skill has valid frontmatter (name + description)`
- Optimization completes with all constraints passing
- Output saved to `output/github-code-review/<timestamp>/`