### PR TITLE
Fix: constraint-validator false positive on valid YAML frontmatter

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -186,7 +186,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"


### PR DESCRIPTION
The skill_structure constraint check was passing evolved_body (markdown body with frontmatter stripped) instead of evolved_full (complete file). Since the validator checks for YAML frontmatter markers, it always failed on valid skills — a false positive documented in the README.

Now checks evolved_full with baseline_text=skill['raw'] for consistency.

Fixes the bug reported in README: 'The constraint validator has a false positive bug on valid YAML.'