### PR TITLE
fix: update GEPA construction for DSPy 3

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -33,6 +33,21 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+def _create_gepa_optimizer(iterations: int, optimizer_model: str):
+    """Create a DSPy 3.x GEPA optimizer.
+
+    DSPy 3.x removed the old ``max_steps`` argument and requires a reflection
+    LM for GEPA's proposal/reflection loop. Keep this construction isolated so
+    it is easy to test against future DSPy API drift.
+    """
+    reflection_lm = dspy.LM(optimizer_model)
+    return dspy.GEPA(
+        metric=skill_fitness_metric,
+        max_metric_calls=max(1, iterations * 20),
+        reflection_lm=reflection_lm,
+    )
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -154,10 +169,7 @@ def evolve(
     start_time = time.time()
 
     try:
-        optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
-            max_steps=iterations,
-        )
+        optimizer = _create_gepa_optimizer(iterations, optimizer_model)
 
         optimized_module = optimizer.compile(
             baseline_module,

--- a/tests/skills/test_evolve_skill_gepa.py
+++ b/tests/skills/test_evolve_skill_gepa.py
@@ -1,0 +1,44 @@
+"""Regression tests for DSPy 3.x GEPA construction."""
+
+from evolution.skills import evolve_skill
+
+
+class FakeLM:
+    def __init__(self, model):
+        self.model = model
+
+
+def test_create_gepa_optimizer_uses_dspy3_api(monkeypatch):
+    """GEPA should use max_metric_calls + reflection_lm, never removed max_steps."""
+    captured = {}
+
+    def fake_gepa(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(evolve_skill.dspy, "LM", FakeLM)
+    monkeypatch.setattr(evolve_skill.dspy, "GEPA", fake_gepa)
+
+    optimizer = evolve_skill._create_gepa_optimizer(iterations=7, optimizer_model="openai/gpt-4.1")
+
+    assert optimizer is not None
+    assert "max_steps" not in captured
+    assert captured["max_metric_calls"] == 140
+    assert isinstance(captured["reflection_lm"], FakeLM)
+    assert captured["reflection_lm"].model == "openai/gpt-4.1"
+    assert captured["metric"] is evolve_skill.skill_fitness_metric
+
+
+def test_create_gepa_optimizer_clamps_zero_iterations_to_one_metric_call(monkeypatch):
+    captured = {}
+
+    def fake_gepa(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(evolve_skill.dspy, "LM", FakeLM)
+    monkeypatch.setattr(evolve_skill.dspy, "GEPA", fake_gepa)
+
+    evolve_skill._create_gepa_optimizer(iterations=0, optimizer_model="openai/gpt-4.1")
+
+    assert captured["max_metric_calls"] == 1


### PR DESCRIPTION
## Summary

Fixes DSPy 3.x GEPA construction for skill evolution:

- removes the obsolete `max_steps` argument from `dspy.GEPA(...)`
- adds a reflection LM from the existing `optimizer_model` parameter
- uses bounded `max_metric_calls` as the DSPy 3.x optimization budget
- isolates GEPA construction in `_create_gepa_optimizer(...)` so future DSPy API drift is easier to test
- adds regression tests that verify `max_steps` is not passed, `reflection_lm` is set, and zero iterations clamp to at least one metric call

## Root cause

DSPy >=3.1 removed `max_steps` from GEPA and requires a reflection LM or instruction proposer. The previous code always raised during GEPA construction and silently fell back to MIPROv2.

## Test Plan

- `pytest tests/skills/test_evolve_skill_gepa.py -q`
- `pytest -q`
- runtime signature probe: `inspect.signature(dspy.GEPA)` confirms `max_steps` is absent and `max_metric_calls` / `reflection_lm` are present
- static added-line security scan for secrets/shell injection/eval/pickle/SQL string formatting
- independent code review pass

Result: 141 passed, 11 warnings (DSPy deprecation warnings only).

Closes #10
