### PR TITLE
fix: use LLM judge feedback for skill fitness

### DIFF
--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -104,36 +104,98 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> dspy.Prediction:
     """DSPy-compatible metric function for skill optimization.
 
-    This is what gets passed to dspy.GEPA(metric=...).
-    Returns a float 0-1 score.
+    Uses the configured DSPy LM as a rubric judge and returns a
+    ``dspy.Prediction(score=..., feedback=...)`` so GEPA can use the
+    feedback for reflective mutation. If judge scoring fails (for example
+    offline use, rate limits, or missing LM configuration), falls back to the
+    old keyword-overlap heuristic with explicit feedback.
     """
-    # The prediction should have an 'output' field with the agent's response
+    # The prediction should have an 'output' field with the agent's response.
     agent_output = getattr(prediction, "output", "") or ""
     expected = getattr(example, "expected_behavior", "") or ""
     task = getattr(example, "task_input", "") or ""
+    skill_text = (
+        getattr(example, "skill_text", "")
+        or getattr(example, "skill_instructions", "")
+        or ""
+    )
 
     if not agent_output.strip():
-        return 0.0
+        return _metric_prediction(0.0, "Agent output was empty, so no task requirements were satisfied.")
 
-    # Quick heuristic scoring (for speed during optimization)
-    # Full LLM-as-judge scoring is expensive — use it selectively
-    score = 0.5  # Base score for non-empty output
+    try:
+        fitness = _score_with_llm_judge(
+            task_input=task,
+            expected_behavior=expected,
+            agent_output=agent_output,
+            skill_text=skill_text,
+        )
+        feedback = fitness.feedback or _default_feedback(fitness)
+        return _metric_prediction(fitness.composite, feedback)
+    except Exception as e:
+        score, feedback = _keyword_overlap_fallback(expected, agent_output)
+        return _metric_prediction(
+            score,
+            f"LLM judge unavailable ({type(e).__name__}: {e}); "
+            f"used keyword-overlap fallback. {feedback}",
+        )
 
-    # Check if key phrases from expected behavior appear
-    expected_lower = expected.lower()
-    output_lower = agent_output.lower()
 
-    # Simple keyword overlap as a fast proxy
-    expected_words = set(expected_lower.split())
-    output_words = set(output_lower.split())
-    if expected_words:
-        overlap = len(expected_words & output_words) / len(expected_words)
-        score = 0.3 + (0.7 * overlap)
+def _score_with_llm_judge(
+    *,
+    task_input: str,
+    expected_behavior: str,
+    agent_output: str,
+    skill_text: str,
+) -> FitnessScore:
+    """Score a metric example with the currently configured DSPy LM."""
+    judge = dspy.ChainOfThought(LLMJudge.JudgeSignature)
+    result = judge(
+        task_input=task_input,
+        expected_behavior=expected_behavior,
+        agent_output=agent_output,
+        skill_text=skill_text,
+    )
 
-    return min(1.0, max(0.0, score))
+    return FitnessScore(
+        correctness=_parse_score(result.correctness),
+        procedure_following=_parse_score(result.procedure_following),
+        conciseness=_parse_score(result.conciseness),
+        feedback=str(result.feedback),
+    )
+
+
+def _keyword_overlap_fallback(expected: str, agent_output: str) -> tuple[float, str]:
+    """Fallback score matching the previous heuristic, plus GEPA feedback."""
+    expected_words = set(expected.lower().split())
+    output_words = set(agent_output.lower().split())
+
+    if not expected_words:
+        return 0.5, "No expected-behavior rubric was provided; assigned neutral score."
+
+    overlap_count = len(expected_words & output_words)
+    overlap = overlap_count / len(expected_words)
+    score = 0.3 + (0.7 * overlap)
+    return min(1.0, max(0.0, score)), (
+        f"Matched {overlap_count}/{len(expected_words)} expected-behavior keywords. "
+        "Improve semantic correctness and procedure following, not just word overlap."
+    )
+
+
+def _metric_prediction(score: float, feedback: str) -> dspy.Prediction:
+    """Create a GEPA feedback metric result while preserving float coercion."""
+    return dspy.Prediction(score=min(1.0, max(0.0, float(score))), feedback=feedback)
+
+
+def _default_feedback(fitness: FitnessScore) -> str:
+    return (
+        f"correctness={fitness.correctness:.2f}, "
+        f"procedure_following={fitness.procedure_following:.2f}, "
+        f"conciseness={fitness.conciseness:.2f}."
+    )
 
 
 def _parse_score(value) -> float:

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -216,11 +216,11 @@ def evolve(
         with dspy.context(lm=lm):
             baseline_pred = baseline_module(task_input=ex.task_input)
             baseline_score = skill_fitness_metric(ex, baseline_pred)
-            baseline_scores.append(baseline_score)
+            baseline_scores.append(float(baseline_score))
 
             evolved_pred = optimized_module(task_input=ex.task_input)
             evolved_score = skill_fitness_metric(ex, evolved_pred)
-            evolved_scores.append(evolved_score)
+            evolved_scores.append(float(evolved_score))
 
     avg_baseline = sum(baseline_scores) / max(1, len(baseline_scores))
     avg_evolved = sum(evolved_scores) / max(1, len(evolved_scores))

--- a/tests/core/test_fitness.py
+++ b/tests/core/test_fitness.py
@@ -1,0 +1,73 @@
+"""Tests for skill fitness scoring."""
+
+import dspy
+import pytest
+
+from evolution.core import fitness
+from evolution.core.fitness import FitnessScore, skill_fitness_metric
+
+
+def _example(expected="Use the repo workflow and run tests", task="Fix a bug"):
+    return dspy.Example(
+        task_input=task,
+        expected_behavior=expected,
+        skill_text="Follow the GitHub workflow skill.",
+    )
+
+
+def _prediction(output="I used the repo workflow and ran tests"):
+    return dspy.Prediction(output=output)
+
+
+class TestSkillFitnessMetric:
+    def test_returns_prediction_with_llm_judge_feedback(self, monkeypatch):
+        def fake_judge(**kwargs):
+            assert kwargs["task_input"] == "Fix a bug"
+            assert kwargs["expected_behavior"] == "Use the repo workflow and run tests"
+            assert kwargs["agent_output"] == "I used the repo workflow and ran tests"
+            assert kwargs["skill_text"] == "Follow the GitHub workflow skill."
+            return FitnessScore(
+                correctness=0.8,
+                procedure_following=0.7,
+                conciseness=0.5,
+                feedback="Mention the exact test command next time.",
+            )
+
+        monkeypatch.setattr(fitness, "_score_with_llm_judge", fake_judge)
+
+        result = skill_fitness_metric(_example(), _prediction())
+
+        assert isinstance(result, dspy.Prediction)
+        assert result.score == pytest.approx(0.71)
+        assert float(result) == pytest.approx(0.71)
+        assert result.feedback == "Mention the exact test command next time."
+
+    def test_falls_back_to_keyword_overlap_with_feedback_when_judge_fails(self, monkeypatch):
+        def failing_judge(**kwargs):
+            raise RuntimeError("rate limited")
+
+        monkeypatch.setattr(fitness, "_score_with_llm_judge", failing_judge)
+
+        result = skill_fitness_metric(
+            _example(expected="alpha beta gamma"),
+            _prediction(output="alpha beta"),
+        )
+
+        assert isinstance(result, dspy.Prediction)
+        assert result.score == pytest.approx(0.3 + 0.7 * (2 / 3))
+        assert float(result) == pytest.approx(result.score)
+        assert "LLM judge unavailable" in result.feedback
+        assert "keyword-overlap fallback" in result.feedback
+
+    def test_empty_output_returns_zero_score_prediction_with_feedback(self, monkeypatch):
+        def should_not_call_judge(**kwargs):
+            raise AssertionError("judge should not be called for empty output")
+
+        monkeypatch.setattr(fitness, "_score_with_llm_judge", should_not_call_judge)
+
+        result = skill_fitness_metric(_example(), _prediction(output="  \n"))
+
+        assert isinstance(result, dspy.Prediction)
+        assert result.score == 0.0
+        assert float(result) == 0.0
+        assert "empty" in result.feedback.lower()


### PR DESCRIPTION
## Summary

Fixes #12 by wiring the existing rubric-based LLM judge into the skill optimization metric:

- makes `skill_fitness_metric(...)` use the currently configured DSPy LM as the primary judge
- returns `dspy.Prediction(score=float, feedback=str)` so GEPA can use reflective feedback instead of generic score-only feedback
- preserves the previous keyword-overlap score as an offline/rate-limit fallback with explicit feedback
- keeps holdout aggregation numeric by coercing metric results with `float(...)`
- adds regression tests for judge scoring, fallback scoring, and empty-output scoring

## Root cause

The codebase already had `LLMJudge`, but the actual optimizer metric still used only keyword overlap. That produced a narrow and easily gamed objective and deprived GEPA of actionable feedback.

## Test Plan

- RED first: `pytest tests/core/test_fitness.py -q` failed before `_score_with_llm_judge` existed
- `pytest tests/core/test_fitness.py -q`
- `pytest -q`
- runtime probe: no configured LM returns `dspy.Prediction(...)`, `float(prediction)` works, and fallback feedback is populated
- static added-line security scan: clean
- `git diff --check`

Result: 142 passed, 11 warnings (DSPy deprecation warnings only).

Closes #12
