### PR TITLE
fix: reject empty holdout datasets

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -33,6 +33,25 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+def _require_non_empty_holdout(dataset: EvalDataset) -> None:
+    """Fail fast when holdout scoring would be meaningless.
+
+    Without holdout examples, the previous average-score calculation silently
+    produced 0.000/0.000 scores via ``max(1, len(scores))`` denominators. That
+    hides dataset construction mistakes and makes optimization reports look
+    valid when no independent evaluation occurred.
+    """
+    if dataset.holdout:
+        return
+
+    total = len(dataset.all_examples)
+    raise click.ClickException(
+        "Evaluation dataset has 0 holdout examples; cannot compute an "
+        f"independent holdout score from {total} total examples. Provide a "
+        "larger dataset or adjust train/val/holdout ratios."
+    )
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -115,6 +134,7 @@ def evolve(
         sys.exit(1)
 
     console.print(f"  Split: {len(dataset.train)} train / {len(dataset.val)} val / {len(dataset.holdout)} holdout")
+    _require_non_empty_holdout(dataset)
 
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")

--- a/tests/skills/test_evolve_skill_dataset_gates.py
+++ b/tests/skills/test_evolve_skill_dataset_gates.py
@@ -1,0 +1,37 @@
+"""Tests for evolution dataset gates."""
+
+import click
+import pytest
+
+from evolution.core.dataset_builder import EvalDataset, EvalExample
+from evolution.skills.evolve_skill import _require_non_empty_holdout
+
+
+def _example(i=1):
+    return EvalExample(
+        task_input=f"task {i}",
+        expected_behavior=f"expected {i}",
+        source="test",
+    )
+
+
+def test_holdout_gate_accepts_dataset_with_holdout_examples():
+    dataset = EvalDataset(
+        train=[_example(1)],
+        val=[_example(2)],
+        holdout=[_example(3)],
+    )
+
+    _require_non_empty_holdout(dataset)
+
+
+def test_holdout_gate_rejects_empty_holdout_with_actionable_error():
+    dataset = EvalDataset(train=[_example(1)], val=[_example(2)], holdout=[])
+
+    with pytest.raises(click.ClickException) as exc_info:
+        _require_non_empty_holdout(dataset)
+
+    message = str(exc_info.value)
+    assert "holdout" in message.lower()
+    assert "0 holdout" in message
+    assert "cannot compute" in message.lower()


### PR DESCRIPTION
## Summary

Partially addresses #33 M2 by failing fast when an evaluation dataset has no holdout examples:

- adds `_require_non_empty_holdout(...)` to reject empty holdout splits before optimization starts
- raises an actionable `click.ClickException` instead of silently producing 0.000/0.000 holdout scores
- adds regression tests for both valid holdout and empty-holdout rejection

## Root cause

The holdout scoring code uses `sum(scores) / max(1, len(scores))`. When `dataset.holdout` is empty, both baseline and evolved score lists are empty, so the report silently shows 0.000 scores rather than warning that no independent evaluation occurred.

## Opposite-perspective review notes

I checked the skeptical cases:

- Could this block intentional train/val-only runs? Yes, but the current CLI always reports holdout improvement, so allowing a zero-example holdout is more misleading than useful.
- Should this happen before or after optimization? Before. If the independent evaluation split is invalid, running GEPA first just wastes model calls and creates a fake-looking report.
- Is this only a warning? No. It hard-fails with a ClickException so the operator must fix the dataset/split.

## Test Plan

- RED first: `pytest tests/skills/test_evolve_skill_dataset_gates.py -q` failed because `_require_non_empty_holdout` did not exist
- `pytest tests/skills/test_evolve_skill_dataset_gates.py -q`
- `pytest -q`
- static added-line security scan
- `git diff --check`

Result: 141 passed, 11 warnings (DSPy deprecation warnings only).

Partially addresses #33 (M2: empty holdout set silently produces 0.000 scores).
