### PR TITLE
fix: declare reportlab dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pyyaml>=6.0",
     "click>=8.0",
     "rich>=13.0",
+    "reportlab>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -1,0 +1,27 @@
+"""Tests for report generation dependencies."""
+
+import importlib.util
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_reportlab_is_declared_for_generate_report_imports():
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    dependencies = pyproject["project"]["dependencies"]
+
+    assert any(dep.lower().startswith("reportlab") for dep in dependencies)
+
+
+def test_generate_report_module_imports_after_project_install():
+    spec = importlib.util.spec_from_file_location(
+        "generate_report",
+        ROOT / "generate_report.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+
+    spec.loader.exec_module(module)
+
+    assert callable(module.build_report)


### PR DESCRIPTION
## Summary

Partially addresses #33 M4 by declaring the PDF report generator dependency:

- adds `reportlab>=4.0` to project dependencies
- adds a regression test that `reportlab` is declared when `generate_report.py` imports it
- adds an import regression test for `generate_report.py` after project install

## Root cause

`generate_report.py` imports `reportlab` at module import time, but `pyproject.toml` did not declare `reportlab`. A fresh `pip install -e '.[dev]'` left the report generator broken with `ModuleNotFoundError: No module named 'reportlab'`.

## Opposite-perspective review notes

I checked the tradeoff explicitly:

- Minimal fix: declare `reportlab` so the existing root-level report script imports and runs after normal project install.
- Alternative: make a `[reports]` optional extra and lazy-import reportlab. That would reduce default install footprint, but it would still leave the current report script unavailable after the documented dev install unless users know to install an extra.
- Since the audit finding is specifically "reportlab Not in Dependencies" and the repo already includes a generated PDF report artifact, the direct dependency is the least surprising fix.

## Test Plan

- RED first: `pytest tests/test_generate_report.py -q` failed because `reportlab` was absent from `pyproject.toml` and unavailable in a fresh dev install
- `python -m pip install -e '.[dev]'`
- `pytest tests/test_generate_report.py -q`
- `pytest -q`
- runtime probe: `generate_report.build_report('/tmp/hae-report-probe.pdf')` created a non-empty PDF
- static added-line security scan
- `git diff --check`

Result: 141 passed, 11 warnings (DSPy deprecation warnings only).

Partially addresses #33 (M4: reportlab missing dependency).
