### PR TITLE
fix: fail fast on invalid baseline skills

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -22,7 +22,7 @@ from evolution.core.config import EvolutionConfig, get_hermes_agent_path
 from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset, GoldenDatasetLoader
 from evolution.core.external_importers import build_dataset_from_external
 from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore
-from evolution.core.constraints import ConstraintValidator
+from evolution.core.constraints import ConstraintValidator, ConstraintResult
 from evolution.skills.skill_module import (
     SkillModule,
     load_skill,
@@ -31,6 +31,30 @@ from evolution.skills.skill_module import (
 )
 
 console = Console()
+
+
+def _require_constraints_pass(
+    results: list[ConstraintResult],
+    *,
+    artifact_label: str,
+) -> None:
+    """Fail fast when a required constraint gate has failures."""
+    failures = [result for result in results if not result.passed]
+    if not failures:
+        return
+
+    details = "; ".join(
+        f"{failure.constraint_name}: {failure.message}" for failure in failures
+    )
+    raise click.ClickException(f"{artifact_label} failed constraints: {details}")
+
+
+def _validate_baseline_constraints(
+    skill: dict,
+    validator: ConstraintValidator,
+) -> list[ConstraintResult]:
+    """Validate the complete baseline skill file, including frontmatter."""
+    return validator.validate_all(skill["raw"], "skill")
 
 
 def evolve(
@@ -119,17 +143,13 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
-    all_pass = True
+    baseline_constraints = _validate_baseline_constraints(skill, validator)
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
         color = "green" if c.passed else "red"
         console.print(f"  [{color}]{icon} {c.constraint_name}[/{color}]: {c.message}")
-        if not c.passed:
-            all_pass = False
 
-    if not all_pass:
-        console.print("[yellow]⚠ Baseline skill has constraint violations — proceeding anyway[/yellow]")
+    _require_constraints_pass(baseline_constraints, artifact_label="Baseline skill")
 
     # ── 4. Set up DSPy + GEPA optimizer ─────────────────────────────────
     console.print(f"\n[bold]Configuring optimizer[/bold]")

--- a/tests/skills/test_evolve_skill_constraint_gates.py
+++ b/tests/skills/test_evolve_skill_constraint_gates.py
@@ -1,0 +1,53 @@
+"""Tests for evolution constraint gates."""
+
+import click
+import pytest
+
+from evolution.core.constraints import ConstraintResult
+from evolution.skills.evolve_skill import (
+    _require_constraints_pass,
+    _validate_baseline_constraints,
+)
+
+
+class RecordingValidator:
+    def __init__(self):
+        self.calls = []
+
+    def validate_all(self, artifact_text, artifact_type):
+        self.calls.append((artifact_text, artifact_type))
+        return [ConstraintResult(True, "skill_structure", "Skill has valid frontmatter")]
+
+
+def test_baseline_validation_uses_full_raw_skill_not_body_only():
+    validator = RecordingValidator()
+    skill = {
+        "raw": "---\nname: test\ndescription: Test skill\n---\n\n# Test\nBody",
+        "body": "# Test\nBody",
+    }
+
+    _validate_baseline_constraints(skill, validator)
+
+    assert validator.calls == [(skill["raw"], "skill")]
+
+
+def test_constraint_gate_accepts_all_passing_results():
+    _require_constraints_pass(
+        [ConstraintResult(True, "size_limit", "Size OK")],
+        artifact_label="baseline skill",
+    )
+
+
+def test_constraint_gate_rejects_any_failing_result_with_context():
+    results = [
+        ConstraintResult(True, "size_limit", "Size OK"),
+        ConstraintResult(False, "skill_structure", "Skill missing frontmatter"),
+    ]
+
+    with pytest.raises(click.ClickException) as exc_info:
+        _require_constraints_pass(results, artifact_label="baseline skill")
+
+    message = str(exc_info.value)
+    assert "baseline skill" in message
+    assert "skill_structure" in message
+    assert "Skill missing frontmatter" in message


### PR DESCRIPTION
## Summary

Partially addresses #33 H3 by making baseline constraint failures a hard gate:

- adds `_require_constraints_pass(...)` to fail fast on any required constraint failure
- uses that gate for baseline skill validation before optimizer setup
- validates the complete baseline skill (`skill["raw"]`) instead of body-only markdown so `skill_structure` sees frontmatter
- adds regression tests for raw baseline validation and fail-fast constraint behavior

## Root cause

The pipeline previously logged a warning when the baseline skill failed constraints, then continued optimization anyway. That made improvement metrics unreliable because the candidate was compared against a malformed baseline.

A direct hard-fail would have exposed a second issue: the old baseline validation used `skill["body"]`, but `skill_structure` requires YAML frontmatter. This PR therefore validates the full raw skill file before enforcing the gate.

## Opposite-perspective review notes

I specifically checked the failure mode that could make this PR harmful:

- Naive hard-fail on the existing body-only validation would reject every valid skill as missing frontmatter.
- The implementation avoids that by validating `skill["raw"]` for the baseline.
- Evolved-skill full-file validation is still a separate upstream issue covered by the existing #11/#34/#49/#50/#51 family of PRs; this PR is scoped to baseline gating.

## Test Plan

- RED first: `pytest tests/skills/test_evolve_skill_constraint_gates.py -q` failed because `_require_constraints_pass` and `_validate_baseline_constraints` did not exist
- `pytest tests/skills/test_evolve_skill_constraint_gates.py -q`
- `pytest -q`
- static added-line security scan
- `git diff --check`

Result: 142 passed, 11 warnings (DSPy deprecation warnings only).

Partially addresses #33 (H3: evolution proceeds despite baseline constraint violations).
