### PR TITLE
fix: fail fast on unsupported tblite gate

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -33,6 +33,19 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+def _run_tblite_gate_if_requested(config: EvolutionConfig) -> None:
+    """Fail loudly until the TBLite benchmark gate has a real implementation."""
+    if not config.run_tblite:
+        return
+
+    raise click.ClickException(
+        "TBLite benchmark gate requested, but TBLite execution is not implemented "
+        "in this repository yet. Re-run with run_tblite=False / without "
+        "--run-tblite, or implement evolution/core/benchmark_gate.py before "
+        "treating this run as benchmark-gated."
+    )
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -42,6 +55,7 @@ def evolve(
     eval_model: str = "openai/gpt-4.1-mini",
     hermes_repo: Optional[str] = None,
     run_tests: bool = False,
+    run_tblite: bool = False,
     dry_run: bool = False,
 ):
     """Main evolution function — orchestrates the full optimization loop."""
@@ -52,7 +66,9 @@ def evolve(
         eval_model=eval_model,
         judge_model=eval_model,  # Use same model for dataset generation
         run_pytest=run_tests,
+        run_tblite=run_tblite,
     )
+    _run_tblite_gate_if_requested(config)
     if hermes_repo:
         config.hermes_agent_path = Path(hermes_repo)
 
@@ -303,8 +319,9 @@ def evolve(
 @click.option("--eval-model", default="openai/gpt-4.1-mini", help="Model for evaluations")
 @click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
 @click.option("--run-tests", is_flag=True, help="Run full pytest suite as constraint gate")
+@click.option("--run-tblite", is_flag=True, help="Require TBLite benchmark gate before accepting evolution")
 @click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")
-def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run):
+def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, run_tblite, dry_run):
     """Evolve a Hermes Agent skill using DSPy + GEPA optimization."""
     evolve(
         skill_name=skill,
@@ -315,6 +332,7 @@ def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_mod
         eval_model=eval_model,
         hermes_repo=hermes_repo,
         run_tests=run_tests,
+        run_tblite=run_tblite,
         dry_run=dry_run,
     )
 

--- a/tests/skills/test_evolve_skill_tblite_gate.py
+++ b/tests/skills/test_evolve_skill_tblite_gate.py
@@ -1,0 +1,33 @@
+"""Tests for TBLite benchmark gate configuration."""
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from evolution.core.config import EvolutionConfig
+from evolution.skills.evolve_skill import _run_tblite_gate_if_requested, main
+
+
+def test_tblite_gate_is_skipped_when_disabled():
+    config = EvolutionConfig(run_tblite=False)
+
+    _run_tblite_gate_if_requested(config)
+
+
+def test_tblite_gate_fails_loudly_when_enabled_until_implemented():
+    config = EvolutionConfig(run_tblite=True)
+
+    with pytest.raises(click.ClickException) as exc_info:
+        _run_tblite_gate_if_requested(config)
+
+    message = str(exc_info.value)
+    assert "TBLite" in message
+    assert "not implemented" in message
+    assert "run_tblite=False" in message
+
+
+def test_run_tblite_cli_option_is_exposed_in_help():
+    result = CliRunner().invoke(main, ["--help"])
+
+    assert result.exit_code == 0
+    assert "--run-tblite" in result.output


### PR DESCRIPTION
## Summary

Partially addresses #33 C3 by turning the dead TBLite config into an explicit fail-fast path:

- adds `--run-tblite` CLI flag and wires it to `EvolutionConfig.run_tblite`
- adds `_run_tblite_gate_if_requested(...)`
- raises a clear `ClickException` when TBLite gating is requested before `benchmark_gate.py` exists
- adds regression tests for disabled/enabled behavior and CLI help exposure

## Root cause

`EvolutionConfig.run_tblite` and `tblite_regression_threshold` existed, but there was no benchmark gate implementation and no CLI wiring. That could make users believe a run was benchmark-gated when the setting was effectively a no-op.

This PR does not implement the benchmark runner itself; it makes the unsupported path explicit so Phase 1 cannot silently pretend to have a TBLite regression gate.

## Opposite-perspective review notes

I checked the main risk: this is not a full C3 fix. It intentionally does not claim benchmark gating exists. Instead, it is a safety patch that prevents false confidence until a real `evolution/core/benchmark_gate.py` lands.

Behavior with `--run-tblite --dry-run` also fails fast. That is intentional: a dry run that asks for an unsupported required gate should not print a successful setup validation.

## Test Plan

- RED first: `pytest tests/skills/test_evolve_skill_tblite_gate.py -q` failed because `_run_tblite_gate_if_requested` did not exist
- `pytest tests/skills/test_evolve_skill_tblite_gate.py -q`
- `pytest -q`
- CLI probe: `python -m evolution.skills.evolve_skill --skill dummy --run-tblite --dry-run` exits non-zero with the explicit TBLite-not-implemented error
- static added-line security scan
- `git diff --check`

Result: 142 passed, 11 warnings (DSPy deprecation warnings only).

Partially addresses #33 (C3: no benchmark gate / dead TBLite config).
