### PR TITLE
feat: write evolution run reports

### DIFF
--- a/evolution/core/run_report.py
+++ b/evolution/core/run_report.py
@@ -1,0 +1,155 @@
+"""Machine-readable evolution run reports for promotion review."""
+
+from __future__ import annotations
+
+import difflib
+import hashlib
+import json
+import re
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from evolution.core.constraints import ConstraintResult
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _slugify_target(target_name: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", target_name.strip()).strip("-")
+    return slug or "target"
+
+
+def _constraint_to_dict(result: ConstraintResult) -> dict[str, Any]:
+    return asdict(result)
+
+
+def _write_diff(
+    baseline_artifact: str,
+    optimized_artifact: str,
+    diff_path: Path,
+) -> None:
+    diff_path.parent.mkdir(parents=True, exist_ok=True)
+    diff = difflib.unified_diff(
+        baseline_artifact.splitlines(keepends=True),
+        optimized_artifact.splitlines(keepends=True),
+        fromfile="baseline",
+        tofile="optimized",
+    )
+    diff_path.write_text("".join(diff))
+
+
+def build_run_report(
+    *,
+    target_name: str,
+    artifact_type: str,
+    baseline_artifact: str,
+    optimized_artifact: str,
+    dataset_source: str,
+    split_counts: dict[str, int],
+    optimizer_model: str,
+    eval_model: str,
+    baseline_score: float | None,
+    evolved_score: float | None,
+    constraints: list[ConstraintResult],
+    elapsed_seconds: float,
+    output_dir: Path,
+    diff_path: Path,
+    timestamp: str,
+    cost_estimate: dict[str, Any] | None = None,
+    latency_estimate: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a sanitized, machine-readable report for one evolution run."""
+    improvement = (
+        evolved_score - baseline_score
+        if baseline_score is not None and evolved_score is not None
+        else None
+    )
+    constraint_results = [_constraint_to_dict(result) for result in constraints]
+    report: dict[str, Any] = {
+        "timestamp": timestamp,
+        "target_name": target_name,
+        "artifact_type": artifact_type,
+        "baseline_hash": _sha256_text(baseline_artifact),
+        "optimized_hash": _sha256_text(optimized_artifact),
+        "baseline_size": len(baseline_artifact),
+        "optimized_size": len(optimized_artifact),
+        # Compatibility aliases for benchmark gates that expect evolved_* fields.
+        "evolved_hash": _sha256_text(optimized_artifact),
+        "evolved_size": len(optimized_artifact),
+        "dataset_source": dataset_source,
+        "split_counts": dict(split_counts),
+        "train_examples": split_counts.get("train", 0),
+        "val_examples": split_counts.get("val", 0),
+        "holdout_examples": split_counts.get("holdout", 0),
+        "optimizer_model": optimizer_model,
+        "eval_model": eval_model,
+        "baseline_score": baseline_score,
+        "evolved_score": evolved_score,
+        "improvement": improvement,
+        "holdout_score_delta": improvement,
+        "constraint_results": constraint_results,
+        "constraints_passed": all(result.passed for result in constraints),
+        "elapsed_seconds": elapsed_seconds,
+        "cost_estimate": cost_estimate,
+        "latency_estimate": latency_estimate,
+        "output_dir": str(output_dir),
+        "diff_path": str(diff_path),
+    }
+    if extra:
+        report.update(extra)
+    return report
+
+
+def write_run_report(
+    *,
+    report_dir: Path,
+    target_name: str,
+    artifact_type: str,
+    baseline_artifact: str,
+    optimized_artifact: str,
+    dataset_source: str,
+    split_counts: dict[str, int],
+    optimizer_model: str,
+    eval_model: str,
+    baseline_score: float | None,
+    evolved_score: float | None,
+    constraints: list[ConstraintResult],
+    elapsed_seconds: float,
+    output_dir: Path,
+    diff_path: Path,
+    timestamp: str,
+    cost_estimate: dict[str, Any] | None = None,
+    latency_estimate: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> Path:
+    """Write the run report and artifact diff, returning the report path."""
+    report_dir.mkdir(parents=True, exist_ok=True)
+    _write_diff(baseline_artifact, optimized_artifact, diff_path)
+    report_path = report_dir / f"{timestamp}-{_slugify_target(target_name)}.json"
+    report = build_run_report(
+        target_name=target_name,
+        artifact_type=artifact_type,
+        baseline_artifact=baseline_artifact,
+        optimized_artifact=optimized_artifact,
+        dataset_source=dataset_source,
+        split_counts=split_counts,
+        optimizer_model=optimizer_model,
+        eval_model=eval_model,
+        baseline_score=baseline_score,
+        evolved_score=evolved_score,
+        constraints=constraints,
+        elapsed_seconds=elapsed_seconds,
+        output_dir=output_dir,
+        diff_path=diff_path,
+        timestamp=timestamp,
+        cost_estimate=cost_estimate,
+        latency_estimate=latency_estimate,
+        extra=extra,
+    )
+    report["report_path"] = str(report_path)
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True))
+    return report_path

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -23,6 +23,7 @@ from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset,
 from evolution.core.external_importers import build_dataset_from_external
 from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore
 from evolution.core.constraints import ConstraintValidator
+from evolution.core.run_report import write_run_report
 from evolution.skills.skill_module import (
     SkillModule,
     load_skill,
@@ -197,11 +198,41 @@ def evolve(
 
     if not all_pass:
         console.print("[red]✗ Evolved skill FAILED constraints — not deploying[/red]")
-        # Still save for inspection
-        output_path = Path("output") / skill_name / "evolved_FAILED.md"
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(evolved_full)
-        console.print(f"  Saved failed variant to {output_path}")
+        # Still save for inspection and promotion audit.
+        failed_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        failed_output_dir = Path("output") / skill_name / failed_timestamp
+        failed_output_dir.mkdir(parents=True, exist_ok=True)
+        failed_output_path = failed_output_dir / "evolved_FAILED.md"
+        failed_output_path.write_text(evolved_full)
+        (failed_output_dir / "baseline_skill.md").write_text(skill["raw"])
+        report_path = write_run_report(
+            report_dir=Path("reports") / "runs",
+            target_name=skill_name,
+            artifact_type="skill",
+            baseline_artifact=skill["raw"],
+            optimized_artifact=evolved_full,
+            dataset_source=eval_source,
+            split_counts={
+                "train": len(dataset.train),
+                "val": len(dataset.val),
+                "holdout": len(dataset.holdout),
+            },
+            optimizer_model=optimizer_model,
+            eval_model=eval_model,
+            baseline_score=None,
+            evolved_score=None,
+            constraints=evolved_constraints,
+            elapsed_seconds=elapsed,
+            output_dir=failed_output_dir,
+            diff_path=failed_output_dir / "skill.diff",
+            timestamp=failed_timestamp,
+            extra={
+                "iterations": iterations,
+                "status": "failed_constraints",
+            },
+        )
+        console.print(f"  Saved failed variant to {failed_output_path}")
+        console.print(f"  Run report saved to {report_path}")
         return
 
     # ── 8. Evaluate on holdout set ──────────────────────────────────────
@@ -283,7 +314,32 @@ def evolve(
     }
     (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
 
+    report_path = write_run_report(
+        report_dir=Path("reports") / "runs",
+        target_name=skill_name,
+        artifact_type="skill",
+        baseline_artifact=skill["raw"],
+        optimized_artifact=evolved_full,
+        dataset_source=eval_source,
+        split_counts={
+            "train": len(dataset.train),
+            "val": len(dataset.val),
+            "holdout": len(dataset.holdout),
+        },
+        optimizer_model=optimizer_model,
+        eval_model=eval_model,
+        baseline_score=avg_baseline,
+        evolved_score=avg_evolved,
+        constraints=evolved_constraints,
+        elapsed_seconds=elapsed,
+        output_dir=output_dir,
+        diff_path=output_dir / "skill.diff",
+        timestamp=timestamp,
+        extra={"iterations": iterations},
+    )
+
     console.print(f"\n  Output saved to {output_dir}/")
+    console.print(f"  Run report saved to {report_path}")
 
     if improvement > 0:
         console.print(f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement/max(0.001, avg_baseline)*100:+.1f}%)[/bold green]")

--- a/tests/core/test_run_report.py
+++ b/tests/core/test_run_report.py
@@ -1,0 +1,125 @@
+"""Tests for evolution run report generation."""
+
+import json
+
+import pytest
+
+from evolution.core.constraints import ConstraintResult
+from evolution.core.run_report import build_run_report, write_run_report
+
+
+def test_build_run_report_contains_promotion_artifact_fields(tmp_path):
+    baseline = "# Skill\nold behavior\n"
+    evolved = "# Skill\nnew improved behavior\n"
+    constraints = [ConstraintResult(True, "size_limit", "Size OK", "details")]
+
+    report = build_run_report(
+        target_name="demo-skill",
+        artifact_type="skill",
+        baseline_artifact=baseline,
+        optimized_artifact=evolved,
+        dataset_source="golden",
+        split_counts={"train": 2, "val": 1, "holdout": 1},
+        optimizer_model="openai/gpt-4.1",
+        eval_model="openai/gpt-4.1-mini",
+        baseline_score=0.4,
+        evolved_score=0.7,
+        constraints=constraints,
+        elapsed_seconds=12.5,
+        output_dir=tmp_path / "output" / "demo-skill" / "run",
+        diff_path=tmp_path / "output" / "demo-skill" / "run" / "skill.diff",
+        timestamp="20260509_010203",
+    )
+
+    assert report["target_name"] == "demo-skill"
+    assert report["artifact_type"] == "skill"
+    assert report["baseline_hash"] != report["optimized_hash"]
+    assert report["baseline_size"] == len(baseline)
+    assert report["optimized_size"] == len(evolved)
+    assert report["evolved_size"] == len(evolved)
+    assert report["dataset_source"] == "golden"
+    assert report["split_counts"] == {"train": 2, "val": 1, "holdout": 1}
+    assert report["train_examples"] == 2
+    assert report["val_examples"] == 1
+    assert report["holdout_examples"] == 1
+    assert report["optimizer_model"] == "openai/gpt-4.1"
+    assert report["eval_model"] == "openai/gpt-4.1-mini"
+    assert report["baseline_score"] == 0.4
+    assert report["evolved_score"] == 0.7
+    assert report["improvement"] == pytest.approx(0.3)
+    assert report["holdout_score_delta"] == pytest.approx(0.3)
+    assert report["constraints_passed"] is True
+    assert report["constraint_results"] == [
+        {
+            "passed": True,
+            "constraint_name": "size_limit",
+            "message": "Size OK",
+            "details": "details",
+        }
+    ]
+    assert report["output_dir"].endswith("output/demo-skill/run")
+    assert report["diff_path"].endswith("skill.diff")
+
+
+def test_build_run_report_allows_failed_run_before_holdout_scores(tmp_path):
+    report = build_run_report(
+        target_name="demo-skill",
+        artifact_type="skill",
+        baseline_artifact="baseline",
+        optimized_artifact="optimized",
+        dataset_source="golden",
+        split_counts={"train": 1, "val": 1, "holdout": 1},
+        optimizer_model="optimizer/model",
+        eval_model="eval/model",
+        baseline_score=None,
+        evolved_score=None,
+        constraints=[ConstraintResult(False, "size_limit", "Too large")],
+        elapsed_seconds=2.0,
+        output_dir=tmp_path / "output",
+        diff_path=tmp_path / "output" / "skill.diff",
+        timestamp="20260509_010203",
+        extra={"status": "failed_constraints"},
+    )
+
+    assert report["baseline_score"] is None
+    assert report["evolved_score"] is None
+    assert report["improvement"] is None
+    assert report["holdout_score_delta"] is None
+    assert report["constraints_passed"] is False
+    assert report["status"] == "failed_constraints"
+
+
+def test_write_run_report_writes_machine_readable_report_and_diff(tmp_path):
+    baseline = "line one\nold line\n"
+    evolved = "line one\nnew line\n"
+    report_dir = tmp_path / "reports" / "runs"
+    diff_path = tmp_path / "output" / "demo" / "run" / "artifact.diff"
+
+    report_path = write_run_report(
+        report_dir=report_dir,
+        target_name="demo skill",
+        artifact_type="skill",
+        baseline_artifact=baseline,
+        optimized_artifact=evolved,
+        dataset_source="sessiondb",
+        split_counts={"train": 1, "val": 1, "holdout": 1},
+        optimizer_model="optimizer/model",
+        eval_model="eval/model",
+        baseline_score=0.5,
+        evolved_score=0.6,
+        constraints=[ConstraintResult(True, "non_empty", "Non-empty")],
+        elapsed_seconds=1.25,
+        output_dir=tmp_path / "output" / "demo" / "run",
+        diff_path=diff_path,
+        timestamp="20260509_010203",
+    )
+
+    assert report_path == report_dir / "20260509_010203-demo-skill.json"
+    payload = json.loads(report_path.read_text())
+    assert payload["target_name"] == "demo skill"
+    assert payload["report_path"] == str(report_path)
+    assert payload["diff_path"] == str(diff_path)
+    assert "-old line" in diff_path.read_text()
+    assert "+new line" in diff_path.read_text()
+    assert payload["cost_estimate"] is None
+    assert payload["latency_estimate"] is None


### PR DESCRIPTION
## Summary

Implements issue #54 step 2: local, machine-readable promotion artifacts for evolution runs.

Adds:

- `evolution/core/run_report.py`
- `build_run_report(...)` for constructing sanitized report payloads
- `write_run_report(...)` for writing `reports/runs/<timestamp>-<target>.json`
- artifact diffs via `skill.diff`
- wiring in `evolve_skill.py` so successful non-dry-run evolutions write and print a run report path
- failure-path reporting when an evolved skill fails constraints, so failed variants still produce auditable artifacts
- tests that generate reports/diffs without live LLM calls

Report fields include:

- baseline and optimized artifact hashes/sizes
- compatibility aliases: `evolved_hash` / `evolved_size`
- dataset source and split counts
- optimizer/eval model names
- constraint results and aggregate pass/fail
- holdout score delta when available
- null cost/latency estimate placeholders when unavailable
- output and diff paths

## Safety / privacy notes

The report stores artifact hashes, sizes, metrics, paths, and constraint messages. It does not persist raw session dumps or raw private tool outputs. The diff is the baseline-vs-optimized artifact diff already written for local review.

No remote mutation or PR automation is introduced here.

## Test Plan

- RED first: `pytest tests/core/test_run_report.py -q` failed because `evolution.core.run_report` did not exist
- `pytest tests/core/test_run_report.py -q`
- `pytest -q`
- runtime probe for successful and failed-score report writes
- static added-line security scan
- `git diff --check`

Result: 142 passed, 11 warnings (DSPy deprecation warnings only).

Partially addresses #54.
