### PR TITLE
feat: report session source availability

### DIFF
--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -26,7 +26,7 @@ import json
 import re
 import random
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import click
 import dspy
@@ -723,6 +723,30 @@ def _load_skill_text(skill_name: str, skills_dir: Optional[Path] = None) -> tupl
     raise FileNotFoundError(f"Skill '{skill_name}' not found in {skills_dir}")
 
 
+def describe_source_availability(
+    sources: list[str],
+    importers: dict[str, type],
+) -> dict[str, dict[str, Any]]:
+    """Report per-source availability and candidate counts without LLM calls."""
+    report: dict[str, dict[str, Any]] = {}
+    for source in sources:
+        try:
+            messages = importers[source].extract_messages()
+            candidate_count = len(messages)
+            report[source] = {
+                "available": candidate_count > 0,
+                "candidate_count": candidate_count,
+                "error": None,
+            }
+        except Exception as exc:
+            report[source] = {
+                "available": False,
+                "candidate_count": 0,
+                "error": str(exc),
+            }
+    return report
+
+
 # ── CLI ───────────────────────────────────────────────────────────────────
 
 
@@ -760,9 +784,14 @@ def main(source, skill, output, model, max_examples, dry_run):
             "copilot": CopilotImporter,
             "hermes": HermesSessionImporter,
         }
+        availability = describe_source_availability(sources, importers)
         for src in sources:
-            msgs = importers[src].extract_messages()
-            console.print(f"  {src}: {len(msgs)} messages")
+            info = availability[src]
+            status = "available" if info["available"] else "unavailable"
+            error = f" error={info['error']}" if info["error"] else ""
+            console.print(
+                f"  {src}: {status}, candidates={info['candidate_count']}{error}"
+            )
         console.print("\n[bold green]DRY RUN — no LLM calls made.[/bold green]")
         return
 

--- a/tests/core/test_external_importer_availability.py
+++ b/tests/core/test_external_importer_availability.py
@@ -1,0 +1,53 @@
+"""Tests for external importer source availability dry-runs."""
+
+from evolution.core.external_importers import describe_source_availability
+
+
+class AvailableImporter:
+    @staticmethod
+    def extract_messages():
+        return [
+            {"task_input": "first useful prompt"},
+            {"task_input": "second useful prompt"},
+        ]
+
+
+class EmptyImporter:
+    @staticmethod
+    def extract_messages():
+        return []
+
+
+class ErrorImporter:
+    @staticmethod
+    def extract_messages():
+        raise RuntimeError("history unreadable")
+
+
+def test_describe_source_availability_reports_available_empty_and_errors():
+    report = describe_source_availability(
+        ["available", "empty", "error"],
+        {
+            "available": AvailableImporter,
+            "empty": EmptyImporter,
+            "error": ErrorImporter,
+        },
+    )
+
+    assert report == {
+        "available": {
+            "available": True,
+            "candidate_count": 2,
+            "error": None,
+        },
+        "empty": {
+            "available": False,
+            "candidate_count": 0,
+            "error": None,
+        },
+        "error": {
+            "available": False,
+            "candidate_count": 0,
+            "error": "history unreadable",
+        },
+    }


### PR DESCRIPTION
## Summary

Partially implements issue #54 step 1 by making all-source dry runs report explicit per-source availability and candidate counts.

Adds:

- `describe_source_availability(sources, importers)`
- dry-run output of `available` / `unavailable`, candidate count, and extraction error if any
- tests for available, empty, and erroring source importers

This turns the existing dry-run count display into an explicit availability boundary, so `--source all --dry-run` no longer silently treats empty/erroring sources as just zero messages.

## Example behavior

```bash
python -m evolution.core.external_importers --source all --skill <skill> --dry-run
```

Now prints each source as:

```text
claude-code: available, candidates=12
copilot: unavailable, candidates=0
hermes: unavailable, candidates=0 error=<reason>
```

## Scope / non-goals

This is the smallest safe ingestion-boundary slice. It does not yet implement the full canonical event/message schema or persist all source metadata into `EvalExample`; those should follow as separate PRs because they touch dataset serialization and deduplication behavior.

## Test Plan

- RED first: `pytest tests/core/test_external_importer_availability.py -q` failed because `describe_source_availability` did not exist
- `pytest tests/core/test_external_importer_availability.py -q`
- `pytest -q`
- static added-line security scan
- `git diff --check`

Result: 140 passed, 11 warnings (DSPy deprecation warnings only).

Partially addresses #54.
