### PR TITLE
fix(skills): pass evolved_full to skill_structure validator

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -185,8 +185,13 @@ def evolve(
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
+    # Pass `evolved_full` (frontmatter + body) so the `skill_structure`
+    # constraint can verify the YAML frontmatter / name / description.
+    # Passing `evolved_body` here causes that constraint to always fail and
+    # routes valid evolutions into the FAILED path even when the assembled
+    # skill is well-formed (and gets saved correctly on line ~206).
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["body"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"


### PR DESCRIPTION
## Summary

`evolve_skill.evolve()` calls the constraints validator with `evolved_body` (the body only), but the `skill_structure` constraint checks for YAML frontmatter (`---`), `name`, and `description`. That constraint *always* failed because those live in the frontmatter, not the body.

Result: every evolution — including high-scoring ones — was routed to `output/<skill>/evolved_FAILED.md` even when the reassembled `evolved_full` skill was completely well-formed (and got saved as `evolved_FAILED.md` immediately after, with all the metadata intact).

## Fix

Pass `evolved_full` (assembled one line earlier via `reassemble_skill(skill[\"frontmatter\"], evolved_body)`) to the validator instead of `evolved_body`. One-line change.

## Repro before fix

```bash
python -m evolution.skills.evolve_skill \
  --skill github-code-review \
  --iterations 5 \
  --eval-source synthetic \
  --optimizer-model openai/MiniMax-M2.7 \
  --eval-model openai/MiniMax-M2.7
```

Output (10 trials complete, optimizer succeeds):

```
Returning best identified program with score 60.87!
  Optimization completed in 364.3s

Validating evolved skill
  ✓ size_limit: Size OK: 13161/15000 chars
  ✓ non_empty: Artifact is non-empty
  ✗ skill_structure: Skill missing: YAML frontmatter (---), name field, description field
✗ Evolved skill FAILED constraints — not deploying
  Saved failed variant to output/github-code-review/evolved_FAILED.md
```

`evolved_FAILED.md` on disk has the full frontmatter + body — confirming the only thing wrong was the validator input.

## Repro after fix (same command)

```
Validating evolved skill
  ✓ size_limit: Size OK: 13481/15000 chars
  ✓ growth_limit: Growth OK: +2.4% (max +20.0%)
  ✓ non_empty: Artifact is non-empty
  ✓ skill_structure: Skill has valid frontmatter (name + description)
  Output saved to output/github-code-review/20260509_224844/
✓ Evolution improved skill by +0.185 (+42.5%)
```

## Test plan

- [x] Run `evolve_skill` with synthetic eval source on a real skill (github-code-review) — verified output now lands in `output/<skill>/<timestamp>/evolved_skill.md` with all 4 constraints passing.
- [x] Failed-constraint path (the `evolved_FAILED.md` save) still uses `evolved_full` (unchanged at L206), so behavior on truly malformed evolutions is preserved.