### PR TITLE
fix: harden phase 1 skill evolution path

### DIFF
--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -104,7 +104,13 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+def skill_fitness_metric(
+    example: dspy.Example,
+    prediction: dspy.Prediction,
+    trace=None,
+    pred_name=None,
+    pred_trace=None,
+) -> float:
     """DSPy-compatible metric function for skill optimization.
 
     This is what gets passed to dspy.GEPA(metric=...).

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -33,6 +33,37 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+def build_gepa_optimizer(iterations: int, optimizer_model: str):
+    """Construct a DSPy 3.2+ GEPA optimizer for skill evolution.
+
+    Older code used ``max_steps``; current DSPy GEPA uses budget arguments
+    such as ``max_full_evals`` and requires an explicit reflection LM.
+    """
+    reflection_lm = dspy.LM(optimizer_model)
+    return dspy.GEPA(
+        metric=skill_fitness_metric,
+        max_full_evals=iterations,
+        reflection_lm=reflection_lm,
+    )
+
+
+def validate_skill_candidate(
+    validator: ConstraintValidator,
+    frontmatter: str,
+    body: str,
+    baseline_body: Optional[str] = None,
+):
+    """Validate a skill candidate using full SKILL.md text for structure.
+
+    The body is what GEPA evolves, but skill-structure validation needs the
+    YAML frontmatter too. Reassemble both candidate and baseline so structure
+    and growth checks evaluate the artifact that would actually be saved.
+    """
+    full_skill = reassemble_skill(frontmatter, body)
+    baseline_full = reassemble_skill(frontmatter, baseline_body) if baseline_body is not None else None
+    return validator.validate_all(full_skill, "skill", baseline_text=baseline_full)
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -43,6 +74,7 @@ def evolve(
     hermes_repo: Optional[str] = None,
     run_tests: bool = False,
     dry_run: bool = False,
+    output_dir: Optional[str] = None,
 ):
     """Main evolution function — orchestrates the full optimization loop."""
 
@@ -55,6 +87,8 @@ def evolve(
     )
     if hermes_repo:
         config.hermes_agent_path = Path(hermes_repo)
+    if output_dir:
+        config.output_dir = Path(output_dir)
 
     # ── 1. Find and load the skill ──────────────────────────────────────
     console.print(f"\n[bold cyan]🧬 Hermes Agent Self-Evolution[/bold cyan] — Evolving skill: [bold]{skill_name}[/bold]\n")
@@ -119,7 +153,11 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validate_skill_candidate(
+        validator=validator,
+        frontmatter=skill["frontmatter"],
+        body=skill["body"],
+    )
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -154,9 +192,9 @@ def evolve(
     start_time = time.time()
 
     try:
-        optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
-            max_steps=iterations,
+        optimizer = build_gepa_optimizer(
+            iterations=iterations,
+            optimizer_model=optimizer_model,
         )
 
         optimized_module = optimizer.compile(
@@ -186,7 +224,12 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validate_skill_candidate(
+        validator=validator,
+        frontmatter=skill["frontmatter"],
+        body=evolved_body,
+        baseline_body=skill["body"],
+    )
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"
@@ -198,7 +241,7 @@ def evolve(
     if not all_pass:
         console.print("[red]✗ Evolved skill FAILED constraints — not deploying[/red]")
         # Still save for inspection
-        output_path = Path("output") / skill_name / "evolved_FAILED.md"
+        output_path = config.output_dir / skill_name / "evolved_FAILED.md"
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(evolved_full)
         console.print(f"  Saved failed variant to {output_path}")
@@ -254,7 +297,7 @@ def evolve(
 
     # ── 10. Save output ─────────────────────────────────────────────────
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_dir = Path("output") / skill_name / timestamp
+    output_dir = config.output_dir / skill_name / timestamp
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Save evolved skill
@@ -304,7 +347,8 @@ def evolve(
 @click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
 @click.option("--run-tests", is_flag=True, help="Run full pytest suite as constraint gate")
 @click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")
-def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run):
+@click.option("--output-dir", default=None, help="Directory for evolved artifacts and metrics")
+def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run, output_dir):
     """Evolve a Hermes Agent skill using DSPy + GEPA optimization."""
     evolve(
         skill_name=skill,
@@ -316,6 +360,7 @@ def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_mod
         hermes_repo=hermes_repo,
         run_tests=run_tests,
         dry_run=dry_run,
+        output_dir=output_dir,
     )
 
 

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -84,33 +84,31 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
 class SkillModule(dspy.Module):
     """A DSPy module that wraps a skill file for optimization.
 
-    The skill text (body) is the parameter that GEPA optimizes.
-    On each forward pass, the module:
-    1. Uses the skill text as instructions
-    2. Processes the task input
-    3. Returns the agent's response
+    The skill body is stored as the predictor signature instructions, which is
+    the text component GEPA mutates in DSPy 3.x. Keeping the skill in the
+    optimizable signature (rather than as a normal input field) lets the
+    compiled module expose the evolved skill text via ``skill_text``.
     """
-
-    class TaskWithSkill(dspy.Signature):
-        """Complete a task following the provided skill instructions.
-
-        You are an AI agent following specific skill instructions to complete a task.
-        Read the skill instructions carefully and follow the procedure described.
-        """
-        skill_instructions: str = dspy.InputField(desc="The skill instructions to follow")
-        task_input: str = dspy.InputField(desc="The task to complete")
-        output: str = dspy.OutputField(desc="Your response following the skill instructions")
 
     def __init__(self, skill_text: str):
         super().__init__()
-        self.skill_text = skill_text
-        self.predictor = dspy.ChainOfThought(self.TaskWithSkill)
+        signature = dspy.Signature(
+            "task_input -> output",
+            instructions=skill_text,
+        )
+        self.predictor = dspy.ChainOfThought(signature)
+
+    @property
+    def skill_text(self) -> str:
+        """Return the current/evolved skill instructions from the predictor."""
+        return self.predictor.predict.signature.instructions
+
+    @skill_text.setter
+    def skill_text(self, value: str) -> None:
+        self.predictor.predict.signature = self.predictor.predict.signature.with_instructions(value)
 
     def forward(self, task_input: str) -> dspy.Prediction:
-        result = self.predictor(
-            skill_instructions=self.skill_text,
-            task_input=task_input,
-        )
+        result = self.predictor(task_input=task_input)
         return dspy.Prediction(output=result.output)
 
 

--- a/tests/skills/test_evolve_skill_phase1.py
+++ b/tests/skills/test_evolve_skill_phase1.py
@@ -1,0 +1,156 @@
+"""Regression tests for the Phase 1 skill evolution path.
+
+These tests lock down the minimum behavior needed before this repo can be
+used as a real skill-evolution experiment harness:
+- the skill text itself must be the optimizable DSPy instruction text,
+- evolved instruction text must be extractable after optimization,
+- GEPA must be constructed with the DSPy 3.2+ API,
+- skill structure constraints must validate the full SKILL.md text, not just
+  the body without YAML frontmatter.
+"""
+
+import json
+from pathlib import Path
+
+import dspy
+
+from evolution.core.config import EvolutionConfig
+from evolution.core.constraints import ConstraintValidator
+from evolution.skills.skill_module import SkillModule, reassemble_skill
+from evolution.skills.evolve_skill import build_gepa_optimizer, evolve, validate_skill_candidate
+
+
+def test_skill_module_places_skill_text_in_optimizable_signature_instructions():
+    skill_text = "# Demo Skill\n\nFollow this exact evolved procedure."
+
+    module = SkillModule(skill_text)
+    signature = module.predictor.predict.signature
+
+    assert skill_text in signature.instructions
+    assert "skill_instructions" not in signature.fields
+    assert "task_input" in signature.fields
+    assert "output" in signature.fields
+
+
+def test_skill_text_property_reflects_optimized_signature_instructions():
+    module = SkillModule("# Original Skill\n\nOriginal procedure.")
+
+    module.predictor.predict.signature = module.predictor.predict.signature.with_instructions(
+        "# Evolved Skill\n\nImproved procedure."
+    )
+
+    assert module.skill_text == "# Evolved Skill\n\nImproved procedure."
+
+
+def test_build_gepa_optimizer_uses_dspy_32_constructor(monkeypatch):
+    captured = {}
+
+    class FakeLM:
+        def __init__(self, model, **kwargs):
+            self.model = model
+            self.kwargs = kwargs
+
+    class FakeGEPA:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("evolution.skills.evolve_skill.dspy.LM", FakeLM)
+    monkeypatch.setattr("evolution.skills.evolve_skill.dspy.GEPA", FakeGEPA)
+
+    optimizer = build_gepa_optimizer(iterations=7, optimizer_model="openai/test-reflector")
+
+    assert isinstance(optimizer, FakeGEPA)
+    assert captured["max_full_evals"] == 7
+    assert "max_steps" not in captured
+    assert captured["reflection_lm"].model == "openai/test-reflector"
+    assert callable(captured["metric"])
+
+
+def test_validate_skill_candidate_checks_structure_on_full_skill_text():
+    config = EvolutionConfig(run_pytest=False)
+    validator = ConstraintValidator(config)
+    frontmatter = "name: demo-skill\ndescription: Demo skill"
+    body = "# Demo Skill\n\n1. Do the thing."
+
+    results = validate_skill_candidate(
+        validator=validator,
+        frontmatter=frontmatter,
+        body=body,
+        baseline_body=body,
+    )
+
+    by_name = {result.constraint_name: result for result in results}
+    assert by_name["skill_structure"].passed
+    assert by_name["size_limit"].passed
+    assert by_name["non_empty"].passed
+
+
+def test_reassembled_skill_candidate_is_what_structure_validator_expects():
+    frontmatter = "name: demo-skill\ndescription: Demo skill"
+    body = "# Demo Skill\n\n1. Do the thing."
+
+    full_skill = reassemble_skill(frontmatter, body)
+    result = ConstraintValidator(EvolutionConfig())._check_skill_structure(full_skill)
+
+    assert result.passed
+
+
+def test_evolve_golden_dataset_writes_baseline_evolved_and_metrics_without_api(tmp_path, monkeypatch):
+    hermes_repo = tmp_path / "hermes-agent"
+    skill_dir = hermes_repo / "skills" / "testing" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo-skill\ndescription: Demo skill\n---\n\n"
+        "# Demo Skill\n\nReturn a concise answer. Include security context, evidence, and one next step. "
+        "Keep the result practical for code review workflows.\n"
+    )
+
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    examples = [
+        {"task_input": "Review this tiny change", "expected_behavior": "security concise", "difficulty": "easy", "category": "review"},
+        {"task_input": "Find the risk", "expected_behavior": "security concise", "difficulty": "medium", "category": "review"},
+        {"task_input": "Summarize issue", "expected_behavior": "security concise", "difficulty": "medium", "category": "review"},
+    ]
+    for split, example in zip(["train", "val", "holdout"], examples):
+        (dataset_dir / f"{split}.jsonl").write_text(json.dumps(example) + "\n")
+
+    class FakeSkillModule:
+        def __init__(self, skill_text):
+            self.skill_text = skill_text
+
+        def __call__(self, task_input):
+            return dspy.Prediction(output="security concise")
+
+    class FakeOptimizer:
+        def compile(self, student, trainset, valset):
+            student.skill_text = student.skill_text + "\n\n## Evolved\nSecurity."
+            return student
+
+    monkeypatch.setattr("evolution.skills.evolve_skill.SkillModule", FakeSkillModule)
+    monkeypatch.setattr("evolution.skills.evolve_skill.build_gepa_optimizer", lambda **kwargs: FakeOptimizer())
+    monkeypatch.setattr("evolution.skills.evolve_skill.dspy.LM", lambda *args, **kwargs: object())
+    monkeypatch.setattr("evolution.skills.evolve_skill.dspy.configure", lambda **kwargs: None)
+
+    output_root = tmp_path / "evolution-output"
+    evolve(
+        skill_name="demo-skill",
+        iterations=1,
+        eval_source="golden",
+        dataset_path=str(dataset_dir),
+        hermes_repo=str(hermes_repo),
+        output_dir=str(output_root),
+    )
+
+    run_dirs = list((output_root / "demo-skill").iterdir())
+    assert len(run_dirs) == 1
+    run_dir = run_dirs[0]
+
+    baseline = (run_dir / "baseline_skill.md").read_text()
+    evolved = (run_dir / "evolved_skill.md").read_text()
+    metrics = json.loads((run_dir / "metrics.json").read_text())
+
+    assert "## Evolved" not in baseline
+    assert "## Evolved" in evolved
+    assert metrics["skill_name"] == "demo-skill"
+    assert metrics["constraints_passed"] is True


### PR DESCRIPTION
## Summary
- Store skill text in DSPy signature instructions so GEPA can actually optimize the skill body
- Update the GEPA construction path for DSPy 3.2+ with reflection_lm and max_full_evals
- Validate full SKILL.md artifacts, including YAML frontmatter, before accepting candidates
- Add configurable output_dir support and API-free golden dataset regression coverage for emitted artifacts

## Test Plan
- [x] .venv/bin/python -m pytest -q
- [x] Static added-line security scan: no hardcoded secrets, shell=True/os.system, eval/exec, pickle.loads, or obvious SQL format injection matches
- [x] Independent pre-commit reviewer passed; one non-blocking baseline_body suggestion was applied

## Notes
- Direct push to NousResearch/hermes-agent-self-evolution was denied for this account, so this PR is opened from the ohkyuetaek fork.