### PR TITLE
fix: use skill raw for constraint validation

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -119,7 +119,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -186,7 +186,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"


### PR DESCRIPTION
## Problem

`ConstraintValidator._check_skill_structure()` always receives skill text **without** YAML frontmatter (via `skill["body"]`), so it perpetually fails with "Skill missing: YAML frontmatter (---)" even when the skill file is perfectly valid.

This makes the constraint gate entirely non-functional — every evolved skill is marked FAILED and saved as `evolved_FAILED.md`.

## Fix

Change two call sites to use the correct field:

```diff
# Line 122 — baseline check
- baseline_constraints = validator.validate_all(skill["body"], "skill")
+ baseline_constraints = validator.validate_all(skill["raw"], "skill")

# Line 189 — evolved check
- evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+ evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
```

`skill["raw"]` contains the full file content (frontmatter + body). `evolved_full` is already computed via `reassemble_skill(skill["frontmatter"], evolved_body)`.

Fixes #74