### PR TITLE
chore: repo hygiene — gitleaks allowlist, ruff fixes, ruff format

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,12 @@
+# gitleaks config — allowlist test fixtures that contain literal strings
+# passed to assertion helpers (not real secrets).
+title = "hermes-agent-self-evolution gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Test fixtures with literal secret-like strings"
+paths = [
+    '''tests/core/test_external_importers\.py''',
+]

--- a/evolution/core/config.py
+++ b/evolution/core/config.py
@@ -3,7 +3,6 @@
 import os
 from pathlib import Path
 from dataclasses import dataclass, field
-from typing import Optional
 
 
 @dataclass

--- a/evolution/core/constraints.py
+++ b/evolution/core/constraints.py
@@ -15,6 +15,7 @@ from evolution.core.config import EvolutionConfig
 @dataclass
 class ConstraintResult:
     """Result of constraint validation."""
+
     passed: bool
     constraint_name: str
     message: str
@@ -41,7 +42,9 @@ class ConstraintValidator:
 
         # 2. Growth limit (if baseline provided)
         if baseline_text:
-            results.append(self._check_growth(artifact_text, baseline_text, artifact_type))
+            results.append(
+                self._check_growth(artifact_text, baseline_text, artifact_type)
+            )
 
         # 3. Non-empty
         results.append(self._check_non_empty(artifact_text))
@@ -68,11 +71,15 @@ class ConstraintValidator:
                     passed=True,
                     constraint_name="test_suite",
                     message="All tests passed",
-                    details=result.stdout.strip().split("\n")[-1] if result.stdout else "",
+                    details=result.stdout.strip().split("\n")[-1]
+                    if result.stdout
+                    else "",
                 )
             else:
                 # Extract failure summary
-                last_lines = result.stdout.strip().split("\n")[-5:] if result.stdout else []
+                last_lines = (
+                    result.stdout.strip().split("\n")[-5:] if result.stdout else []
+                )
                 return ConstraintResult(
                     passed=False,
                     constraint_name="test_suite",
@@ -116,7 +123,9 @@ class ConstraintValidator:
                 message=f"Size exceeded: {size}/{limit} chars ({size - limit} over)",
             )
 
-    def _check_growth(self, text: str, baseline: str, artifact_type: str) -> ConstraintResult:
+    def _check_growth(
+        self, text: str, baseline: str, artifact_type: str
+    ) -> ConstraintResult:
         growth = (len(text) - len(baseline)) / max(1, len(baseline))
         max_growth = self.config.max_prompt_growth
 

--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -20,6 +20,7 @@ from evolution.core.config import EvolutionConfig
 @dataclass
 class EvalExample:
     """A single evaluation example."""
+
     task_input: str  # What the user asks
     expected_behavior: str  # Rubric — what a good response looks like
     difficulty: str = "medium"  # easy, medium, hard
@@ -43,6 +44,7 @@ class EvalExample:
 @dataclass
 class EvalDataset:
     """Train/val/holdout split of evaluation examples."""
+
     train: list[EvalExample] = field(default_factory=list)
     val: list[EvalExample] = field(default_factory=list)
     holdout: list[EvalExample] = field(default_factory=list)
@@ -54,7 +56,11 @@ class EvalDataset:
     def save(self, path: Path):
         """Save dataset splits to JSONL files."""
         path.mkdir(parents=True, exist_ok=True)
-        for split_name, split_data in [("train", self.train), ("val", self.val), ("holdout", self.holdout)]:
+        for split_name, split_data in [
+            ("train", self.train),
+            ("val", self.val),
+            ("holdout", self.holdout),
+        ]:
             with open(path / f"{split_name}.jsonl", "w") as f:
                 for ex in split_data:
                     f.write(json.dumps(ex.to_dict()) + "\n")
@@ -103,10 +109,17 @@ class SyntheticDatasetBuilder:
         - A difficulty level (easy, medium, hard)
         - A category (what aspect of the skill this tests)
         """
-        artifact_text: str = dspy.InputField(desc="The full text of the skill/tool/prompt being tested")
-        artifact_type: str = dspy.InputField(desc="Type: 'skill', 'tool_description', or 'prompt_section'")
+
+        artifact_text: str = dspy.InputField(
+            desc="The full text of the skill/tool/prompt being tested"
+        )
+        artifact_type: str = dspy.InputField(
+            desc="Type: 'skill', 'tool_description', or 'prompt_section'"
+        )
         num_cases: int = dspy.InputField(desc="Number of test cases to generate")
-        test_cases: str = dspy.OutputField(desc="JSON array of test cases, each with: task_input, expected_behavior, difficulty, category")
+        test_cases: str = dspy.OutputField(
+            desc="JSON array of test cases, each with: task_input, expected_behavior, difficulty, category"
+        )
 
     def __init__(self, config: EvolutionConfig):
         self.config = config
@@ -138,11 +151,14 @@ class SyntheticDatasetBuilder:
         except json.JSONDecodeError:
             # Try to extract JSON from the response
             import re
-            match = re.search(r'\[.*\]', result.test_cases, re.DOTALL)
+
+            match = re.search(r"\[.*\]", result.test_cases, re.DOTALL)
             if match:
                 cases_raw = json.loads(match.group())
             else:
-                raise ValueError(f"Could not parse test cases from LLM output: {result.test_cases[:200]}")
+                raise ValueError(
+                    f"Could not parse test cases from LLM output: {result.test_cases[:200]}"
+                )
 
         examples = [
             EvalExample(
@@ -164,8 +180,8 @@ class SyntheticDatasetBuilder:
 
         return EvalDataset(
             train=examples[:n_train],
-            val=examples[n_train:n_train + n_val],
-            holdout=examples[n_train + n_val:],
+            val=examples[n_train : n_train + n_val],
+            holdout=examples[n_train + n_val :],
         )
 
 
@@ -196,6 +212,6 @@ class GoldenDatasetLoader:
 
         return EvalDataset(
             train=examples[:n_train],
-            val=examples[n_train:n_train + n_val],
-            holdout=examples[n_train + n_val:],
+            val=examples[n_train : n_train + n_val],
+            holdout=examples[n_train + n_val :],
         )

--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -43,29 +43,29 @@ console = Console()
 # Each pattern is intentionally anchored to known key formats to minimize
 # false positives on normal prose.
 SECRET_PATTERNS = re.compile(
-    r'('
-    r'sk-ant-api\S+'           # Anthropic API keys
-    r'|sk-or-v1-\S+'          # OpenRouter API keys
-    r'|sk-\S{20,}'            # Generic OpenAI-style keys (20+ chars after sk-)
-    r'|ghp_\S+'               # GitHub personal access tokens
-    r'|ghu_\S+'               # GitHub user tokens
-    r'|xoxb-\S+'              # Slack bot tokens
-    r'|xapp-\S+'              # Slack app tokens
-    r'|ntn_\S+'               # Notion integration tokens
-    r'|AKIA[0-9A-Z]{16}'      # AWS access key IDs
-    r'|Bearer\s+\S{20,}'      # Bearer auth headers (20+ char tokens)
-    r'|-----BEGIN\s+(RSA\s+)?PRIVATE\sKEY-----'  # PEM private keys
-    r'|ANTHROPIC_API_KEY'      # Known env var names (exact match)
-    r'|OPENAI_API_KEY'
-    r'|OPENROUTER_API_KEY'
-    r'|SLACK_BOT_TOKEN'
-    r'|GITHUB_TOKEN'
-    r'|AWS_SECRET_ACCESS_KEY'
-    r'|DATABASE_URL'
-    r'|\bpassword\s*[=:]\s*\S+' # password assignments (password=xxx, password: xxx)
-    r'|\bsecret\s*[=:]\s*\S+'   # secret assignments (secret=xxx, secret: xxx)
-    r'|\btoken\s*[=:]\s*\S{10,}' # token assignments with 10+ char values
-    r')',
+    r"("
+    r"sk-ant-api\S+"  # Anthropic API keys
+    r"|sk-or-v1-\S+"  # OpenRouter API keys
+    r"|sk-\S{20,}"  # Generic OpenAI-style keys (20+ chars after sk-)
+    r"|ghp_\S+"  # GitHub personal access tokens
+    r"|ghu_\S+"  # GitHub user tokens
+    r"|xoxb-\S+"  # Slack bot tokens
+    r"|xapp-\S+"  # Slack app tokens
+    r"|ntn_\S+"  # Notion integration tokens
+    r"|AKIA[0-9A-Z]{16}"  # AWS access key IDs
+    r"|Bearer\s+\S{20,}"  # Bearer auth headers (20+ char tokens)
+    r"|-----BEGIN\s+(RSA\s+)?PRIVATE\sKEY-----"  # PEM private keys
+    r"|ANTHROPIC_API_KEY"  # Known env var names (exact match)
+    r"|OPENAI_API_KEY"
+    r"|OPENROUTER_API_KEY"
+    r"|SLACK_BOT_TOKEN"
+    r"|GITHUB_TOKEN"
+    r"|AWS_SECRET_ACCESS_KEY"
+    r"|DATABASE_URL"
+    r"|\bpassword\s*[=:]\s*\S+"  # password assignments (password=xxx, password: xxx)
+    r"|\bsecret\s*[=:]\s*\S+"  # secret assignments (secret=xxx, secret: xxx)
+    r"|\btoken\s*[=:]\s*\S{10,}"  # token assignments with 10+ char values
+    r")",
     re.IGNORECASE,
 )
 
@@ -141,12 +141,12 @@ def _is_relevant_to_skill(text: str, skill_name: str, skill_text: str) -> bool:
     # Extract meaningful keywords from skill text (first 500 chars)
     skill_keywords = set()
     for word in skill_text[:500].lower().split():
-        word = re.sub(r'[^a-z]', '', word)
+        word = re.sub(r"[^a-z]", "", word)
         if len(word) > 4:
             skill_keywords.add(word)
 
     # Require at least 2 keyword matches
-    message_words = set(re.sub(r'[^a-z\s]', '', text_lower).split())
+    message_words = set(re.sub(r"[^a-z\s]", "", text_lower).split())
     overlap = message_words & skill_keywords
     return len(overlap) >= 2
 
@@ -193,13 +193,15 @@ class ClaudeCodeImporter:
                 if _contains_secret(text):
                     continue
 
-                messages.append({
-                    "source": "claude-code",
-                    "task_input": text,
-                    "project": entry.get("project", ""),
-                    "session_id": entry.get("sessionId", ""),
-                    "timestamp": entry.get("timestamp", 0),
-                })
+                messages.append(
+                    {
+                        "source": "claude-code",
+                        "task_input": text,
+                        "project": entry.get("project", ""),
+                        "session_id": entry.get("sessionId", ""),
+                        "timestamp": entry.get("timestamp", 0),
+                    }
+                )
 
                 if limit and len(messages) >= limit:
                     break
@@ -239,7 +241,9 @@ class CopilotImporter:
         event_files = list(CopilotImporter.SESSION_DIR.glob("*/events.jsonl"))
 
         with Progress() as progress:
-            task = progress.add_task("Reading Copilot sessions...", total=len(event_files))
+            task = progress.add_task(
+                "Reading Copilot sessions...", total=len(event_files)
+            )
 
             for events_path in event_files:
                 session_id = events_path.parent.name
@@ -271,7 +275,9 @@ def _read_copilot_workspace(workspace_path: Path) -> str:
 
 
 def _parse_copilot_events(
-    events_path: Path, session_id: str, project: str,
+    events_path: Path,
+    session_id: str,
+    project: str,
 ) -> list[dict]:
     """Parse a single Copilot events.jsonl into user/assistant pairs."""
     pairs = []
@@ -294,14 +300,18 @@ def _parse_copilot_events(
                 if event_type == "user.message":
                     # Save previous pair before starting new one
                     if current_user_msg and current_assistant_msg:
-                        if not _contains_secret(current_user_msg) and not _contains_secret(current_assistant_msg):
-                            pairs.append({
-                                "source": "copilot",
-                                "task_input": current_user_msg,
-                                "assistant_response": current_assistant_msg,
-                                "project": project,
-                                "session_id": session_id,
-                            })
+                        if not _contains_secret(
+                            current_user_msg
+                        ) and not _contains_secret(current_assistant_msg):
+                            pairs.append(
+                                {
+                                    "source": "copilot",
+                                    "task_input": current_user_msg,
+                                    "assistant_response": current_assistant_msg,
+                                    "project": project,
+                                    "session_id": session_id,
+                                }
+                            )
 
                     current_user_msg = data.get("content", "")
                     current_assistant_msg = None
@@ -316,14 +326,18 @@ def _parse_copilot_events(
 
         # Don't forget the last pair in the file
         if current_user_msg and current_assistant_msg:
-            if not _contains_secret(current_user_msg) and not _contains_secret(current_assistant_msg):
-                pairs.append({
-                    "source": "copilot",
-                    "task_input": current_user_msg,
-                    "assistant_response": current_assistant_msg,
-                    "project": project,
-                    "session_id": session_id,
-                })
+            if not _contains_secret(current_user_msg) and not _contains_secret(
+                current_assistant_msg
+            ):
+                pairs.append(
+                    {
+                        "source": "copilot",
+                        "task_input": current_user_msg,
+                        "assistant_response": current_assistant_msg,
+                        "project": project,
+                        "session_id": session_id,
+                    }
+                )
 
     except Exception as e:
         console.print(f"[dim]Skipped {session_id}: {e}[/dim]")
@@ -403,12 +417,14 @@ class HermesSessionImporter:
                 if assistant_text and _contains_secret(assistant_text):
                     continue
 
-                messages.append({
-                    "source": "hermes",
-                    "task_input": user_text,
-                    "assistant_response": assistant_text,
-                    "session_id": session_id,
-                })
+                messages.append(
+                    {
+                        "source": "hermes",
+                        "task_input": user_text,
+                        "assistant_response": assistant_text,
+                        "session_id": session_id,
+                    }
+                )
 
                 if limit and len(messages) >= limit:
                     return messages
@@ -436,11 +452,18 @@ class RelevanceFilter:
         - difficulty: string (easy, medium, or hard)
         - category: string (what aspect of the skill this tests)
         """
+
         skill_name: str = dspy.InputField(desc="Name of the skill")
-        skill_description: str = dspy.InputField(desc="First 800 chars of the skill file")
+        skill_description: str = dspy.InputField(
+            desc="First 800 chars of the skill file"
+        )
         user_message: str = dspy.InputField(desc="The user's message to evaluate")
-        assistant_response: str = dspy.InputField(desc="The assistant's actual response (may be empty)")
-        scoring: str = dspy.OutputField(desc="JSON object with: relevant, expected_behavior, difficulty, category")
+        assistant_response: str = dspy.InputField(
+            desc="The assistant's actual response (may be empty)"
+        )
+        scoring: str = dspy.OutputField(
+            desc="JSON object with: relevant, expected_behavior, difficulty, category"
+        )
 
     def __init__(self, model: str):
         self.scorer = dspy.ChainOfThought(self.ScoreRelevance)
@@ -471,7 +494,8 @@ class RelevanceFilter:
 
         # Stage 1: cheap heuristic pre-filter
         candidates = [
-            m for m in messages
+            m
+            for m in messages
             if _is_relevant_to_skill(m["task_input"], skill_name, skill_text)
         ]
 
@@ -480,12 +504,14 @@ class RelevanceFilter:
             candidate_ids = {id(m) for m in candidates}
             remaining = [m for m in messages if id(m) not in candidate_ids]
             random.shuffle(remaining)
-            candidates.extend(remaining[:max_examples * 2])
+            candidates.extend(remaining[: max_examples * 2])
 
         # Cap candidates to control LLM costs
-        candidates = candidates[:max_examples * 3]
+        candidates = candidates[: max_examples * 3]
 
-        console.print(f"  Pre-filtered to {len(candidates)} candidates (from {len(messages)} total)")
+        console.print(
+            f"  Pre-filtered to {len(candidates)} candidates (from {len(messages)} total)"
+        )
 
         # Stage 2: LLM relevance scoring
         examples = []
@@ -519,10 +545,12 @@ class RelevanceFilter:
                             category=scoring.get("category", "general"),
                         )
                         if validated:
-                            examples.append(EvalExample(
-                                source=msg["source"],
-                                **validated,
-                            ))
+                            examples.append(
+                                EvalExample(
+                                    source=msg["source"],
+                                    **validated,
+                                )
+                            )
 
                 except Exception:
                     errors += 1
@@ -567,7 +595,7 @@ def _parse_scoring_json(text: str) -> Optional[dict]:
     # Slow path: find balanced {...} block using brace counting.
     # Simple regex like r'\{[^}]+\}' breaks on nested braces
     # (e.g. "handle {edge} cases" in a string value).
-    start = text.find('{')
+    start = text.find("{")
     if start == -1:
         return None
 
@@ -579,7 +607,7 @@ def _parse_scoring_json(text: str) -> Optional[dict]:
         if escape_next:
             escape_next = False
             continue
-        if ch == '\\' and in_string:
+        if ch == "\\" and in_string:
             escape_next = True
             continue
         if ch == '"':
@@ -587,13 +615,13 @@ def _parse_scoring_json(text: str) -> Optional[dict]:
             continue
         if in_string:
             continue
-        if ch == '{':
+        if ch == "{":
             depth += 1
-        elif ch == '}':
+        elif ch == "}":
             depth -= 1
             if depth == 0:
                 try:
-                    return json.loads(text[start:i + 1])
+                    return json.loads(text[start : i + 1])
                 except json.JSONDecodeError:
                     return None
 
@@ -653,13 +681,18 @@ def build_dataset_from_external(
 
     relevance_filter = RelevanceFilter(model=model)
     examples = relevance_filter.filter_and_score(
-        all_messages, skill_name, skill_text, max_examples=max_examples,
+        all_messages,
+        skill_name,
+        skill_text,
+        max_examples=max_examples,
     )
 
     console.print(f"\n[bold green]Found {len(examples)} relevant examples[/bold green]")
 
     if not examples:
-        console.print("[yellow]No relevant examples found. Try a different skill or broader sources.[/yellow]")
+        console.print(
+            "[yellow]No relevant examples found. Try a different skill or broader sources.[/yellow]"
+        )
         return EvalDataset()
 
     if len(examples) < MIN_DATASET_SIZE:
@@ -676,13 +709,15 @@ def build_dataset_from_external(
 
     dataset = EvalDataset(
         train=examples[:n_train],
-        val=examples[n_train:n_train + n_val],
-        holdout=examples[n_train + n_val:],
+        val=examples[n_train : n_train + n_val],
+        holdout=examples[n_train + n_val :],
     )
 
     dataset.save(output_path)
     console.print(f"\n[bold]Saved to {output_path}/[/bold]")
-    console.print(f"  train: {len(dataset.train)}  val: {len(dataset.val)}  holdout: {len(dataset.holdout)}")
+    console.print(
+        f"  train: {len(dataset.train)}  val: {len(dataset.val)}  holdout: {len(dataset.holdout)}"
+    )
 
     source_counts: dict[str, int] = {}
     for ex in examples:
@@ -693,7 +728,9 @@ def build_dataset_from_external(
     return dataset
 
 
-def _load_skill_text(skill_name: str, skills_dir: Optional[Path] = None) -> tuple[str, str]:
+def _load_skill_text(
+    skill_name: str, skills_dir: Optional[Path] = None
+) -> tuple[str, str]:
     """Load skill text from the installed Hermes skills directory.
 
     This is used by the standalone CLI only. When called via evolve_skill.py,
@@ -734,15 +771,24 @@ def _load_skill_text(skill_name: str, skills_dir: Optional[Path] = None) -> tupl
     help="Which tool to import from",
 )
 @click.option("--skill", required=True, help="Skill name to generate eval data for")
-@click.option("--output", type=click.Path(), default=None,
-              help="Output directory (default: datasets/skills/<skill>/)")
-@click.option("--model", default="openrouter/google/gemini-2.5-flash",
-              help="LiteLLM model string for relevance scoring")
+@click.option(
+    "--output",
+    type=click.Path(),
+    default=None,
+    help="Output directory (default: datasets/skills/<skill>/)",
+)
+@click.option(
+    "--model",
+    default="openrouter/google/gemini-2.5-flash",
+    help="LiteLLM model string for relevance scoring",
+)
 @click.option("--max-examples", default=50, help="Max eval examples to generate")
 @click.option("--dry-run", is_flag=True, help="Show message counts without LLM scoring")
 def main(source, skill, output, model, max_examples, dry_run):
     """Import external session data into golden eval datasets for self-evolution."""
-    console.print(f"\n[bold cyan]External Session Importer[/bold cyan] — skill: [bold]{skill}[/bold]\n")
+    console.print(
+        f"\n[bold cyan]External Session Importer[/bold cyan] — skill: [bold]{skill}[/bold]\n"
+    )
 
     try:
         skill_name, skill_text = _load_skill_text(skill)
@@ -767,7 +813,9 @@ def main(source, skill, output, model, max_examples, dry_run):
         return
 
     if output is None:
-        output = Path(__file__).parent.parent.parent / "datasets" / "skills" / skill_name
+        output = (
+            Path(__file__).parent.parent.parent / "datasets" / "skills" / skill_name
+        )
     else:
         output = Path(output)
 

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -14,6 +14,7 @@ from evolution.core.config import EvolutionConfig
 @dataclass
 class FitnessScore:
     """Multi-dimensional fitness score."""
+
     correctness: float = 0.0  # Did the agent produce correct output? (0-1)
     procedure_following: float = 0.0  # Did it follow the skill's procedure? (0-1)
     conciseness: float = 0.0  # Was it appropriately concise? (0-1)
@@ -48,14 +49,27 @@ class LLMJudge:
 
         Also provide specific, actionable feedback on what could be improved.
         """
+
         task_input: str = dspy.InputField(desc="The task the agent was given")
-        expected_behavior: str = dspy.InputField(desc="Rubric describing what a good response looks like")
+        expected_behavior: str = dspy.InputField(
+            desc="Rubric describing what a good response looks like"
+        )
         agent_output: str = dspy.InputField(desc="The agent's actual response")
-        skill_text: str = dspy.InputField(desc="The skill/instructions the agent was following")
-        correctness: float = dspy.OutputField(desc="Score 0.0-1.0: Did the response correctly address the task?")
-        procedure_following: float = dspy.OutputField(desc="Score 0.0-1.0: Did it follow the expected procedure?")
-        conciseness: float = dspy.OutputField(desc="Score 0.0-1.0: Appropriately concise?")
-        feedback: str = dspy.OutputField(desc="Specific, actionable feedback on what could be improved")
+        skill_text: str = dspy.InputField(
+            desc="The skill/instructions the agent was following"
+        )
+        correctness: float = dspy.OutputField(
+            desc="Score 0.0-1.0: Did the response correctly address the task?"
+        )
+        procedure_following: float = dspy.OutputField(
+            desc="Score 0.0-1.0: Did it follow the expected procedure?"
+        )
+        conciseness: float = dspy.OutputField(
+            desc="Score 0.0-1.0: Appropriately concise?"
+        )
+        feedback: str = dspy.OutputField(
+            desc="Specific, actionable feedback on what could be improved"
+        )
 
     def __init__(self, config: EvolutionConfig):
         self.config = config
@@ -104,7 +118,9 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+def skill_fitness_metric(
+    example: dspy.Example, prediction: dspy.Prediction, trace=None
+) -> float:
     """DSPy-compatible metric function for skill optimization.
 
     This is what gets passed to dspy.GEPA(metric=...).

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -18,7 +18,11 @@ from rich.console import Console
 from rich.table import Table
 
 from evolution.core.config import EvolutionConfig
-from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset, GoldenDatasetLoader
+from evolution.core.dataset_builder import (
+    SyntheticDatasetBuilder,
+    EvalDataset,
+    GoldenDatasetLoader,
+)
 from evolution.core.external_importers import build_dataset_from_external
 from evolution.core.fitness import skill_fitness_metric
 from evolution.core.constraints import ConstraintValidator
@@ -56,11 +60,15 @@ def evolve(
         config.hermes_agent_path = Path(hermes_repo)
 
     # ── 1. Find and load the skill ──────────────────────────────────────
-    console.print(f"\n[bold cyan]🧬 Hermes Agent Self-Evolution[/bold cyan] — Evolving skill: [bold]{skill_name}[/bold]\n")
+    console.print(
+        f"\n[bold cyan]🧬 Hermes Agent Self-Evolution[/bold cyan] — Evolving skill: [bold]{skill_name}[/bold]\n"
+    )
 
     skill_path = find_skill(skill_name, config.hermes_agent_path)
     if not skill_path:
-        console.print(f"[red]✗ Skill '{skill_name}' not found in {config.hermes_agent_path / 'skills'}[/red]")
+        console.print(
+            f"[red]✗ Skill '{skill_name}' not found in {config.hermes_agent_path / 'skills'}[/red]"
+        )
         sys.exit(1)
 
     skill = load_skill(skill_path)
@@ -70,7 +78,9 @@ def evolve(
     console.print(f"  Description: {skill['description'][:80]}...")
 
     if dry_run:
-        console.print("\n[bold green]DRY RUN — setup validated successfully.[/bold green]")
+        console.print(
+            "\n[bold green]DRY RUN — setup validated successfully.[/bold green]"
+        )
         console.print(f"  Would generate eval dataset (source: {eval_source})")
         console.print(f"  Would run GEPA optimization ({iterations} iterations)")
         console.print("  Would validate constraints and create PR")
@@ -83,7 +93,11 @@ def evolve(
         dataset = GoldenDatasetLoader.load(Path(dataset_path))
         console.print(f"  Loaded golden dataset: {len(dataset.all_examples)} examples")
     elif eval_source == "sessiondb":
-        save_path = Path(dataset_path) if dataset_path else Path("datasets") / "skills" / skill_name
+        save_path = (
+            Path(dataset_path)
+            if dataset_path
+            else Path("datasets") / "skills" / skill_name
+        )
         dataset = build_dataset_from_external(
             skill_name=skill_name,
             skill_text=skill["raw"],
@@ -92,9 +106,13 @@ def evolve(
             model=eval_model,
         )
         if not dataset.all_examples:
-            console.print("[red]✗ No relevant examples found from session history[/red]")
+            console.print(
+                "[red]✗ No relevant examples found from session history[/red]"
+            )
             sys.exit(1)
-        console.print(f"  Mined {len(dataset.all_examples)} examples from session history")
+        console.print(
+            f"  Mined {len(dataset.all_examples)} examples from session history"
+        )
     elif eval_source == "synthetic":
         builder = SyntheticDatasetBuilder(config)
         dataset = builder.generate(
@@ -110,10 +128,14 @@ def evolve(
         dataset = EvalDataset.load(Path(dataset_path))
         console.print(f"  Loaded dataset: {len(dataset.all_examples)} examples")
     else:
-        console.print("[red]✗ Specify --dataset-path or use --eval-source synthetic[/red]")
+        console.print(
+            "[red]✗ Specify --dataset-path or use --eval-source synthetic[/red]"
+        )
         sys.exit(1)
 
-    console.print(f"  Split: {len(dataset.train)} train / {len(dataset.val)} val / {len(dataset.holdout)} holdout")
+    console.print(
+        f"  Split: {len(dataset.train)} train / {len(dataset.val)} val / {len(dataset.holdout)} holdout"
+    )
 
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print("\n[bold]Validating baseline constraints[/bold]")
@@ -128,7 +150,9 @@ def evolve(
             all_pass = False
 
     if not all_pass:
-        console.print("[yellow]⚠ Baseline skill has constraint violations — proceeding anyway[/yellow]")
+        console.print(
+            "[yellow]⚠ Baseline skill has constraint violations — proceeding anyway[/yellow]"
+        )
 
     # ── 4. Set up DSPy + GEPA optimizer ─────────────────────────────────
     console.print("\n[bold]Configuring optimizer[/bold]")
@@ -148,7 +172,9 @@ def evolve(
     valset = dataset.to_dspy_examples("val")
 
     # ── 5. Run GEPA optimization ────────────────────────────────────────
-    console.print(f"\n[bold cyan]Running GEPA optimization ({iterations} iterations)...[/bold cyan]\n")
+    console.print(
+        f"\n[bold cyan]Running GEPA optimization ({iterations} iterations)...[/bold cyan]\n"
+    )
 
     start_time = time.time()
 
@@ -165,7 +191,9 @@ def evolve(
         )
     except Exception as e:
         # Fall back to MIPROv2 if GEPA isn't available in this DSPy version
-        console.print(f"[yellow]GEPA not available ({e}), falling back to MIPROv2[/yellow]")
+        console.print(
+            f"[yellow]GEPA not available ({e}), falling back to MIPROv2[/yellow]"
+        )
         optimizer = dspy.MIPROv2(
             metric=skill_fitness_metric,
             auto="light",
@@ -185,7 +213,9 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print("\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(
+        evolved_body, "skill", baseline_text=skill["body"]
+    )
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"
@@ -204,7 +234,9 @@ def evolve(
         return
 
     # ── 8. Evaluate on holdout set ──────────────────────────────────────
-    console.print(f"\n[bold]Evaluating on holdout set ({len(dataset.holdout)} examples)[/bold]")
+    console.print(
+        f"\n[bold]Evaluating on holdout set ({len(dataset.holdout)} examples)[/bold]"
+    )
 
     holdout_examples = dataset.to_dspy_examples("holdout")
 
@@ -285,25 +317,57 @@ def evolve(
     console.print(f"\n  Output saved to {output_dir}/")
 
     if improvement > 0:
-        console.print(f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement/max(0.001, avg_baseline)*100:+.1f}%)[/bold green]")
-        console.print(f"  Review the diff: diff {output_dir}/baseline_skill.md {output_dir}/evolved_skill.md")
+        console.print(
+            f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement / max(0.001, avg_baseline) * 100:+.1f}%)[/bold green]"
+        )
+        console.print(
+            f"  Review the diff: diff {output_dir}/baseline_skill.md {output_dir}/evolved_skill.md"
+        )
     else:
-        console.print(f"\n[yellow]⚠ Evolution did not improve skill (change: {improvement:+.3f})[/yellow]")
-        console.print("  Try: more iterations, better eval dataset, or different optimizer model")
+        console.print(
+            f"\n[yellow]⚠ Evolution did not improve skill (change: {improvement:+.3f})[/yellow]"
+        )
+        console.print(
+            "  Try: more iterations, better eval dataset, or different optimizer model"
+        )
 
 
 @click.command()
 @click.option("--skill", required=True, help="Name of the skill to evolve")
 @click.option("--iterations", default=10, help="Number of GEPA iterations")
-@click.option("--eval-source", default="synthetic", type=click.Choice(["synthetic", "golden", "sessiondb"]),
-              help="Source for evaluation dataset")
-@click.option("--dataset-path", default=None, help="Path to existing eval dataset (JSONL)")
-@click.option("--optimizer-model", default="openai/gpt-4.1", help="Model for GEPA reflections")
-@click.option("--eval-model", default="openai/gpt-4.1-mini", help="Model for evaluations")
+@click.option(
+    "--eval-source",
+    default="synthetic",
+    type=click.Choice(["synthetic", "golden", "sessiondb"]),
+    help="Source for evaluation dataset",
+)
+@click.option(
+    "--dataset-path", default=None, help="Path to existing eval dataset (JSONL)"
+)
+@click.option(
+    "--optimizer-model", default="openai/gpt-4.1", help="Model for GEPA reflections"
+)
+@click.option(
+    "--eval-model", default="openai/gpt-4.1-mini", help="Model for evaluations"
+)
 @click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
-@click.option("--run-tests", is_flag=True, help="Run full pytest suite as constraint gate")
-@click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")
-def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run):
+@click.option(
+    "--run-tests", is_flag=True, help="Run full pytest suite as constraint gate"
+)
+@click.option(
+    "--dry-run", is_flag=True, help="Validate setup without running optimization"
+)
+def main(
+    skill,
+    iterations,
+    eval_source,
+    dataset_path,
+    optimizer_model,
+    eval_model,
+    hermes_repo,
+    run_tests,
+    dry_run,
+):
     """Evolve a Hermes Agent skill using DSPy + GEPA optimization."""
     evolve(
         skill_name=skill,

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -15,13 +15,12 @@ from typing import Optional
 import click
 import dspy
 from rich.console import Console
-from rich.panel import Panel
 from rich.table import Table
 
-from evolution.core.config import EvolutionConfig, get_hermes_agent_path
+from evolution.core.config import EvolutionConfig
 from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset, GoldenDatasetLoader
 from evolution.core.external_importers import build_dataset_from_external
-from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore
+from evolution.core.fitness import skill_fitness_metric
 from evolution.core.constraints import ConstraintValidator
 from evolution.skills.skill_module import (
     SkillModule,
@@ -71,10 +70,10 @@ def evolve(
     console.print(f"  Description: {skill['description'][:80]}...")
 
     if dry_run:
-        console.print(f"\n[bold green]DRY RUN — setup validated successfully.[/bold green]")
+        console.print("\n[bold green]DRY RUN — setup validated successfully.[/bold green]")
         console.print(f"  Would generate eval dataset (source: {eval_source})")
         console.print(f"  Would run GEPA optimization ({iterations} iterations)")
-        console.print(f"  Would validate constraints and create PR")
+        console.print("  Would validate constraints and create PR")
         return
 
     # ── 2. Build or load evaluation dataset ─────────────────────────────
@@ -117,7 +116,7 @@ def evolve(
     console.print(f"  Split: {len(dataset.train)} train / {len(dataset.val)} val / {len(dataset.holdout)} holdout")
 
     # ── 3. Validate constraints on baseline ─────────────────────────────
-    console.print(f"\n[bold]Validating baseline constraints[/bold]")
+    console.print("\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
     baseline_constraints = validator.validate_all(skill["body"], "skill")
     all_pass = True
@@ -132,7 +131,7 @@ def evolve(
         console.print("[yellow]⚠ Baseline skill has constraint violations — proceeding anyway[/yellow]")
 
     # ── 4. Set up DSPy + GEPA optimizer ─────────────────────────────────
-    console.print(f"\n[bold]Configuring optimizer[/bold]")
+    console.print("\n[bold]Configuring optimizer[/bold]")
     console.print(f"  Optimizer: GEPA ({iterations} iterations)")
     console.print(f"  Optimizer model: {optimizer_model}")
     console.print(f"  Eval model: {eval_model}")
@@ -185,7 +184,7 @@ def evolve(
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
-    console.print(f"\n[bold]Validating evolved skill[/bold]")
+    console.print("\n[bold]Validating evolved skill[/bold]")
     evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
     all_pass = True
     for c in evolved_constraints:

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -5,7 +5,6 @@ where the skill text is the optimizable parameter. GEPA can then
 mutate the skill text and evaluate the results.
 """
 
-import re
 from pathlib import Path
 from typing import Optional
 

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -96,9 +96,14 @@ class SkillModule(dspy.Module):
         You are an AI agent following specific skill instructions to complete a task.
         Read the skill instructions carefully and follow the procedure described.
         """
-        skill_instructions: str = dspy.InputField(desc="The skill instructions to follow")
+
+        skill_instructions: str = dspy.InputField(
+            desc="The skill instructions to follow"
+        )
         task_input: str = dspy.InputField(desc="The task to complete")
-        output: str = dspy.OutputField(desc="Your response following the skill instructions")
+        output: str = dspy.OutputField(
+            desc="Your response following the skill instructions"
+        )
 
     def __init__(self, skill_text: str):
         super().__init__()

--- a/generate_report.py
+++ b/generate_report.py
@@ -2,14 +2,13 @@
 
 from reportlab.lib.pagesizes import letter
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
-from reportlab.lib.colors import HexColor, black, white
+from reportlab.lib.colors import HexColor, white
 from reportlab.lib.units import inch
-from reportlab.lib.enums import TA_CENTER, TA_LEFT, TA_JUSTIFY
+from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
 from reportlab.platypus import (
     SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle,
     PageBreak, HRFlowable,
 )
-from reportlab.lib import colors
 from datetime import datetime
 
 

--- a/generate_report.py
+++ b/generate_report.py
@@ -6,14 +6,20 @@ from reportlab.lib.colors import HexColor, white
 from reportlab.lib.units import inch
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
 from reportlab.platypus import (
-    SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle,
-    PageBreak, HRFlowable,
+    SimpleDocTemplate,
+    Paragraph,
+    Spacer,
+    Table,
+    TableStyle,
+    PageBreak,
+    HRFlowable,
 )
 from datetime import datetime
 
 
 def build_report(output_path: str = "reports/phase1_validation_report.pdf"):
     import os
+
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
     doc = SimpleDocTemplate(
@@ -28,212 +34,298 @@ def build_report(output_path: str = "reports/phase1_validation_report.pdf"):
     styles = getSampleStyleSheet()
 
     # Custom styles
-    styles.add(ParagraphStyle(
-        name='Title2',
-        parent=styles['Title'],
-        fontSize=24,
-        spaceAfter=6,
-        textColor=HexColor('#1a1a2e'),
-    ))
-    styles.add(ParagraphStyle(
-        name='Subtitle',
-        parent=styles['Normal'],
-        fontSize=14,
-        textColor=HexColor('#555555'),
-        alignment=TA_CENTER,
-        spaceAfter=20,
-    ))
-    styles.add(ParagraphStyle(
-        name='SectionHead',
-        parent=styles['Heading1'],
-        fontSize=16,
-        spaceBefore=24,
-        spaceAfter=10,
-        textColor=HexColor('#1a1a2e'),
-    ))
-    styles.add(ParagraphStyle(
-        name='SubSection',
-        parent=styles['Heading2'],
-        fontSize=13,
-        spaceBefore=16,
-        spaceAfter=8,
-        textColor=HexColor('#2d2d44'),
-    ))
-    styles.add(ParagraphStyle(
-        name='BodyJust',
-        parent=styles['Normal'],
-        fontSize=10.5,
-        leading=15,
-        alignment=TA_JUSTIFY,
-        spaceAfter=8,
-    ))
-    styles.add(ParagraphStyle(
-        name='CodeBlock',
-        parent=styles['Code'],
-        fontSize=9,
-        leading=12,
-        backColor=HexColor('#f5f5f5'),
-        borderColor=HexColor('#dddddd'),
-        borderWidth=0.5,
-        borderPadding=6,
-        spaceAfter=10,
-    ))
-    styles.add(ParagraphStyle(
-        name='Metric',
-        parent=styles['Normal'],
-        fontSize=11,
-        leading=16,
-        leftIndent=20,
-        spaceAfter=4,
-    ))
-    styles.add(ParagraphStyle(
-        name='Footer',
-        parent=styles['Normal'],
-        fontSize=8,
-        textColor=HexColor('#999999'),
-        alignment=TA_CENTER,
-    ))
+    styles.add(
+        ParagraphStyle(
+            name="Title2",
+            parent=styles["Title"],
+            fontSize=24,
+            spaceAfter=6,
+            textColor=HexColor("#1a1a2e"),
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="Subtitle",
+            parent=styles["Normal"],
+            fontSize=14,
+            textColor=HexColor("#555555"),
+            alignment=TA_CENTER,
+            spaceAfter=20,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="SectionHead",
+            parent=styles["Heading1"],
+            fontSize=16,
+            spaceBefore=24,
+            spaceAfter=10,
+            textColor=HexColor("#1a1a2e"),
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="SubSection",
+            parent=styles["Heading2"],
+            fontSize=13,
+            spaceBefore=16,
+            spaceAfter=8,
+            textColor=HexColor("#2d2d44"),
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="BodyJust",
+            parent=styles["Normal"],
+            fontSize=10.5,
+            leading=15,
+            alignment=TA_JUSTIFY,
+            spaceAfter=8,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="CodeBlock",
+            parent=styles["Code"],
+            fontSize=9,
+            leading=12,
+            backColor=HexColor("#f5f5f5"),
+            borderColor=HexColor("#dddddd"),
+            borderWidth=0.5,
+            borderPadding=6,
+            spaceAfter=10,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="Metric",
+            parent=styles["Normal"],
+            fontSize=11,
+            leading=16,
+            leftIndent=20,
+            spaceAfter=4,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="Footer",
+            parent=styles["Normal"],
+            fontSize=8,
+            textColor=HexColor("#999999"),
+            alignment=TA_CENTER,
+        )
+    )
 
     story = []
 
     # ── TITLE PAGE ──────────────────────────────────────────────────────
     story.append(Spacer(1, 1.5 * inch))
-    story.append(Paragraph("🧬 Hermes Agent Self-Evolution", styles['Title2']))
-    story.append(Paragraph("Phase 1 Validation Report", styles['Subtitle']))
+    story.append(Paragraph("🧬 Hermes Agent Self-Evolution", styles["Title2"]))
+    story.append(Paragraph("Phase 1 Validation Report", styles["Subtitle"]))
     story.append(Spacer(1, 0.3 * inch))
-    story.append(HRFlowable(width="60%", thickness=1, color=HexColor('#cccccc')))
+    story.append(HRFlowable(width="60%", thickness=1, color=HexColor("#cccccc")))
     story.append(Spacer(1, 0.3 * inch))
-    story.append(Paragraph(
-        f"Date: {datetime.now().strftime('%B %d, %Y')}",
-        ParagraphStyle('DateStyle', parent=styles['Normal'], alignment=TA_CENTER,
-                       fontSize=11, textColor=HexColor('#777777'))
-    ))
-    story.append(Paragraph(
-        "Organization: Nous Research",
-        ParagraphStyle('OrgStyle', parent=styles['Normal'], alignment=TA_CENTER,
-                       fontSize=11, textColor=HexColor('#777777'))
-    ))
-    story.append(Paragraph(
-        "Repository: github.com/NousResearch/hermes-agent-self-evolution",
-        ParagraphStyle('RepoStyle', parent=styles['Normal'], alignment=TA_CENTER,
-                       fontSize=10, textColor=HexColor('#999999'))
-    ))
+    story.append(
+        Paragraph(
+            f"Date: {datetime.now().strftime('%B %d, %Y')}",
+            ParagraphStyle(
+                "DateStyle",
+                parent=styles["Normal"],
+                alignment=TA_CENTER,
+                fontSize=11,
+                textColor=HexColor("#777777"),
+            ),
+        )
+    )
+    story.append(
+        Paragraph(
+            "Organization: Nous Research",
+            ParagraphStyle(
+                "OrgStyle",
+                parent=styles["Normal"],
+                alignment=TA_CENTER,
+                fontSize=11,
+                textColor=HexColor("#777777"),
+            ),
+        )
+    )
+    story.append(
+        Paragraph(
+            "Repository: github.com/NousResearch/hermes-agent-self-evolution",
+            ParagraphStyle(
+                "RepoStyle",
+                parent=styles["Normal"],
+                alignment=TA_CENTER,
+                fontSize=10,
+                textColor=HexColor("#999999"),
+            ),
+        )
+    )
 
     story.append(PageBreak())
 
     # ── EXECUTIVE SUMMARY ───────────────────────────────────────────────
-    story.append(Paragraph("Executive Summary", styles['SectionHead']))
-    story.append(Paragraph(
-        "Hermes Agent Self-Evolution is a standalone optimization pipeline that uses DSPy and GEPA "
-        "(Genetic-Pareto Prompt Evolution) to automatically improve Hermes Agent's skills, "
-        "tool descriptions, system prompts, and code through evolutionary search — all via "
-        "API calls with no GPU training required.",
-        styles['BodyJust']
-    ))
-    story.append(Paragraph(
-        "This report documents the Phase 1 validation: the first end-to-end test of the skill "
-        "evolution pipeline. Using MiniMax M2.5 via OpenRouter, we evolved the <b>arxiv</b> skill "
-        "and observed a <b>+39.5% improvement</b> in task completion quality on a held-out validation "
-        "example, demonstrating that the pipeline works and can produce measurably better skills.",
-        styles['BodyJust']
-    ))
+    story.append(Paragraph("Executive Summary", styles["SectionHead"]))
+    story.append(
+        Paragraph(
+            "Hermes Agent Self-Evolution is a standalone optimization pipeline that uses DSPy and GEPA "
+            "(Genetic-Pareto Prompt Evolution) to automatically improve Hermes Agent's skills, "
+            "tool descriptions, system prompts, and code through evolutionary search — all via "
+            "API calls with no GPU training required.",
+            styles["BodyJust"],
+        )
+    )
+    story.append(
+        Paragraph(
+            "This report documents the Phase 1 validation: the first end-to-end test of the skill "
+            "evolution pipeline. Using MiniMax M2.5 via OpenRouter, we evolved the <b>arxiv</b> skill "
+            "and observed a <b>+39.5% improvement</b> in task completion quality on a held-out validation "
+            "example, demonstrating that the pipeline works and can produce measurably better skills.",
+            styles["BodyJust"],
+        )
+    )
 
     # Key result box
     result_data = [
-        ['KEY RESULT'],
-        ['Baseline Score → Optimized Score:   0.408 → 0.569   (+39.5%)'],
+        ["KEY RESULT"],
+        ["Baseline Score → Optimized Score:   0.408 → 0.569   (+39.5%)"],
     ]
     result_table = Table(result_data, colWidths=[5.5 * inch])
-    result_table.setStyle(TableStyle([
-        ('BACKGROUND', (0, 0), (-1, 0), HexColor('#1a1a2e')),
-        ('TEXTCOLOR', (0, 0), (-1, 0), white),
-        ('FONTSIZE', (0, 0), (-1, 0), 12),
-        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-        ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
-        ('BACKGROUND', (0, 1), (-1, -1), HexColor('#e8f5e9')),
-        ('FONTSIZE', (0, 1), (-1, -1), 13),
-        ('FONTNAME', (0, 1), (-1, -1), 'Helvetica-Bold'),
-        ('TEXTCOLOR', (0, 1), (-1, -1), HexColor('#2e7d32')),
-        ('TOPPADDING', (0, 0), (-1, -1), 12),
-        ('BOTTOMPADDING', (0, 0), (-1, -1), 12),
-        ('BOX', (0, 0), (-1, -1), 1, HexColor('#1a1a2e')),
-    ]))
+    result_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), HexColor("#1a1a2e")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), white),
+                ("FONTSIZE", (0, 0), (-1, 0), 12),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                ("BACKGROUND", (0, 1), (-1, -1), HexColor("#e8f5e9")),
+                ("FONTSIZE", (0, 1), (-1, -1), 13),
+                ("FONTNAME", (0, 1), (-1, -1), "Helvetica-Bold"),
+                ("TEXTCOLOR", (0, 1), (-1, -1), HexColor("#2e7d32")),
+                ("TOPPADDING", (0, 0), (-1, -1), 12),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 12),
+                ("BOX", (0, 0), (-1, -1), 1, HexColor("#1a1a2e")),
+            ]
+        )
+    )
     story.append(Spacer(1, 0.2 * inch))
     story.append(result_table)
     story.append(Spacer(1, 0.3 * inch))
 
     # ── BACKGROUND ──────────────────────────────────────────────────────
-    story.append(Paragraph("Background", styles['SectionHead']))
-    story.append(Paragraph(
-        "Hermes Agent is a general-purpose AI agent built by Nous Research that uses tool-calling "
-        "LLMs to complete tasks via terminal commands, file operations, web search, code execution, "
-        "and more. Its behavior is governed by three layers:",
-        styles['BodyJust']
-    ))
+    story.append(Paragraph("Background", styles["SectionHead"]))
+    story.append(
+        Paragraph(
+            "Hermes Agent is a general-purpose AI agent built by Nous Research that uses tool-calling "
+            "LLMs to complete tasks via terminal commands, file operations, web search, code execution, "
+            "and more. Its behavior is governed by three layers:",
+            styles["BodyJust"],
+        )
+    )
 
     layers_data = [
-        ['Layer', 'What It Is', 'How It\'s Currently Improved'],
-        ['Model Weights', 'The underlying LLM (Claude, GPT, etc.)', 'RL training (Tinker-Atropos)'],
-        ['Instructions', 'Skills, system prompts, tool descriptions', 'Manual authoring (static)'],
-        ['Tool Code', 'Python implementations of each tool', 'Manual development'],
+        ["Layer", "What It Is", "How It's Currently Improved"],
+        [
+            "Model Weights",
+            "The underlying LLM (Claude, GPT, etc.)",
+            "RL training (Tinker-Atropos)",
+        ],
+        [
+            "Instructions",
+            "Skills, system prompts, tool descriptions",
+            "Manual authoring (static)",
+        ],
+        ["Tool Code", "Python implementations of each tool", "Manual development"],
     ]
     layers_table = Table(layers_data, colWidths=[1.2 * inch, 2.3 * inch, 2.5 * inch])
-    layers_table.setStyle(TableStyle([
-        ('BACKGROUND', (0, 0), (-1, 0), HexColor('#1a1a2e')),
-        ('TEXTCOLOR', (0, 0), (-1, 0), white),
-        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-        ('FONTSIZE', (0, 0), (-1, -1), 9),
-        ('GRID', (0, 0), (-1, -1), 0.5, HexColor('#cccccc')),
-        ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-        ('TOPPADDING', (0, 0), (-1, -1), 6),
-        ('BOTTOMPADDING', (0, 0), (-1, -1), 6),
-        ('LEFTPADDING', (0, 0), (-1, -1), 8),
-        ('BACKGROUND', (0, 2), (-1, 2), HexColor('#fff9c4')),
-    ]))
+    layers_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), HexColor("#1a1a2e")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("GRID", (0, 0), (-1, -1), 0.5, HexColor("#cccccc")),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                ("LEFTPADDING", (0, 0), (-1, -1), 8),
+                ("BACKGROUND", (0, 2), (-1, 2), HexColor("#fff9c4")),
+            ]
+        )
+    )
     story.append(layers_table)
     story.append(Spacer(1, 0.15 * inch))
-    story.append(Paragraph(
-        "The <b>instructions layer</b> (highlighted) is the sweet spot for automated optimization: "
-        "it's pure text that LLMs can meaningfully mutate, changes are immediately deployable, and "
-        "results are directly measurable. Hermes Agent Self-Evolution targets this layer.",
-        styles['BodyJust']
-    ))
+    story.append(
+        Paragraph(
+            "The <b>instructions layer</b> (highlighted) is the sweet spot for automated optimization: "
+            "it's pure text that LLMs can meaningfully mutate, changes are immediately deployable, and "
+            "results are directly measurable. Hermes Agent Self-Evolution targets this layer.",
+            styles["BodyJust"],
+        )
+    )
 
     # ── APPROACH ────────────────────────────────────────────────────────
-    story.append(Paragraph("Approach: Evolutionary Skill Optimization", styles['SectionHead']))
+    story.append(
+        Paragraph("Approach: Evolutionary Skill Optimization", styles["SectionHead"])
+    )
 
-    story.append(Paragraph("Three Optimization Engines", styles['SubSection']))
+    story.append(Paragraph("Three Optimization Engines", styles["SubSection"]))
     engines_data = [
-        ['Engine', 'What It Optimizes', 'License', 'Role'],
-        ['DSPy + GEPA', 'Skills, prompts, tool descriptions', 'MIT', 'Primary optimizer'],
-        ['DSPy MIPROv2', 'Few-shot examples, instruction text', 'MIT', 'Fallback optimizer'],
-        ['Darwinian Evolver', 'Code files, algorithms', 'AGPL v3', 'Code evolution (Phase 4)'],
+        ["Engine", "What It Optimizes", "License", "Role"],
+        [
+            "DSPy + GEPA",
+            "Skills, prompts, tool descriptions",
+            "MIT",
+            "Primary optimizer",
+        ],
+        [
+            "DSPy MIPROv2",
+            "Few-shot examples, instruction text",
+            "MIT",
+            "Fallback optimizer",
+        ],
+        [
+            "Darwinian Evolver",
+            "Code files, algorithms",
+            "AGPL v3",
+            "Code evolution (Phase 4)",
+        ],
     ]
-    engines_table = Table(engines_data, colWidths=[1.4 * inch, 2.0 * inch, 0.8 * inch, 1.8 * inch])
-    engines_table.setStyle(TableStyle([
-        ('BACKGROUND', (0, 0), (-1, 0), HexColor('#1a1a2e')),
-        ('TEXTCOLOR', (0, 0), (-1, 0), white),
-        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-        ('FONTSIZE', (0, 0), (-1, -1), 9),
-        ('GRID', (0, 0), (-1, -1), 0.5, HexColor('#cccccc')),
-        ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-        ('TOPPADDING', (0, 0), (-1, -1), 6),
-        ('BOTTOMPADDING', (0, 0), (-1, -1), 6),
-        ('LEFTPADDING', (0, 0), (-1, -1), 6),
-    ]))
+    engines_table = Table(
+        engines_data, colWidths=[1.4 * inch, 2.0 * inch, 0.8 * inch, 1.8 * inch]
+    )
+    engines_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), HexColor("#1a1a2e")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("GRID", (0, 0), (-1, -1), 0.5, HexColor("#cccccc")),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+            ]
+        )
+    )
     story.append(engines_table)
 
-    story.append(Paragraph(
-        "<b>GEPA</b> (Genetic-Pareto Prompt Evolution) is the star engine — an ICLR 2026 Oral paper "
-        "from Stanford/UC Berkeley. Unlike traditional evolutionary search that only sees pass/fail "
-        "scores, GEPA reads full execution traces to understand <i>why</i> things failed, then proposes "
-        "targeted mutations. It outperforms reinforcement learning (GRPO) by +6% with 35x fewer "
-        "rollouts, and outperforms DSPy's previous best optimizer (MIPROv2) by +10%. It works with "
-        "as few as 3 training examples.",
-        styles['BodyJust']
-    ))
+    story.append(
+        Paragraph(
+            "<b>GEPA</b> (Genetic-Pareto Prompt Evolution) is the star engine — an ICLR 2026 Oral paper "
+            "from Stanford/UC Berkeley. Unlike traditional evolutionary search that only sees pass/fail "
+            "scores, GEPA reads full execution traces to understand <i>why</i> things failed, then proposes "
+            "targeted mutations. It outperforms reinforcement learning (GRPO) by +6% with 35x fewer "
+            "rollouts, and outperforms DSPy's previous best optimizer (MIPROv2) by +10%. It works with "
+            "as few as 3 training examples.",
+            styles["BodyJust"],
+        )
+    )
 
-    story.append(Paragraph("The Optimization Pipeline", styles['SubSection']))
+    story.append(Paragraph("The Optimization Pipeline", styles["SubSection"]))
     pipeline_steps = [
         "1. <b>Load skill</b> — Read the SKILL.md file from the hermes-agent repository",
         "2. <b>Generate eval dataset</b> — An LLM reads the skill and generates realistic "
@@ -247,136 +339,173 @@ def build_report(output_path: str = "reports/phase1_validation_report.pdf"):
         "7. <b>Report</b> — Before/after comparison with full metrics",
     ]
     for step in pipeline_steps:
-        story.append(Paragraph(step, styles['Metric']))
+        story.append(Paragraph(step, styles["Metric"]))
     story.append(Spacer(1, 0.1 * inch))
-    story.append(Paragraph(
-        "Critically, <b>no GPU training is involved</b>. The entire pipeline operates via LLM API calls — "
-        "mutating text, evaluating results, and selecting the best variants. A typical optimization run "
-        "costs $2-10 in API credits.",
-        styles['BodyJust']
-    ))
+    story.append(
+        Paragraph(
+            "Critically, <b>no GPU training is involved</b>. The entire pipeline operates via LLM API calls — "
+            "mutating text, evaluating results, and selecting the best variants. A typical optimization run "
+            "costs $2-10 in API credits.",
+            styles["BodyJust"],
+        )
+    )
 
     # ── EXPERIMENT ──────────────────────────────────────────────────────
-    story.append(Paragraph("Phase 1 Experiment", styles['SectionHead']))
+    story.append(Paragraph("Phase 1 Experiment", styles["SectionHead"]))
 
-    story.append(Paragraph("Configuration", styles['SubSection']))
+    story.append(Paragraph("Configuration", styles["SubSection"]))
     config_data = [
-        ['Parameter', 'Value'],
-        ['Target Skill', 'arxiv (arXiv paper search and retrieval)'],
-        ['Skill Size', '10,175 characters'],
-        ['Model', 'MiniMax M2.5 via OpenRouter'],
-        ['Optimizer', 'DSPy BootstrapFewShot'],
-        ['Training Examples', '3 (from 7 synthetic total)'],
-        ['Validation Examples', '2 (held-out)'],
-        ['Max Bootstrapped Demos', '2'],
-        ['Optimization Rounds', '1'],
-        ['Total Optimization Time', '< 60 seconds'],
-        ['Estimated Cost', '< $0.50'],
+        ["Parameter", "Value"],
+        ["Target Skill", "arxiv (arXiv paper search and retrieval)"],
+        ["Skill Size", "10,175 characters"],
+        ["Model", "MiniMax M2.5 via OpenRouter"],
+        ["Optimizer", "DSPy BootstrapFewShot"],
+        ["Training Examples", "3 (from 7 synthetic total)"],
+        ["Validation Examples", "2 (held-out)"],
+        ["Max Bootstrapped Demos", "2"],
+        ["Optimization Rounds", "1"],
+        ["Total Optimization Time", "< 60 seconds"],
+        ["Estimated Cost", "< $0.50"],
     ]
     config_table = Table(config_data, colWidths=[2.2 * inch, 3.8 * inch])
-    config_table.setStyle(TableStyle([
-        ('BACKGROUND', (0, 0), (-1, 0), HexColor('#1a1a2e')),
-        ('TEXTCOLOR', (0, 0), (-1, 0), white),
-        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-        ('FONTSIZE', (0, 0), (-1, -1), 9.5),
-        ('GRID', (0, 0), (-1, -1), 0.5, HexColor('#cccccc')),
-        ('TOPPADDING', (0, 0), (-1, -1), 5),
-        ('BOTTOMPADDING', (0, 0), (-1, -1), 5),
-        ('LEFTPADDING', (0, 0), (-1, -1), 8),
-        ('FONTNAME', (0, 1), (0, -1), 'Helvetica-Bold'),
-    ]))
+    config_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), HexColor("#1a1a2e")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9.5),
+                ("GRID", (0, 0), (-1, -1), 0.5, HexColor("#cccccc")),
+                ("TOPPADDING", (0, 0), (-1, -1), 5),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
+                ("LEFTPADDING", (0, 0), (-1, -1), 8),
+                ("FONTNAME", (0, 1), (0, -1), "Helvetica-Bold"),
+            ]
+        )
+    )
     story.append(config_table)
 
-    story.append(Paragraph("Evaluation Dataset", styles['SubSection']))
-    story.append(Paragraph(
-        "The evaluation dataset was synthetically generated by MiniMax M2.5. Given the full arxiv "
-        "skill text, the model generated 7 realistic test cases with rubric-based expected behaviors. "
-        "Examples of generated test cases:",
-        styles['BodyJust']
-    ))
+    story.append(Paragraph("Evaluation Dataset", styles["SubSection"]))
+    story.append(
+        Paragraph(
+            "The evaluation dataset was synthetically generated by MiniMax M2.5. Given the full arxiv "
+            "skill text, the model generated 7 realistic test cases with rubric-based expected behaviors. "
+            "Examples of generated test cases:",
+            styles["BodyJust"],
+        )
+    )
 
     examples_data = [
-        ['Task Input', 'Expected Behavior (Rubric)'],
-        ['Generate a BibTeX entry for\npaper 2402.03300',
-         'Should query arXiv API, parse metadata\n(title, authors, year), format as BibTeX'],
-        ['Find papers by author\n\'Ian Goodfellow\' with citations',
-         'Should search Semantic Scholar endpoint,\nretrieve author profile and h-index'],
-        ['Find recent papers about\nlarge language models',
-         'Should search arXiv with relevant query,\napply date filters, return sorted results'],
+        ["Task Input", "Expected Behavior (Rubric)"],
+        [
+            "Generate a BibTeX entry for\npaper 2402.03300",
+            "Should query arXiv API, parse metadata\n(title, authors, year), format as BibTeX",
+        ],
+        [
+            "Find papers by author\n'Ian Goodfellow' with citations",
+            "Should search Semantic Scholar endpoint,\nretrieve author profile and h-index",
+        ],
+        [
+            "Find recent papers about\nlarge language models",
+            "Should search arXiv with relevant query,\napply date filters, return sorted results",
+        ],
     ]
     examples_table = Table(examples_data, colWidths=[2.5 * inch, 3.5 * inch])
-    examples_table.setStyle(TableStyle([
-        ('BACKGROUND', (0, 0), (-1, 0), HexColor('#1a1a2e')),
-        ('TEXTCOLOR', (0, 0), (-1, 0), white),
-        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-        ('FONTSIZE', (0, 0), (-1, -1), 9),
-        ('GRID', (0, 0), (-1, -1), 0.5, HexColor('#cccccc')),
-        ('VALIGN', (0, 0), (-1, -1), 'TOP'),
-        ('TOPPADDING', (0, 0), (-1, -1), 6),
-        ('BOTTOMPADDING', (0, 0), (-1, -1), 6),
-        ('LEFTPADDING', (0, 0), (-1, -1), 6),
-    ]))
+    examples_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), HexColor("#1a1a2e")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("GRID", (0, 0), (-1, -1), 0.5, HexColor("#cccccc")),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+            ]
+        )
+    )
     story.append(examples_table)
 
-    story.append(Paragraph("Fitness Function", styles['SubSection']))
-    story.append(Paragraph(
-        "Fitness was measured using keyword overlap between the expected behavior rubric and the "
-        "agent's actual output. For each evaluation example, the score is computed as:",
-        styles['BodyJust']
-    ))
-    story.append(Paragraph(
-        "<font face='Courier' size=9>score = 0.3 + 0.7 × (|expected_words ∩ output_words| / |expected_words|)</font>",
-        ParagraphStyle('Formula', parent=styles['Normal'], alignment=TA_CENTER,
-                       spaceBefore=8, spaceAfter=8, fontSize=10)
-    ))
-    story.append(Paragraph(
-        "This provides a fast proxy for semantic similarity. The full pipeline also supports "
-        "LLM-as-judge scoring with multi-dimensional rubrics (correctness, procedure-following, "
-        "conciseness), but the heuristic scorer was used for this validation to minimize API costs.",
-        styles['BodyJust']
-    ))
+    story.append(Paragraph("Fitness Function", styles["SubSection"]))
+    story.append(
+        Paragraph(
+            "Fitness was measured using keyword overlap between the expected behavior rubric and the "
+            "agent's actual output. For each evaluation example, the score is computed as:",
+            styles["BodyJust"],
+        )
+    )
+    story.append(
+        Paragraph(
+            "<font face='Courier' size=9>score = 0.3 + 0.7 × (|expected_words ∩ output_words| / |expected_words|)</font>",
+            ParagraphStyle(
+                "Formula",
+                parent=styles["Normal"],
+                alignment=TA_CENTER,
+                spaceBefore=8,
+                spaceAfter=8,
+                fontSize=10,
+            ),
+        )
+    )
+    story.append(
+        Paragraph(
+            "This provides a fast proxy for semantic similarity. The full pipeline also supports "
+            "LLM-as-judge scoring with multi-dimensional rubrics (correctness, procedure-following, "
+            "conciseness), but the heuristic scorer was used for this validation to minimize API costs.",
+            styles["BodyJust"],
+        )
+    )
 
     # ── RESULTS ─────────────────────────────────────────────────────────
-    story.append(Paragraph("Results", styles['SectionHead']))
+    story.append(Paragraph("Results", styles["SectionHead"]))
 
     results_data = [
-        ['Metric', 'Baseline', 'Optimized', 'Change'],
-        ['Validation Example 1', '0.408', '0.569', '+39.5%'],
-        ['Validation Example 2', '0.374', '0.374', '0.0%'],
-        ['Average', '0.391', '0.472', '+20.7%'],
+        ["Metric", "Baseline", "Optimized", "Change"],
+        ["Validation Example 1", "0.408", "0.569", "+39.5%"],
+        ["Validation Example 2", "0.374", "0.374", "0.0%"],
+        ["Average", "0.391", "0.472", "+20.7%"],
     ]
-    results_table = Table(results_data, colWidths=[1.8 * inch, 1.2 * inch, 1.2 * inch, 1.3 * inch])
-    results_table.setStyle(TableStyle([
-        ('BACKGROUND', (0, 0), (-1, 0), HexColor('#1a1a2e')),
-        ('TEXTCOLOR', (0, 0), (-1, 0), white),
-        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-        ('FONTSIZE', (0, 0), (-1, -1), 10.5),
-        ('GRID', (0, 0), (-1, -1), 0.5, HexColor('#cccccc')),
-        ('ALIGN', (1, 0), (-1, -1), 'CENTER'),
-        ('TOPPADDING', (0, 0), (-1, -1), 8),
-        ('BOTTOMPADDING', (0, 0), (-1, -1), 8),
-        ('FONTNAME', (0, -1), (-1, -1), 'Helvetica-Bold'),
-        ('BACKGROUND', (3, 1), (3, 1), HexColor('#e8f5e9')),
-        ('TEXTCOLOR', (3, 1), (3, 1), HexColor('#2e7d32')),
-        ('FONTNAME', (3, 1), (3, 1), 'Helvetica-Bold'),
-        ('BACKGROUND', (0, -1), (-1, -1), HexColor('#f5f5f5')),
-    ]))
+    results_table = Table(
+        results_data, colWidths=[1.8 * inch, 1.2 * inch, 1.2 * inch, 1.3 * inch]
+    )
+    results_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), HexColor("#1a1a2e")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 10.5),
+                ("GRID", (0, 0), (-1, -1), 0.5, HexColor("#cccccc")),
+                ("ALIGN", (1, 0), (-1, -1), "CENTER"),
+                ("TOPPADDING", (0, 0), (-1, -1), 8),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+                ("FONTNAME", (0, -1), (-1, -1), "Helvetica-Bold"),
+                ("BACKGROUND", (3, 1), (3, 1), HexColor("#e8f5e9")),
+                ("TEXTCOLOR", (3, 1), (3, 1), HexColor("#2e7d32")),
+                ("FONTNAME", (3, 1), (3, 1), "Helvetica-Bold"),
+                ("BACKGROUND", (0, -1), (-1, -1), HexColor("#f5f5f5")),
+            ]
+        )
+    )
     story.append(results_table)
     story.append(Spacer(1, 0.15 * inch))
 
-    story.append(Paragraph(
-        "The optimized skill showed a <b>+39.5% improvement</b> on the first validation example "
-        "and maintained parity on the second. The average improvement across both examples was "
-        "<b>+20.7%</b>. This was achieved with the simplest DSPy optimizer (BootstrapFewShot) using "
-        "only 3 training examples and a single optimization round completing in under 60 seconds.",
-        styles['BodyJust']
-    ))
+    story.append(
+        Paragraph(
+            "The optimized skill showed a <b>+39.5% improvement</b> on the first validation example "
+            "and maintained parity on the second. The average improvement across both examples was "
+            "<b>+20.7%</b>. This was achieved with the simplest DSPy optimizer (BootstrapFewShot) using "
+            "only 3 training examples and a single optimization round completing in under 60 seconds.",
+            styles["BodyJust"],
+        )
+    )
 
-    story.append(Paragraph("How the Improvement Was Achieved", styles['SubSection']))
-    story.append(Paragraph(
-        "DSPy's BootstrapFewShot optimizer works by:",
-        styles['BodyJust']
-    ))
+    story.append(Paragraph("How the Improvement Was Achieved", styles["SubSection"]))
+    story.append(
+        Paragraph("DSPy's BootstrapFewShot optimizer works by:", styles["BodyJust"])
+    )
     improve_steps = [
         "1. Running the baseline skill module on each training example",
         "2. Collecting successful execution traces (where the output scored well)",
@@ -384,87 +513,128 @@ def build_report(output_path: str = "reports/phase1_validation_report.pdf"):
         "4. Injecting these demonstrations into the optimized module's prompt",
     ]
     for step in improve_steps:
-        story.append(Paragraph(step, styles['Metric']))
+        story.append(Paragraph(step, styles["Metric"]))
     story.append(Spacer(1, 0.1 * inch))
-    story.append(Paragraph(
-        "The key insight is that the optimizer doesn't rewrite the skill — it <b>augments</b> the skill's "
-        "instructions with concrete examples of successful execution. The model learns from its own "
-        "best outputs, creating a positive feedback loop. More powerful optimizers like GEPA and MIPROv2 "
-        "can additionally rewrite the instruction text itself, potentially yielding larger improvements.",
-        styles['BodyJust']
-    ))
+    story.append(
+        Paragraph(
+            "The key insight is that the optimizer doesn't rewrite the skill — it <b>augments</b> the skill's "
+            "instructions with concrete examples of successful execution. The model learns from its own "
+            "best outputs, creating a positive feedback loop. More powerful optimizers like GEPA and MIPROv2 "
+            "can additionally rewrite the instruction text itself, potentially yielding larger improvements.",
+            styles["BodyJust"],
+        )
+    )
 
     # ── SAFETY ──────────────────────────────────────────────────────────
-    story.append(Paragraph("Safety and Guardrails", styles['SectionHead']))
-    story.append(Paragraph(
-        "Every evolved variant must pass all of the following constraints before deployment:",
-        styles['BodyJust']
-    ))
+    story.append(Paragraph("Safety and Guardrails", styles["SectionHead"]))
+    story.append(
+        Paragraph(
+            "Every evolved variant must pass all of the following constraints before deployment:",
+            styles["BodyJust"],
+        )
+    )
     safety_data = [
-        ['Constraint', 'Enforcement', 'Status'],
-        ['Full test suite', 'pytest must pass 100% (2550+ tests)', 'Implemented'],
-        ['Size limits', 'Skills ≤15KB, tool descs ≤500 chars', 'Implemented'],
-        ['Growth limit', 'Max +20% over baseline size', 'Implemented'],
-        ['Structural integrity', 'Valid YAML frontmatter required', 'Implemented'],
-        ['Caching compatibility', 'No mid-conversation changes', 'By design'],
-        ['Deployment via PR', 'Human review required, never auto-merge', 'By design'],
-        ['Benchmark regression', 'TBLite/YC-Bench score must hold', 'Planned (Phase 2+)'],
+        ["Constraint", "Enforcement", "Status"],
+        ["Full test suite", "pytest must pass 100% (2550+ tests)", "Implemented"],
+        ["Size limits", "Skills ≤15KB, tool descs ≤500 chars", "Implemented"],
+        ["Growth limit", "Max +20% over baseline size", "Implemented"],
+        ["Structural integrity", "Valid YAML frontmatter required", "Implemented"],
+        ["Caching compatibility", "No mid-conversation changes", "By design"],
+        ["Deployment via PR", "Human review required, never auto-merge", "By design"],
+        [
+            "Benchmark regression",
+            "TBLite/YC-Bench score must hold",
+            "Planned (Phase 2+)",
+        ],
     ]
     safety_table = Table(safety_data, colWidths=[1.6 * inch, 2.8 * inch, 1.1 * inch])
-    safety_table.setStyle(TableStyle([
-        ('BACKGROUND', (0, 0), (-1, 0), HexColor('#1a1a2e')),
-        ('TEXTCOLOR', (0, 0), (-1, 0), white),
-        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-        ('FONTSIZE', (0, 0), (-1, -1), 9),
-        ('GRID', (0, 0), (-1, -1), 0.5, HexColor('#cccccc')),
-        ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-        ('TOPPADDING', (0, 0), (-1, -1), 5),
-        ('BOTTOMPADDING', (0, 0), (-1, -1), 5),
-        ('LEFTPADDING', (0, 0), (-1, -1), 6),
-    ]))
+    safety_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), HexColor("#1a1a2e")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("GRID", (0, 0), (-1, -1), 0.5, HexColor("#cccccc")),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("TOPPADDING", (0, 0), (-1, -1), 5),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+            ]
+        )
+    )
     story.append(safety_table)
     story.append(Spacer(1, 0.1 * inch))
-    story.append(Paragraph(
-        "The hermes-agent repository is never modified directly. All evolution output is written "
-        "to the hermes-agent-self-evolution repository, and improvements are proposed as pull requests "
-        "against hermes-agent for human review.",
-        styles['BodyJust']
-    ))
+    story.append(
+        Paragraph(
+            "The hermes-agent repository is never modified directly. All evolution output is written "
+            "to the hermes-agent-self-evolution repository, and improvements are proposed as pull requests "
+            "against hermes-agent for human review.",
+            styles["BodyJust"],
+        )
+    )
 
     # ── ROADMAP ─────────────────────────────────────────────────────────
-    story.append(Paragraph("Roadmap", styles['SectionHead']))
+    story.append(Paragraph("Roadmap", styles["SectionHead"]))
     roadmap_data = [
-        ['Phase', 'Target', 'Engine', 'Timeline', 'Status'],
-        ['Phase 1', 'Skill files (SKILL.md)', 'DSPy + GEPA', '3-4 weeks', 'Validated ✓'],
-        ['Phase 2', 'Tool descriptions', 'DSPy + GEPA', '2-3 weeks', 'Planned'],
-        ['Phase 3', 'System prompt sections', 'DSPy + GEPA', '2-3 weeks', 'Planned'],
-        ['Phase 4', 'Tool implementation code', 'Darwinian Evolver', '3-4 weeks', 'Planned'],
-        ['Phase 5', 'Continuous improvement', 'Automated pipeline', '2 weeks', 'Planned'],
+        ["Phase", "Target", "Engine", "Timeline", "Status"],
+        [
+            "Phase 1",
+            "Skill files (SKILL.md)",
+            "DSPy + GEPA",
+            "3-4 weeks",
+            "Validated ✓",
+        ],
+        ["Phase 2", "Tool descriptions", "DSPy + GEPA", "2-3 weeks", "Planned"],
+        ["Phase 3", "System prompt sections", "DSPy + GEPA", "2-3 weeks", "Planned"],
+        [
+            "Phase 4",
+            "Tool implementation code",
+            "Darwinian Evolver",
+            "3-4 weeks",
+            "Planned",
+        ],
+        [
+            "Phase 5",
+            "Continuous improvement",
+            "Automated pipeline",
+            "2 weeks",
+            "Planned",
+        ],
     ]
-    roadmap_table = Table(roadmap_data, colWidths=[0.9 * inch, 1.6 * inch, 1.3 * inch, 1.0 * inch, 1.0 * inch])
-    roadmap_table.setStyle(TableStyle([
-        ('BACKGROUND', (0, 0), (-1, 0), HexColor('#1a1a2e')),
-        ('TEXTCOLOR', (0, 0), (-1, 0), white),
-        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-        ('FONTSIZE', (0, 0), (-1, -1), 9),
-        ('GRID', (0, 0), (-1, -1), 0.5, HexColor('#cccccc')),
-        ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-        ('TOPPADDING', (0, 0), (-1, -1), 5),
-        ('BOTTOMPADDING', (0, 0), (-1, -1), 5),
-        ('LEFTPADDING', (0, 0), (-1, -1), 6),
-        ('BACKGROUND', (0, 1), (-1, 1), HexColor('#e8f5e9')),
-    ]))
+    roadmap_table = Table(
+        roadmap_data,
+        colWidths=[0.9 * inch, 1.6 * inch, 1.3 * inch, 1.0 * inch, 1.0 * inch],
+    )
+    roadmap_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), HexColor("#1a1a2e")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("GRID", (0, 0), (-1, -1), 0.5, HexColor("#cccccc")),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("TOPPADDING", (0, 0), (-1, -1), 5),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                ("BACKGROUND", (0, 1), (-1, 1), HexColor("#e8f5e9")),
+            ]
+        )
+    )
     story.append(roadmap_table)
     story.append(Spacer(1, 0.15 * inch))
-    story.append(Paragraph(
-        "Each phase must demonstrate measurable improvement and pass benchmark regression gates "
-        "before proceeding. If a phase does not produce meaningful gains, we reassess before continuing. "
-        "The full plan is documented in PLAN.md within the repository.",
-        styles['BodyJust']
-    ))
+    story.append(
+        Paragraph(
+            "Each phase must demonstrate measurable improvement and pass benchmark regression gates "
+            "before proceeding. If a phase does not produce meaningful gains, we reassess before continuing. "
+            "The full plan is documented in PLAN.md within the repository.",
+            styles["BodyJust"],
+        )
+    )
 
     # ── NEXT STEPS ──────────────────────────────────────────────────────
-    story.append(Paragraph("Immediate Next Steps", styles['SectionHead']))
+    story.append(Paragraph("Immediate Next Steps", styles["SectionHead"]))
     next_steps = [
         "1. <b>Run GEPA optimizer</b> — The most powerful optimizer, which reads execution traces "
         "for reflective mutation. Requires longer runtime (15-30 minutes) but expected to yield "
@@ -479,20 +649,23 @@ def build_report(output_path: str = "reports/phase1_validation_report.pdf"):
         "skills, including full metrics and diffs.",
     ]
     for step in next_steps:
-        story.append(Paragraph(step, styles['Metric']))
+        story.append(Paragraph(step, styles["Metric"]))
 
     # ── FOOTER ──────────────────────────────────────────────────────────
     story.append(Spacer(1, 0.5 * inch))
-    story.append(HRFlowable(width="100%", thickness=0.5, color=HexColor('#cccccc')))
+    story.append(HRFlowable(width="100%", thickness=0.5, color=HexColor("#cccccc")))
     story.append(Spacer(1, 0.1 * inch))
-    story.append(Paragraph(
-        f"Hermes Agent Self-Evolution — Phase 1 Validation Report — {datetime.now().strftime('%B %d, %Y')} — Nous Research",
-        styles['Footer']
-    ))
-    story.append(Paragraph(
-        "github.com/NousResearch/hermes-agent-self-evolution",
-        styles['Footer']
-    ))
+    story.append(
+        Paragraph(
+            f"Hermes Agent Self-Evolution — Phase 1 Validation Report — {datetime.now().strftime('%B %d, %Y')} — Nous Research",
+            styles["Footer"],
+        )
+    )
+    story.append(
+        Paragraph(
+            "github.com/NousResearch/hermes-agent-self-evolution", styles["Footer"]
+        )
+    )
 
     doc.build(story)
     return output_path

--- a/tests/core/test_constraints.py
+++ b/tests/core/test_constraints.py
@@ -88,7 +88,9 @@ class TestSkillStructure:
 
 class TestValidateAll:
     def test_valid_skill_passes_all(self, validator):
-        skill = "---\nname: test\ndescription: Test skill\n---\n\n# Procedure\n1. Do thing"
+        skill = (
+            "---\nname: test\ndescription: Test skill\n---\n\n# Procedure\n1. Do thing"
+        )
         results = validator.validate_all(skill, "skill")
         assert all(r.passed for r in results)
 

--- a/tests/core/test_external_importers.py
+++ b/tests/core/test_external_importers.py
@@ -15,7 +15,6 @@ Tests cover:
 """
 
 import json
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 

--- a/tests/core/test_external_importers.py
+++ b/tests/core/test_external_importers.py
@@ -235,7 +235,7 @@ class TestScoringJsonParser:
 
     def test_non_dict_json_returns_none(self):
         """A JSON array or string should return None (we need a dict)."""
-        assert _parse_scoring_json('[1, 2, 3]') is None
+        assert _parse_scoring_json("[1, 2, 3]") is None
         assert _parse_scoring_json('"just a string"') is None
 
     def test_nested_braces_in_values(self):
@@ -257,9 +257,33 @@ class TestClaudeCodeImporter:
     def test_parses_history_jsonl(self, tmp_path):
         history = tmp_path / "history.jsonl"
         history.write_text(
-            json.dumps({"display": "sort my slack messages by topic", "timestamp": 1700000000000, "project": "/test", "sessionId": "abc"}) + "\n"
-            + json.dumps({"display": "yes go", "timestamp": 1700000001000, "project": "/test", "sessionId": "abc"}) + "\n"
-            + json.dumps({"display": "here is sk-ant-api03-SECRETKEY123456789012345678 the key", "timestamp": 1700000002000, "project": "/test", "sessionId": "abc"}) + "\n"
+            json.dumps(
+                {
+                    "display": "sort my slack messages by topic",
+                    "timestamp": 1700000000000,
+                    "project": "/test",
+                    "sessionId": "abc",
+                }
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "display": "yes go",
+                    "timestamp": 1700000001000,
+                    "project": "/test",
+                    "sessionId": "abc",
+                }
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "display": "here is sk-ant-api03-SECRETKEY123456789012345678 the key",
+                    "timestamp": 1700000002000,
+                    "project": "/test",
+                    "sessionId": "abc",
+                }
+            )
+            + "\n"
         )
 
         with patch.object(ClaudeCodeImporter, "HISTORY_PATH", history):
@@ -272,14 +296,23 @@ class TestClaudeCodeImporter:
         assert messages[0]["project"] == "/test"
 
     def test_handles_missing_file(self, tmp_path):
-        with patch.object(ClaudeCodeImporter, "HISTORY_PATH", tmp_path / "nonexistent.jsonl"):
+        with patch.object(
+            ClaudeCodeImporter, "HISTORY_PATH", tmp_path / "nonexistent.jsonl"
+        ):
             messages = ClaudeCodeImporter.extract_messages()
         assert messages == []
 
     def test_respects_limit(self, tmp_path):
         history = tmp_path / "history.jsonl"
         lines = [
-            json.dumps({"display": f"message number {i} with enough length to pass", "timestamp": i, "project": "/test", "sessionId": "s"})
+            json.dumps(
+                {
+                    "display": f"message number {i} with enough length to pass",
+                    "timestamp": i,
+                    "project": "/test",
+                    "sessionId": "s",
+                }
+            )
             for i in range(100)
         ]
         history.write_text("\n".join(lines) + "\n")
@@ -293,7 +326,15 @@ class TestClaudeCodeImporter:
         history = tmp_path / "history.jsonl"
         history.write_text(
             "this is not json\n"
-            + json.dumps({"display": "valid message with sufficient length", "timestamp": 1, "project": "/test", "sessionId": "s"}) + "\n"
+            + json.dumps(
+                {
+                    "display": "valid message with sufficient length",
+                    "timestamp": 1,
+                    "project": "/test",
+                    "sessionId": "s",
+                }
+            )
+            + "\n"
             + "{broken\n"
         )
 
@@ -306,7 +347,15 @@ class TestClaudeCodeImporter:
         history = tmp_path / "history.jsonl"
         history.write_text(
             "\n\n"
-            + json.dumps({"display": "valid message with enough length", "timestamp": 1, "project": "/test", "sessionId": "s"}) + "\n"
+            + json.dumps(
+                {
+                    "display": "valid message with enough length",
+                    "timestamp": 1,
+                    "project": "/test",
+                    "sessionId": "s",
+                }
+            )
+            + "\n"
             + "\n"
         )
 
@@ -323,14 +372,27 @@ class TestCopilotImporter:
     def test_parses_events_jsonl(self, tmp_path):
         session_dir = tmp_path / "session-state" / "test-session-1"
         session_dir.mkdir(parents=True)
-        (session_dir / "workspace.yaml").write_text("id: test-session-1\ncwd: /Users/test/project\n")
+        (session_dir / "workspace.yaml").write_text(
+            "id: test-session-1\ncwd: /Users/test/project\n"
+        )
 
         events = [
             {"type": "session.start", "data": {"sessionId": "test-session-1"}},
-            {"type": "user.message", "data": {"content": "sort these emails into categories for the team"}},
-            {"type": "assistant.message", "data": {"content": "I'll categorize your emails into the following topics..."}},
+            {
+                "type": "user.message",
+                "data": {"content": "sort these emails into categories for the team"},
+            },
+            {
+                "type": "assistant.message",
+                "data": {
+                    "content": "I'll categorize your emails into the following topics..."
+                },
+            },
             {"type": "user.message", "data": {"content": "now do the second batch"}},
-            {"type": "assistant.message", "data": {"content": "Here are the categories for batch 2..."}},
+            {
+                "type": "assistant.message",
+                "data": {"content": "Here are the categories for batch 2..."},
+            },
         ]
         (session_dir / "events.jsonl").write_text(
             "\n".join(json.dumps(e) for e in events) + "\n"
@@ -340,8 +402,14 @@ class TestCopilotImporter:
             messages = CopilotImporter.extract_messages()
 
         assert len(messages) == 2
-        assert messages[0]["task_input"] == "sort these emails into categories for the team"
-        assert messages[0]["assistant_response"] == "I'll categorize your emails into the following topics..."
+        assert (
+            messages[0]["task_input"]
+            == "sort these emails into categories for the team"
+        )
+        assert (
+            messages[0]["assistant_response"]
+            == "I'll categorize your emails into the following topics..."
+        )
         assert messages[0]["source"] == "copilot"
         assert messages[0]["project"] == "/Users/test/project"
 
@@ -351,7 +419,12 @@ class TestCopilotImporter:
         (session_dir / "workspace.yaml").write_text("id: test-2\ncwd: /test\n")
 
         events = [
-            {"type": "user.message", "data": {"content": "here is my key sk-ant-api03-SECRET123456789012345678901234"}},
+            {
+                "type": "user.message",
+                "data": {
+                    "content": "here is my key sk-ant-api03-SECRET123456789012345678901234"
+                },
+            },
             {"type": "assistant.message", "data": {"content": "I see your API key"}},
         ]
         (session_dir / "events.jsonl").write_text(
@@ -375,7 +448,10 @@ class TestCopilotImporter:
         (session_dir / "workspace.yaml").write_text("cwd: /test\n")
 
         events = [
-            {"type": "user.message", "data": {"content": "hello this is a long enough message"}},
+            {
+                "type": "user.message",
+                "data": {"content": "hello this is a long enough message"},
+            },
             # No assistant response follows
         ]
         (session_dir / "events.jsonl").write_text(
@@ -394,9 +470,18 @@ class TestCopilotImporter:
         (session_dir / "workspace.yaml").write_text("cwd: /test\n")
 
         events = [
-            {"type": "user.message", "data": {"content": "explain this code in detail please"}},
-            {"type": "assistant.message", "data": {"content": "First, the function validates input."}},
-            {"type": "assistant.message", "data": {"content": "Then it processes the data in chunks."}},
+            {
+                "type": "user.message",
+                "data": {"content": "explain this code in detail please"},
+            },
+            {
+                "type": "assistant.message",
+                "data": {"content": "First, the function validates input."},
+            },
+            {
+                "type": "assistant.message",
+                "data": {"content": "Then it processes the data in chunks."},
+            },
         ]
         (session_dir / "events.jsonl").write_text(
             "\n".join(json.dumps(e) for e in events) + "\n"
@@ -440,8 +525,12 @@ class TestCopilotHelpers:
         events_path = tmp_path / "events.jsonl"
         events_path.write_text(
             "not json\n"
-            + json.dumps({"type": "user.message", "data": {"content": "hello this is a message"}}) + "\n"
-            + json.dumps({"type": "assistant.message", "data": {"content": "hi there"}}) + "\n"
+            + json.dumps(
+                {"type": "user.message", "data": {"content": "hello this is a message"}}
+            )
+            + "\n"
+            + json.dumps({"type": "assistant.message", "data": {"content": "hi there"}})
+            + "\n"
         )
         pairs = _parse_copilot_events(events_path, "s1", "/test")
         assert len(pairs) == 1
@@ -472,7 +561,11 @@ class TestHermesSessionImporter:
             "session_id": "test-session",
             "messages": [
                 {"role": "user", "content": "Fix the bug in auth.py"},
-                {"role": "assistant", "content": None, "tool_calls": [{"name": "read_file"}]},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{"name": "read_file"}],
+                },
                 {"role": "tool", "content": "file contents here"},
                 {"role": "assistant", "content": "I found the issue and fixed it."},
                 {"role": "user", "content": "Now run the tests"},
@@ -507,7 +600,10 @@ class TestHermesSessionImporter:
     def test_filters_secrets(self, tmp_path):
         session = {
             "messages": [
-                {"role": "user", "content": "Set ANTHROPIC_API_KEY=sk-ant-api03-xyz in the env"},
+                {
+                    "role": "user",
+                    "content": "Set ANTHROPIC_API_KEY=sk-ant-api03-xyz in the env",
+                },
                 {"role": "assistant", "content": "Done."},
             ],
         }
@@ -518,7 +614,9 @@ class TestHermesSessionImporter:
         assert len(msgs) == 0
 
     def test_handles_missing_dir(self, tmp_path):
-        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path / "nonexistent"):
+        with patch.object(
+            HermesSessionImporter, "SESSION_DIR", tmp_path / "nonexistent"
+        ):
             msgs = HermesSessionImporter.extract_messages()
         assert msgs == []
 
@@ -545,7 +643,8 @@ class TestHermesSessionImporter:
     def test_respects_limit(self, tmp_path):
         session = {
             "messages": [
-                {"role": "user", "content": f"Message number {i} with enough text"} for i in range(10)
+                {"role": "user", "content": f"Message number {i} with enough text"}
+                for i in range(10)
             ],
         }
         (tmp_path / "s.json").write_text(json.dumps(session))
@@ -610,10 +709,19 @@ class TestRelevanceFilter:
 
         messages = [
             {"task_input": "sort these messages by topic", "source": "claude-code"},
-            {"task_input": "categorize my emails please", "source": "copilot", "assistant_response": "Sure!"},
+            {
+                "task_input": "categorize my emails please",
+                "source": "copilot",
+                "assistant_response": "Sure!",
+            },
         ]
 
-        examples = rf.filter_and_score(messages, "categorize", "Sort text into topics. Categorize content.", max_examples=10)
+        examples = rf.filter_and_score(
+            messages,
+            "categorize",
+            "Sort text into topics. Categorize content.",
+            max_examples=10,
+        )
 
         assert len(examples) == 2
         inputs = {ex.task_input for ex in examples}
@@ -629,15 +737,15 @@ class TestRelevanceFilter:
         rf.model = "test-model"
 
         rf.scorer = MagicMock()
-        rf.scorer.return_value = SimpleNamespace(
-            scoring='{"relevant": false}'
-        )
+        rf.scorer.return_value = SimpleNamespace(scoring='{"relevant": false}')
 
         messages = [
             {"task_input": "deploy the app to production", "source": "claude-code"},
         ]
 
-        examples = rf.filter_and_score(messages, "categorize", "Sort text into topics.", max_examples=10)
+        examples = rf.filter_and_score(
+            messages, "categorize", "Sort text into topics.", max_examples=10
+        )
         assert len(examples) == 0
 
     def test_malformed_llm_output_counted_as_error(self, mock_dspy):
@@ -645,13 +753,20 @@ class TestRelevanceFilter:
         rf.model = "test-model"
 
         rf.scorer = MagicMock()
-        rf.scorer.return_value = SimpleNamespace(scoring="I cannot determine relevance right now")
+        rf.scorer.return_value = SimpleNamespace(
+            scoring="I cannot determine relevance right now"
+        )
 
         messages = [
-            {"task_input": "sort these messages by topic please", "source": "claude-code"},
+            {
+                "task_input": "sort these messages by topic please",
+                "source": "claude-code",
+            },
         ]
 
-        examples = rf.filter_and_score(messages, "categorize", "Sort text into topics.", max_examples=10)
+        examples = rf.filter_and_score(
+            messages, "categorize", "Sort text into topics.", max_examples=10
+        )
         assert len(examples) == 0
 
     def test_max_examples_cap_respected(self, mock_dspy):
@@ -664,11 +779,19 @@ class TestRelevanceFilter:
         )
 
         messages = [
-            {"task_input": f"categorize message number {i} into topics", "source": "claude-code"}
+            {
+                "task_input": f"categorize message number {i} into topics",
+                "source": "claude-code",
+            }
             for i in range(20)
         ]
 
-        examples = rf.filter_and_score(messages, "categorize", "Sort text into topics. Categorize content.", max_examples=3)
+        examples = rf.filter_and_score(
+            messages,
+            "categorize",
+            "Sort text into topics. Categorize content.",
+            max_examples=3,
+        )
         assert len(examples) == 3
 
     def test_scorer_exception_counted_as_error(self, mock_dspy):
@@ -678,11 +801,16 @@ class TestRelevanceFilter:
         rf.scorer = MagicMock(side_effect=RuntimeError("API timeout"))
 
         messages = [
-            {"task_input": "sort these messages by topic please", "source": "claude-code"},
+            {
+                "task_input": "sort these messages by topic please",
+                "source": "claude-code",
+            },
         ]
 
         # Should not raise — errors are caught and counted
-        examples = rf.filter_and_score(messages, "categorize", "Sort text into topics.", max_examples=10)
+        examples = rf.filter_and_score(
+            messages, "categorize", "Sort text into topics.", max_examples=10
+        )
         assert len(examples) == 0
 
 
@@ -712,8 +840,14 @@ class TestBuildDataset:
 
         output = tmp_path / "output"
 
-        with patch.object(ClaudeCodeImporter, "extract_messages", return_value=mock_messages), \
-             patch.object(RelevanceFilter, "filter_and_score", return_value=mock_examples):
+        with (
+            patch.object(
+                ClaudeCodeImporter, "extract_messages", return_value=mock_messages
+            ),
+            patch.object(
+                RelevanceFilter, "filter_and_score", return_value=mock_examples
+            ),
+        ):
             dataset = build_dataset_from_external(
                 skill_name="categorize",
                 skill_text="Sort text into topics.",
@@ -749,8 +883,12 @@ class TestBuildDataset:
     def test_no_relevant_examples_returns_empty_dataset(self, tmp_path):
         mock_messages = [{"task_input": "deploy the app", "source": "claude-code"}]
 
-        with patch.object(ClaudeCodeImporter, "extract_messages", return_value=mock_messages), \
-             patch.object(RelevanceFilter, "filter_and_score", return_value=[]):
+        with (
+            patch.object(
+                ClaudeCodeImporter, "extract_messages", return_value=mock_messages
+            ),
+            patch.object(RelevanceFilter, "filter_and_score", return_value=[]),
+        ):
             dataset = build_dataset_from_external(
                 skill_name="categorize",
                 skill_text="Sort text into topics.",
@@ -762,17 +900,37 @@ class TestBuildDataset:
         assert len(dataset.all_examples) == 0
 
     def test_multiple_sources(self, tmp_path):
-        cc_msgs = [{"task_input": "sort from claude code session", "source": "claude-code"}]
-        cp_msgs = [{"task_input": "sort from copilot session", "source": "copilot", "assistant_response": "ok"}]
-
-        all_examples = [
-            EvalExample(task_input="sort from claude code session", expected_behavior="test", source="claude-code"),
-            EvalExample(task_input="sort from copilot session", expected_behavior="test", source="copilot"),
+        cc_msgs = [
+            {"task_input": "sort from claude code session", "source": "claude-code"}
+        ]
+        cp_msgs = [
+            {
+                "task_input": "sort from copilot session",
+                "source": "copilot",
+                "assistant_response": "ok",
+            }
         ]
 
-        with patch.object(ClaudeCodeImporter, "extract_messages", return_value=cc_msgs), \
-             patch.object(CopilotImporter, "extract_messages", return_value=cp_msgs), \
-             patch.object(RelevanceFilter, "filter_and_score", return_value=all_examples):
+        all_examples = [
+            EvalExample(
+                task_input="sort from claude code session",
+                expected_behavior="test",
+                source="claude-code",
+            ),
+            EvalExample(
+                task_input="sort from copilot session",
+                expected_behavior="test",
+                source="copilot",
+            ),
+        ]
+
+        with (
+            patch.object(ClaudeCodeImporter, "extract_messages", return_value=cc_msgs),
+            patch.object(CopilotImporter, "extract_messages", return_value=cp_msgs),
+            patch.object(
+                RelevanceFilter, "filter_and_score", return_value=all_examples
+            ),
+        ):
             dataset = build_dataset_from_external(
                 skill_name="categorize",
                 skill_text="Sort text.",
@@ -817,7 +975,14 @@ class TestEndToEndRoundtrip:
         # Create fake Claude Code history
         history = tmp_path / "history.jsonl"
         lines = [
-            json.dumps({"display": f"categorize these {i} messages into topics", "timestamp": i, "project": "/test", "sessionId": "s1"})
+            json.dumps(
+                {
+                    "display": f"categorize these {i} messages into topics",
+                    "timestamp": i,
+                    "project": "/test",
+                    "sessionId": "s1",
+                }
+            )
             for i in range(20)
         ]
         history.write_text("\n".join(lines) + "\n")
@@ -836,8 +1001,12 @@ class TestEndToEndRoundtrip:
 
         output = tmp_path / "dataset"
 
-        with patch.object(ClaudeCodeImporter, "HISTORY_PATH", history), \
-             patch.object(RelevanceFilter, "filter_and_score", return_value=mock_examples):
+        with (
+            patch.object(ClaudeCodeImporter, "HISTORY_PATH", history),
+            patch.object(
+                RelevanceFilter, "filter_and_score", return_value=mock_examples
+            ),
+        ):
             dataset = build_dataset_from_external(
                 skill_name="categorize",
                 skill_text="Sort text into topics.",
@@ -870,8 +1039,14 @@ class TestEndToEndRoundtrip:
         (session_dir / "workspace.yaml").write_text("cwd: /Users/test/project\n")
 
         events = [
-            {"type": "user.message", "data": {"content": "sort these messages into categories for me"}},
-            {"type": "assistant.message", "data": {"content": "I grouped them into 3 categories"}},
+            {
+                "type": "user.message",
+                "data": {"content": "sort these messages into categories for me"},
+            },
+            {
+                "type": "assistant.message",
+                "data": {"content": "I grouped them into 3 categories"},
+            },
         ]
         (session_dir / "events.jsonl").write_text(
             "\n".join(json.dumps(e) for e in events) + "\n"
@@ -889,8 +1064,12 @@ class TestEndToEndRoundtrip:
 
         output = tmp_path / "dataset"
 
-        with patch.object(CopilotImporter, "SESSION_DIR", tmp_path / "session-state"), \
-             patch.object(RelevanceFilter, "filter_and_score", return_value=mock_examples):
+        with (
+            patch.object(CopilotImporter, "SESSION_DIR", tmp_path / "session-state"),
+            patch.object(
+                RelevanceFilter, "filter_and_score", return_value=mock_examples
+            ),
+        ):
             dataset = build_dataset_from_external(
                 skill_name="categorize",
                 skill_text="Sort text.",
@@ -904,7 +1083,10 @@ class TestEndToEndRoundtrip:
         # Reload and verify
         reloaded = EvalDataset.load(output)
         assert len(reloaded.all_examples) == 1
-        assert reloaded.all_examples[0].task_input == "sort these messages into categories for me"
+        assert (
+            reloaded.all_examples[0].task_input
+            == "sort these messages into categories for me"
+        )
 
 
 # ── _load_skill_text ─────────────────────────────────────────────────────────
@@ -1023,7 +1205,9 @@ class TestValidateEvalExample:
         assert len(result["task_input"]) == 2000
 
     def test_expected_behavior_stripped(self):
-        result = _validate_eval_example("task", "  behavior with spaces  ", "easy", "cat")
+        result = _validate_eval_example(
+            "task", "  behavior with spaces  ", "easy", "cat"
+        )
         assert result["expected_behavior"] == "behavior with spaces"
 
     def test_category_stripped(self):
@@ -1055,7 +1239,12 @@ class TestValidationIntegration:
             {"task_input": "sort these messages by topic", "source": "claude-code"},
         ]
 
-        examples = rf.filter_and_score(messages, "categorize", "Sort text into topics. Categorize content.", max_examples=10)
+        examples = rf.filter_and_score(
+            messages,
+            "categorize",
+            "Sort text into topics. Categorize content.",
+            max_examples=10,
+        )
         assert len(examples) == 0
 
     def test_invalid_difficulty_normalized(self, mock_dspy):
@@ -1072,7 +1261,12 @@ class TestValidationIntegration:
             {"task_input": "sort these messages by topic", "source": "claude-code"},
         ]
 
-        examples = rf.filter_and_score(messages, "categorize", "Sort text into topics. Categorize content.", max_examples=10)
+        examples = rf.filter_and_score(
+            messages,
+            "categorize",
+            "Sort text into topics. Categorize content.",
+            max_examples=10,
+        )
         assert len(examples) == 1
         assert examples[0].difficulty == "medium"
 
@@ -1091,7 +1285,12 @@ class TestValidationIntegration:
             {"task_input": "categorize emails", "source": "claude-code"},
         ]
 
-        examples = rf.filter_and_score(messages, "categorize", "Sort text into topics. Categorize content.", max_examples=10)
+        examples = rf.filter_and_score(
+            messages,
+            "categorize",
+            "Sort text into topics. Categorize content.",
+            max_examples=10,
+        )
         assert len(examples) == 1
         assert examples[0].source == "claude-code"
 
@@ -1106,7 +1305,9 @@ class TestValidationIntegration:
             {"source": "claude-code"},  # missing task_input
         ]
 
-        examples = rf.filter_and_score(messages, "categorize", "Sort text into topics.", max_examples=10)
+        examples = rf.filter_and_score(
+            messages, "categorize", "Sort text into topics.", max_examples=10
+        )
         assert len(examples) == 0
         # scorer should never be called for invalid messages
         rf.scorer.assert_not_called()
@@ -1130,8 +1331,14 @@ class TestMinDatasetSizeWarning:
 
         output = tmp_path / "output"
 
-        with patch.object(ClaudeCodeImporter, "extract_messages", return_value=mock_messages), \
-             patch.object(RelevanceFilter, "filter_and_score", return_value=mock_examples):
+        with (
+            patch.object(
+                ClaudeCodeImporter, "extract_messages", return_value=mock_messages
+            ),
+            patch.object(
+                RelevanceFilter, "filter_and_score", return_value=mock_examples
+            ),
+        ):
             dataset = build_dataset_from_external(
                 skill_name="categorize",
                 skill_text="Sort text.",
@@ -1156,34 +1363,63 @@ class TestCLI:
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("---\nname: test-skill\n---\nTest skill.")
 
-        with patch.object(ClaudeCodeImporter, "extract_messages", return_value=[
-            {"task_input": "hello with enough length", "source": "claude-code"},
-        ]):
+        with patch.object(
+            ClaudeCodeImporter,
+            "extract_messages",
+            return_value=[
+                {"task_input": "hello with enough length", "source": "claude-code"},
+            ],
+        ):
             runner = CliRunner()
-            result = runner.invoke(main, [
-                "--skill", "test-skill",
-                "--source", "claude-code",
-                "--dry-run",
-            ], catch_exceptions=False, env={"HOME": str(tmp_path.parent)})
+            result = runner.invoke(
+                main,
+                [
+                    "--skill",
+                    "test-skill",
+                    "--source",
+                    "claude-code",
+                    "--dry-run",
+                ],
+                catch_exceptions=False,
+                env={"HOME": str(tmp_path.parent)},
+            )
 
             # _load_skill_text uses ~/.hermes/skills by default, so we patch it
         # Instead, use the skills_dir parameter approach
-        with patch("evolution.core.external_importers._load_skill_text", return_value=("test-skill", "Test skill.")), \
-             patch.object(ClaudeCodeImporter, "extract_messages", return_value=[
-                 {"task_input": "hello with enough length", "source": "claude-code"},
-             ]):
+        with (
+            patch(
+                "evolution.core.external_importers._load_skill_text",
+                return_value=("test-skill", "Test skill."),
+            ),
+            patch.object(
+                ClaudeCodeImporter,
+                "extract_messages",
+                return_value=[
+                    {"task_input": "hello with enough length", "source": "claude-code"},
+                ],
+            ),
+        ):
             runner = CliRunner()
-            result = runner.invoke(main, [
-                "--skill", "test-skill",
-                "--source", "claude-code",
-                "--dry-run",
-            ], catch_exceptions=False)
+            result = runner.invoke(
+                main,
+                [
+                    "--skill",
+                    "test-skill",
+                    "--source",
+                    "claude-code",
+                    "--dry-run",
+                ],
+                catch_exceptions=False,
+            )
 
         assert result.exit_code == 0
         assert "DRY RUN" in result.output
 
     def test_missing_skill_exits_with_error(self):
-        with patch("evolution.core.external_importers._load_skill_text", side_effect=FileNotFoundError("not found")):
+        with patch(
+            "evolution.core.external_importers._load_skill_text",
+            side_effect=FileNotFoundError("not found"),
+        ):
             runner = CliRunner()
             result = runner.invoke(main, ["--skill", "nonexistent"])
 
@@ -1229,4 +1465,10 @@ class TestEvalExampleFormat:
         with open(jsonl_path) as f:
             data = json.loads(f.readline())
 
-        assert set(data.keys()) == {"task_input", "expected_behavior", "difficulty", "category", "source"}
+        assert set(data.keys()) == {
+            "task_input",
+            "expected_behavior",
+            "difficulty",
+            "category",
+            "source",
+        }

--- a/tests/skills/test_skill_module.py
+++ b/tests/skills/test_skill_module.py
@@ -1,7 +1,5 @@
 """Tests for skill module loading and parsing."""
 
-import pytest
-from pathlib import Path
 from evolution.skills.skill_module import load_skill, reassemble_skill
 
 


### PR DESCRIPTION
Three small, mechanical commits from a repo audit (REPO_AUDIT.md kept local, not committed).

## Commits
1. **`chore: add .gitleaks.toml allowlisting test fixtures`** — silences 6 gitleaks false positives in `tests/core/test_external_importers.py` (literal strings passed to `_contains_secret(...)` assertions, not real secrets).
2. **`style(ruff): apply --fix`** — 17 auto-fixes: 14 unused imports (F401), 3 empty f-strings (F541). 3 issues remain (need human judgement — not touched here).
3. **`style: ruff format`** — reformats 9 files to match the rest of the tree (21 files now consistent).

## Verification
- `ruff check .` → 3 remaining issues (down from 20), none auto-fixable
- `ruff format --check .` → clean
- No functional/behavioural changes; pure hygiene.

## Not included (need separate decisions)
- LICENSE (pick license — Apache-2.0?)
- `.github/workflows/ci.yml` (ruff + pytest + gitleaks)
- Dependabot / pre-commit
- Lockfile (`uv.lock` vs upper-bound pins)

Happy to follow up with those as separate PRs.