### PR TITLE
Log exceptions in skill scoring and skill file loading

### DIFF
--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -524,7 +524,8 @@ class RelevanceFilter:
                                 **validated,
                             ))
 
-                except Exception:
+                except Exception as e:
+                    console.print(f"[dim]  Scoring failed ({type(e).__name__}: {e})[/dim]")
                     errors += 1
 
                 progress.update(task, advance=1)

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -5,11 +5,14 @@ where the skill text is the optimizable parameter. GEPA can then
 mutate the skill text and evaluate the results.
 """
 
+import logging
 import re
 from pathlib import Path
 from typing import Optional
 
 import dspy
+
+logger = logging.getLogger(__name__)
 
 
 def load_skill(skill_path: Path) -> dict:
@@ -75,7 +78,8 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
             content = skill_md.read_text()[:500]
             if f"name: {skill_name}" in content or f'name: "{skill_name}"' in content:
                 return skill_md
-        except Exception:
+        except Exception as e:
+            logger.debug("Could not read %s during skill search: %s", skill_md, e)
             continue
 
     return None


### PR DESCRIPTION
## Summary

Two silent `except Exception:` blocks were swallowing errors without any diagnostic output, making it hard to understand why runs were failing.

### `evolution/core/external_importers.py`

The `except Exception:` inside `select_relevant_examples` incremented the `errors` counter but gave no indication of *what* failed. If the LLM call raised an unexpected error (wrong model name, API quota, malformed response, etc.) it was invisible to the user — they'd just see a higher error rate percentage with no way to debug it.

**Before:**
```python
except Exception:
    errors += 1
```

**After:**
```python
except Exception as e:
    console.print(f"[dim]  Scoring failed ({type(e).__name__}: {e})[/dim]")
    errors += 1
```

### `evolution/skills/skill_module.py`

The fuzzy skill search silently skipped unreadable `SKILL.md` files. If a file had a permissions issue or encoding problem, `find_skill` would return `None` with no indication of why — appearing as if the skill simply didn't exist.

**Before:**
```python
except Exception:
    continue
```

**After:**
```python
except Exception as e:
    logger.debug("Could not read %s during skill search: %s", skill_md, e)
    continue
```

Uses `logger.debug` so it's silent by default but visible when running with `--log-level DEBUG`.

## Test plan

- [ ] Run `python -m evolution.skills.evolve_skill` with an intentionally bad model name and confirm the error is now printed per-example rather than silently counted
- [ ] Set `logging.basicConfig(level=logging.DEBUG)` and confirm unreadable skill files are reported