### PR TITLE
chore: harden local self-evolution runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ datasets/**/*.json
 snapshots/
 *.pkl
 
+# Local run artifacts and operator-only cron wrappers
+logs/
+output/
+scripts/
+
 # IDE
 .idea/
 .vscode/

--- a/evolution/artifacts/__init__.py
+++ b/evolution/artifacts/__init__.py
@@ -1,0 +1,8 @@
+"""Artifact evolution framework for Hermes Agent self-evolution.
+
+Supports evolving any text-based artifact:
+  - persona (L1)
+  - eval_prompts (L3)
+  - constraints (L5)
+  - skills (L2) — already implemented via evolve_skill.py
+"""

--- a/evolution/artifacts/artifact_module.py
+++ b/evolution/artifacts/artifact_module.py
@@ -1,0 +1,34 @@
+"""Generic DSPy module for evolving any text artifact.
+
+Mirrors SkillModule but works with arbitrary artifact text.
+"""
+
+import dspy
+
+
+class ArtifactModule(dspy.Module):
+    """A DSPy module wrapping an evolvable text artifact.
+
+    The artifact_text represents the body of the artifact
+    (e.g., persona rules, eval prompt, constraint rules).
+    """
+
+    def __init__(self, artifact_text: str):
+        super().__init__()
+        self.artifact_text = artifact_text
+        self.predictor = dspy.Predict(ArtifactSignature)
+
+    def forward(self, task_input: str) -> dspy.Prediction:
+        """Apply the artifact to a task input and return the output."""
+        return self.predictor(
+            artifact=self.artifact_text,
+            task_input=task_input,
+        )
+
+
+class ArtifactSignature(dspy.Signature):
+    """Apply an artifact to a given task."""
+
+    artifact = dspy.InputField(desc="The artifact text (rules, persona, prompt, etc.)")
+    task_input = dspy.InputField(desc="The task or scenario to apply the artifact to")
+    output = dspy.OutputField(desc="The result of applying the artifact to the task")

--- a/evolution/artifacts/constraint_analyzer.py
+++ b/evolution/artifacts/constraint_analyzer.py
@@ -1,0 +1,142 @@
+"""L5 Constraint Analyzer — Analyze recent evolution results and propose constraint adjustments.
+
+Constraints are rules that validate artifacts (size limits, growth limits, etc.).
+This analyzer looks at recent evolution history to suggest tuning:
+- Should size limits be relaxed or tightened?
+- Are growth limits causing too many rejections?
+- What constraint patterns correlate with successful evolutions?
+
+Usage:
+    python -m evolution.artifacts.constraint_analyzer
+"""
+
+import json
+import os
+from pathlib import Path
+from datetime import datetime
+from typing import List, Dict
+
+import dspy
+from rich.console import Console
+
+console = Console()
+
+OUTPUT_DIR = Path("output")
+
+
+def load_recent_results(days: int = 14) -> List[Dict]:
+    """Load all recent evolution metrics."""
+    results = []
+    cutoff = datetime.now().timestamp() - (days * 86400)
+
+    for artifact_dir in OUTPUT_DIR.glob("*/*"):
+        if not artifact_dir.is_dir():
+            continue
+        mfile = artifact_dir / "metrics.json"
+        if mfile.exists() and mfile.stat().st_mtime > cutoff:
+            try:
+                data = json.loads(mfile.read_text())
+                data["_source"] = str(mfile)
+                results.append(data)
+            except Exception:
+                pass
+
+    return results
+
+
+class ConstraintTuningProposal(dspy.Signature):
+    """Analyze evolution history and propose constraint rule adjustments.
+
+    Given metrics from recent self-evolution runs, identify:
+    - Constraints that are too strict (causing false rejections of good artifacts)
+    - Constraints that are too loose (allowing bad artifacts through)
+    - Missing constraints that would have caught problems
+
+    Output specific, actionable constraint adjustments.
+    """
+
+    evolution_history = dspy.InputField(desc="Summary of recent evolution runs with pass/fail and scores")
+    current_constraints = dspy.InputField(desc="Current constraint rules being used")
+    proposals = dspy.OutputField(desc="JSON array of proposals, each with: constraint_name, current_value, proposed_value, reasoning")
+
+
+def analyze_constraints():
+    """Main analysis function."""
+    console.print("\n[bold cyan]⚖️ L5 Constraint Analysis[/bold cyan]\n")
+
+    results = load_recent_results(days=21)
+    console.print(f"  Loaded {len(results)} recent evolution results")
+
+    if len(results) < 2:
+        console.print("  [yellow]Not enough history for analysis. Need ≥2 runs.[/yellow]")
+        return
+
+    # Build history summary
+    summary = []
+    for r in results:
+        summary.append({
+            "type": r.get("artifact_type", "unknown"),
+            "improvement": r.get("improvement", 0),
+            "constraints_passed": r.get("constraints_passed", True),
+            "baseline_size": r.get("baseline_size", 0),
+            "evolved_size": r.get("evolved_size", 0),
+            "size_change_pct": round((r.get("evolved_size", 0) - r.get("baseline_size", 0)) / max(1, r.get("baseline_size", 1)) * 100, 1),
+        })
+
+    current_constraints = """
+Current constraint rules:
+- size_limit: Max 15000 chars per artifact
+- growth_limit: Max +20% size increase from baseline
+- non_empty: Artifact must not be empty
+- skill_structure: Must have YAML frontmatter with name + description (skills only)
+"""
+
+    # Configure DSPy
+    api_base = os.environ.get("OPENAI_API_BASE") or os.environ.get("OPENAI_BASE_URL")
+    api_key = os.environ.get("OPENAI_API_KEY")
+    lm_kwargs = {}
+    if api_base:
+        lm_kwargs["api_base"] = api_base
+    if api_key:
+        lm_kwargs["api_key"] = api_key
+    lm = dspy.LM("openai/glm-5.1", **lm_kwargs)
+
+    with dspy.context(lm=lm):
+        gen = dspy.Predict(ConstraintTuningProposal)
+        result = gen(
+            evolution_history=json.dumps(summary, indent=2),
+            current_constraints=current_constraints,
+        )
+
+    # Parse proposals
+    import json_repair
+    try:
+        proposals = json.loads(json_repair.repair_json(result.proposals))
+    except Exception:
+        proposals = []
+
+    if not proposals:
+        console.print("  [yellow]No proposals generated.[/yellow]")
+        return
+
+    console.print(f"\n[bold]Generated {len(proposals)} constraint proposals:[/bold]\n")
+    for i, p in enumerate(proposals, 1):
+        name = p.get("constraint_name", "?")
+        current = p.get("current_value", "?")
+        proposed = p.get("proposed_value", "?")
+        reasoning = p.get("reasoning", "")
+        console.print(f"  {i}. [bold]{name}[/bold]")
+        console.print(f"     Current: {current} → Proposed: {proposed}")
+        console.print(f"     Reason: {reasoning}")
+        console.print()
+
+    # Save
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out = Path("output") / "constraints" / timestamp
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "proposals.json").write_text(json.dumps(proposals, indent=2))
+    console.print(f"  Saved to {out}/")
+
+
+if __name__ == "__main__":
+    analyze_constraints()

--- a/evolution/artifacts/eval_prompt_evolver.py
+++ b/evolution/artifacts/eval_prompt_evolver.py
@@ -1,0 +1,285 @@
+"""Evolve LLM judge / evaluator prompts using LLM-guided mutation.
+
+Eval prompts are critical because they determine how we score everything else.
+We evolve them by testing their discrimination power on a set of scenarios.
+
+Usage:
+    python -m evolution.artifacts.eval_prompt_evolver --prompt-name persona_evaluator --iterations 3
+"""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from datetime import datetime
+from typing import List
+
+import click
+import dspy
+from rich.console import Console
+from rich.table import Table
+
+from evolution.core.config import EvolutionConfig
+
+console = Console()
+
+PROMPTS_DIR = Path.home() / ".hermes" / "artifacts" / "eval_prompts"
+
+def load_prompt(name: str) -> str:
+    path = PROMPTS_DIR / f"{name}.txt"
+    if path.exists():
+        return path.read_text()
+    console.print(f"[red]✗ Prompt not found at {path}[/red]")
+    sys.exit(1)
+
+
+def save_prompt(name: str, text: str):
+    path = PROMPTS_DIR / f"{name}.txt"
+    path.write_text(text)
+
+
+class EvalPromptVariationGenerator(dspy.Signature):
+    """Generate improved variations of an evaluation prompt.
+
+    Given a current evaluator prompt and examples where it performed
+    well or poorly, produce 3 improved variations.
+    """
+
+    current_prompt = dspy.InputField(desc="The current evaluator prompt text")
+    good_examples = dspy.InputField(desc="Scenarios where the prompt evaluated correctly")
+    bad_examples = dspy.InputField(desc="Scenarios where the prompt evaluated incorrectly")
+    variation_1 = dspy.OutputField(desc="First improved prompt variation (full text)")
+    variation_2 = dspy.OutputField(desc="Second improved prompt variation (full text)")
+    variation_3 = dspy.OutputField(desc="Third improved prompt variation (full text)")
+    changes_summary = dspy.OutputField(desc="Brief summary of key changes")
+
+
+class ScenarioGenerator(dspy.Signature):
+    """Generate evaluation scenarios for testing an evaluator prompt."""
+
+    prompt_purpose = dspy.InputField(desc="What this evaluator judges (e.g., persona quality)")
+    num_scenarios = dspy.InputField(desc="Number of scenarios to generate")
+    scenarios = dspy.OutputField(desc="JSON array of scenarios, each with: description, good_response, bad_response")
+
+
+def generate_test_scenarios(purpose: str, n: int, lm: dspy.LM) -> List[dict]:
+    """Generate scenarios with known good/bad responses."""
+    with dspy.context(lm=lm):
+        gen = dspy.Predict(ScenarioGenerator)
+        result = gen(prompt_purpose=purpose, num_scenarios=n)
+    import json, re
+    from json_repair import repair_json
+    raw = result.scenarios or "[]"
+    try:
+        return json.loads(repair_json(raw))
+    except Exception:
+        match = re.search(r'\[.*\]', raw, re.DOTALL)
+        if match:
+            try:
+                return json.loads(repair_json(match.group()))
+            except Exception:
+                return []
+        return []
+
+
+def score_with_prompt(prompt_text: str, scenario: dict, lm: dspy.LM) -> tuple:
+    """Use the prompt to score good vs bad response. Returns (good_score, bad_score, discrimination)."""
+    # Fill in the prompt template
+    good_prompt = prompt_text.replace("{{scenario}}", scenario.get("description", ""))
+    good_prompt = good_prompt.replace("{{expected}}", scenario.get("good_response", ""))
+    good_prompt = good_prompt.replace("{{actual}}", scenario.get("good_response", ""))
+
+    bad_prompt = prompt_text.replace("{{scenario}}", scenario.get("description", ""))
+    bad_prompt = bad_prompt.replace("{{expected}}", scenario.get("good_response", ""))
+    bad_prompt = bad_prompt.replace("{{actual}}", scenario.get("bad_response", ""))
+
+    with dspy.context(lm=lm):
+        good_result = lm(good_prompt)
+        bad_result = lm(bad_prompt)
+
+    # Extract scores
+    import re
+    good_score = 5.0
+    bad_score = 5.0
+    if good_result:
+        m = re.search(r'(\d+(?:\.\d+)?)\s*/\s*10', str(good_result[0]) if isinstance(good_result, list) else str(good_result))
+        if m:
+            good_score = float(m.group(1))
+    if bad_result:
+        m = re.search(r'(\d+(?:\.\d+)?)\s*/\s*10', str(bad_result[0]) if isinstance(bad_result, list) else str(bad_result))
+        if m:
+            bad_score = float(m.group(1))
+
+    discrimination = good_score - bad_score
+    return good_score, bad_score, discrimination
+
+
+def evaluate_prompt(prompt_text: str, scenarios: List[dict], lm: dspy.LM) -> float:
+    """Average discrimination power across scenarios."""
+    discriminations = []
+    for sc in scenarios:
+        _, _, disc = score_with_prompt(prompt_text, sc, lm)
+        discriminations.append(disc)
+    return sum(discriminations) / max(1, len(discriminations))
+
+
+def generate_variations(current_prompt: str, scenarios: List[dict], lm: dspy.LM) -> List[str]:
+    """Generate improved variations of the eval prompt."""
+    # Score current on all scenarios
+    results = []
+    for sc in scenarios:
+        g, b, d = score_with_prompt(current_prompt, sc, lm)
+        results.append((d, sc))
+
+    results.sort(key=lambda x: x[0])
+    bad_examples = results[:3]
+    good_examples = results[-2:]
+
+    bad_text = "\n".join([f"- Discrimination {d:.1f} on: {sc.get('description', '')[:100]}" for d, sc in bad_examples])
+    good_text = "\n".join([f"- Discrimination {d:.1f} on: {sc.get('description', '')[:100]}" for d, sc in good_examples])
+
+    with dspy.context(lm=lm):
+        gen = dspy.Predict(EvalPromptVariationGenerator)
+        result = gen(
+            current_prompt=current_prompt,
+            good_examples=good_text,
+            bad_examples=bad_text,
+        )
+
+    variations = []
+    for v in [result.variation_1, result.variation_2, result.variation_3]:
+        if v and len(v) > 100:
+            variations.append(v)
+    variations.append(current_prompt)
+    return variations
+
+
+def evolve_eval_prompt(
+    prompt_name: str = "persona_evaluator",
+    iterations: int = 120,
+    num_scenarios: int = 8,
+    optimizer_model: str = "openai/glm-5.1",
+    eval_model: str = "openai/glm-5.1",
+    dry_run: bool = False,
+):
+    """Evolve an evaluation prompt."""
+
+    console.print(f"\n[bold cyan]🧬 Eval Prompt Self-Evolution[/bold cyan] — Evolving: {prompt_name}\n")
+
+    prompt_text = load_prompt(prompt_name)
+    console.print(f"  Loaded: {PROMPTS_DIR / (prompt_name + '.txt')}")
+    console.print(f"  Size: {len(prompt_text):,} chars")
+
+    if dry_run:
+        console.print(f"\n[bold green]DRY RUN — setup validated.[/bold green]")
+        return
+
+    # Configure DSPy
+    api_base = os.environ.get("OPENAI_API_BASE") or os.environ.get("OPENAI_BASE_URL")
+    api_key = os.environ.get("OPENAI_API_KEY")
+    lm_kwargs = {}
+    if api_base:
+        lm_kwargs["api_base"] = api_base
+    if api_key:
+        lm_kwargs["api_key"] = api_key
+    lm = dspy.LM(eval_model, **lm_kwargs)
+    dspy.configure(lm=lm)
+
+    # Generate test scenarios
+    console.print(f"\n[bold]Generating {num_scenarios} test scenarios[/bold]")
+    scenarios = generate_test_scenarios(
+        f"Evaluate agent responses based on {prompt_name}",
+        num_scenarios,
+        lm,
+    )
+    console.print(f"  Generated {len(scenarios)} scenarios")
+
+    # Baseline
+    console.print(f"\n[bold]Evaluating baseline prompt[/bold]")
+    baseline_score = evaluate_prompt(prompt_text, scenarios, lm)
+    console.print(f"  Baseline discrimination: {baseline_score:.2f}")
+
+    # Evolution loop
+    console.print(f"\n[bold cyan]Running evolution ({iterations} iterations)...[/bold cyan]\n")
+    start_time = time.time()
+
+    best_prompt = prompt_text
+    best_score = baseline_score
+
+    for i in range(iterations):
+        console.print(f"  Iteration {i+1}/{iterations}")
+        variations = generate_variations(best_prompt, scenarios, lm)
+
+        best_var_score = best_score
+        best_var_prompt = best_prompt
+
+        for j, var in enumerate(variations[:-1]):
+            score = evaluate_prompt(var, scenarios, lm)
+            console.print(f"    Variant {j+1}: discrimination {score:.2f}")
+            if score > best_var_score:
+                best_var_score = score
+                best_var_prompt = var
+
+        if best_var_score > best_score:
+            improvement = best_var_score - best_score
+            console.print(f"  [green]→ Improved by +{improvement:.2f}[/green]")
+            best_score = best_var_score
+            best_prompt = best_var_prompt
+        else:
+            console.print(f"  [yellow]→ No improvement[/yellow]")
+
+    elapsed = time.time() - start_time
+    console.print(f"\n  Evolution completed in {elapsed:.1f}s")
+
+    # Save output
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = Path("output") / "eval_prompts" / prompt_name / timestamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    (output_dir / "evolved_prompt.txt").write_text(best_prompt)
+    (output_dir / "baseline_prompt.txt").write_text(prompt_text)
+
+    metrics = {
+        "artifact_type": "eval_prompt",
+        "prompt_name": prompt_name,
+        "timestamp": timestamp,
+        "iterations": iterations,
+        "baseline_score": baseline_score,
+        "evolved_score": best_score,
+        "improvement": best_score - baseline_score,
+        "elapsed_seconds": elapsed,
+    }
+    (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+
+    console.print(f"\n  Output saved to {output_dir}/")
+
+    if best_score > baseline_score:
+        console.print(f"\n[bold green]✓ Prompt improved by {best_score - baseline_score:+.2f}[/bold green]")
+        save_prompt(prompt_name, best_prompt)
+        console.print(f"[bold green]✓ Deployed to {PROMPTS_DIR / (prompt_name + '.txt')}[/bold green]")
+    else:
+        console.print(f"\n[yellow]⚠ No improvement. Keeping baseline.[/yellow]")
+
+
+@click.command()
+@click.option("--prompt-name", default="persona_evaluator", help="Name of the eval prompt to evolve")
+@click.option("--iterations", default=120, help="Number of evolution iterations")
+@click.option("--num-scenarios", default=8, help="Number of test scenarios")
+@click.option("--optimizer-model", default="openai/glm-5.1", help="Model for generating variations")
+@click.option("--eval-model", default="openai/glm-5.1", help="Model for evaluation")
+@click.option("--dry-run", is_flag=True, help="Validate setup without running")
+def main(prompt_name, iterations, num_scenarios, optimizer_model, eval_model, dry_run):
+    """Evolve an evaluation prompt."""
+    evolve_eval_prompt(
+        prompt_name=prompt_name,
+        iterations=iterations,
+        num_scenarios=num_scenarios,
+        optimizer_model=optimizer_model,
+        eval_model=eval_model,
+        dry_run=dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/evolution/artifacts/memory_reflector.py
+++ b/evolution/artifacts/memory_reflector.py
@@ -1,0 +1,133 @@
+"""L4 Memory Reflection — Analyze recent sessions and evolution logs to suggest memory updates.
+
+This is NOT traditional memory compaction. Instead, it:
+1. Reads recent evolution logs and metrics
+2. Identifies patterns in what works/doesn't work
+3. Proposes memory entries (user preferences, system insights)
+4. Outputs suggestions that can be manually reviewed or auto-applied
+
+Usage:
+    python -m evolution.artifacts.memory_reflector
+"""
+
+import json
+import os
+from pathlib import Path
+from datetime import datetime
+from typing import List, Dict
+
+import dspy
+from rich.console import Console
+
+console = Console()
+
+OUTPUT_DIR = Path("output")
+LOG_DIR = Path("logs")
+
+
+def load_recent_metrics(days: int = 7) -> List[Dict]:
+    """Load metrics.json files from recent evolution runs."""
+    metrics = []
+    cutoff = datetime.now().timestamp() - (days * 86400)
+
+    for artifact_dir in OUTPUT_DIR.glob("*/*"):
+        if not artifact_dir.is_dir():
+            continue
+        mfile = artifact_dir / "metrics.json"
+        if mfile.exists() and mfile.stat().st_mtime > cutoff:
+            try:
+                data = json.loads(mfile.read_text())
+                data["_source"] = str(mfile)
+                metrics.append(data)
+            except Exception:
+                pass
+
+    return metrics
+
+
+class MemoryInsightGenerator(dspy.Signature):
+    """Analyze evolution metrics and generate memory insights.
+
+    Given a history of self-evolution runs, identify patterns:
+    - What consistently improves scores?
+    - What causes failures or regressions?
+    - What user preferences are emerging?
+    - What system configuration works best?
+
+    Output 3-5 concise memory entries that should be saved.
+    """
+
+    metrics_history = dspy.InputField(desc="JSON array of recent evolution metrics")
+    insights = dspy.OutputField(desc="JSON array of memory insights, each with: category, content, confidence (high/medium/low)")
+
+
+def reflect_and_propose_memory():
+    """Main reflection function."""
+    console.print("\n[bold cyan]🧠 L4 Memory Reflection[/bold cyan]\n")
+
+    metrics = load_recent_metrics(days=14)
+    console.print(f"  Loaded {len(metrics)} recent evolution metrics")
+
+    if len(metrics) < 2:
+        console.print("  [yellow]Not enough history for meaningful reflection. Need ≥2 runs.[/yellow]")
+        return
+
+    # Sort by timestamp
+    metrics.sort(key=lambda x: x.get("timestamp", ""))
+
+    # Summarize for the LLM
+    summary = []
+    for m in metrics:
+        summary.append({
+            "type": m.get("artifact_type", "unknown"),
+            "timestamp": m.get("timestamp", "?"),
+            "improvement": m.get("improvement", 0),
+            "baseline": m.get("baseline_score", 0),
+            "evolved": m.get("evolved_score", 0),
+            "model": m.get("eval_model", "?"),
+            "elapsed": m.get("elapsed_seconds", 0),
+        })
+
+    # Configure DSPy
+    api_base = os.environ.get("OPENAI_API_BASE") or os.environ.get("OPENAI_BASE_URL")
+    api_key = os.environ.get("OPENAI_API_KEY")
+    lm_kwargs = {}
+    if api_base:
+        lm_kwargs["api_base"] = api_base
+    if api_key:
+        lm_kwargs["api_key"] = api_key
+    lm = dspy.LM("openai/glm-5.1", **lm_kwargs)
+
+    with dspy.context(lm=lm):
+        gen = dspy.Predict(MemoryInsightGenerator)
+        result = gen(metrics_history=json.dumps(summary, indent=2))
+
+    # Parse insights
+    import json_repair
+    try:
+        insights = json.loads(json_repair.repair_json(result.insights))
+    except Exception:
+        insights = []
+
+    if not insights:
+        console.print("  [yellow]No insights generated.[/yellow]")
+        return
+
+    console.print(f"\n[bold]Generated {len(insights)} memory insights:[/bold]\n")
+    for i, ins in enumerate(insights, 1):
+        cat = ins.get("category", "general")
+        content = ins.get("content", "")
+        conf = ins.get("confidence", "medium")
+        color = {"high": "green", "medium": "yellow", "low": "red"}.get(conf, "white")
+        console.print(f"  {i}. [{color}]{conf.upper()}[/{color}] [{cat}] {content}")
+
+    # Save suggestions
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out = Path("output") / "memory" / timestamp
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "insights.json").write_text(json.dumps(insights, indent=2))
+    console.print(f"\n  Saved to {out}/")
+
+
+if __name__ == "__main__":
+    reflect_and_propose_memory()

--- a/evolution/artifacts/persona_evolver.py
+++ b/evolution/artifacts/persona_evolver.py
@@ -1,0 +1,339 @@
+"""Evolve the Hermes Agent persona using LLM-guided text mutation.
+
+Unlike skills (where MIPROv2 optimizes instructions), persona is a text artifact
+that must be directly mutated and evaluated. We use a genetic algorithm approach:
+1. Generate N candidate variations of the persona
+2. Score each against evaluation scenarios
+3. Keep the best, optionally iterate
+
+Usage:
+    python -m evolution.artifacts.persona_evolver --iterations 3
+"""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from datetime import datetime
+from typing import Optional, List
+
+import click
+import dspy
+from rich.console import Console
+from rich.table import Table
+
+from evolution.core.config import EvolutionConfig
+from evolution.core.dataset_builder import SyntheticDatasetBuilder
+from evolution.core.constraints import ConstraintValidator
+
+console = Console()
+
+PERSONA_PATH = Path.home() / ".hermes" / "artifacts" / "persona" / "persona.md"
+
+def load_persona() -> str:
+    if PERSONA_PATH.exists():
+        return PERSONA_PATH.read_text()
+    console.print(f"[red]✗ Persona not found at {PERSONA_PATH}[/red]")
+    sys.exit(1)
+
+
+def save_persona(text: str):
+    PERSONA_PATH.write_text(text)
+
+
+class PersonaVariationGenerator(dspy.Signature):
+    """Generate improved variations of a persona text.
+
+    Given a current persona and feedback on what works/doesn't work,
+    produce 3 improved variations. Each variation should preserve the
+    core identity while strengthening weak areas.
+    """
+
+    current_persona = dspy.InputField(desc="The current persona text")
+    evaluation_scenarios = dspy.InputField(desc="Scenarios where the persona performed well or poorly")
+    weaknesses = dspy.InputField(desc="Identified weaknesses to address")
+    variation_1 = dspy.OutputField(desc="First improved persona variation (full text)")
+    variation_2 = dspy.OutputField(desc="Second improved persona variation (full text)")
+    variation_3 = dspy.OutputField(desc="Third improved persona variation (full text)")
+    changes_summary = dspy.OutputField(desc="Brief summary of key changes made")
+
+
+class PersonaEvaluator(dspy.Signature):
+    """Evaluate how well a persona guides an agent's response to a scenario.
+
+    Score 0-10 on: directness, conciseness, correctness, proactive_action, tone_match.
+    """
+
+    persona = dspy.InputField(desc="The persona text")
+    scenario = dspy.InputField(desc="The scenario to evaluate")
+    expected_behavior = dspy.InputField(desc="The expected ideal behavior")
+    score = dspy.OutputField(desc="Score 0-10")
+    reasoning = dspy.OutputField(desc="Brief reasoning")
+
+
+def score_persona(persona_text: str, scenario: str, expected: str, lm: dspy.LM) -> float:
+    """Score a persona variant against a single scenario."""
+    with dspy.context(lm=lm):
+        evaluator = dspy.Predict(PersonaEvaluator)
+        result = evaluator(persona=persona_text, scenario=scenario, expected_behavior=expected)
+    try:
+        return float(result.score)
+    except (ValueError, TypeError):
+        return 5.0
+
+
+def evaluate_persona(persona_text: str, examples: list, lm: dspy.LM) -> float:
+    """Average score across all evaluation examples."""
+    scores = []
+    for ex in examples:
+        # Handle different field names in dataset
+        scenario = ex.task_input if hasattr(ex, "task_input") else ex.get("task_input", "")
+        expected = ex.expected_output if hasattr(ex, "expected_output") else \
+                   ex.expected_behavior if hasattr(ex, "expected_behavior") else \
+                   ex.get("expected_behavior", ex.get("expected_output", ""))
+        s = score_persona(persona_text, scenario, expected, lm)
+        scores.append(s)
+    return sum(scores) / max(1, len(scores))
+
+
+def generate_variations(current_persona: str, examples: list, lm: dspy.LM) -> List[str]:
+    """Generate 3 improved variations of the persona."""
+    # Build weaknesses summary from lowest-scoring examples
+    scores = []
+    for ex in examples:
+        scenario = ex.task_input if hasattr(ex, "task_input") else ex.get("task_input", "")
+        expected = ex.expected_output if hasattr(ex, "expected_output") else \
+                   ex.expected_behavior if hasattr(ex, "expected_behavior") else \
+                   ex.get("expected_behavior", ex.get("expected_output", ""))
+        s = score_persona(current_persona, scenario, expected, lm)
+        scores.append((s, scenario, expected))
+
+    # Sort by score, lowest first
+    scores.sort(key=lambda x: x[0])
+    weak_scenarios = scores[:3]
+    strong_scenarios = scores[-2:]
+
+    eval_text = "WEAK PERFORMANCES (need improvement):\n"
+    for s, sc, exp in weak_scenarios:
+        eval_text += f"- Score {s}/10 | Scenario: {sc[:120]}... | Expected: {exp[:120]}...\n"
+
+    eval_text += "\nSTRONG PERFORMANCES (preserve these):\n"
+    for s, sc, exp in strong_scenarios:
+        eval_text += f"- Score {s}/10 | Scenario: {sc[:120]}... | Expected: {exp[:120]}...\n"
+
+    weaknesses = "; ".join([f"{sc[:60]}... (scored {s})" for s, sc, _ in weak_scenarios])
+
+    with dspy.context(lm=lm):
+        generator = dspy.Predict(PersonaVariationGenerator)
+        result = generator(
+            current_persona=current_persona,
+            evaluation_scenarios=eval_text,
+            weaknesses=weaknesses,
+        )
+
+    variations = []
+    for v in [result.variation_1, result.variation_2, result.variation_3]:
+        if v and len(v) > 200:
+            variations.append(v)
+
+    # Always include current as baseline
+    variations.append(current_persona)
+    return variations
+
+
+def evolve_persona(
+    iterations: int = 120,
+    optimizer_model: str = "openai/glm-5.1",
+    eval_model: str = "openai/glm-5.1",
+    dry_run: bool = False,
+):
+    """Main persona evolution function using text mutation."""
+
+    console.print(f"\n[bold cyan]🧬 Persona Self-Evolution[/bold cyan] — Evolving agent identity\n")
+
+    persona_text = load_persona()
+    console.print(f"  Loaded: {PERSONA_PATH}")
+    console.print(f"  Size: {len(persona_text):,} chars")
+
+    if dry_run:
+        console.print(f"\n[bold green]DRY RUN — setup validated.[/bold green]")
+        return
+
+    # ── 1. Build evaluation dataset ──────────────────────────────────────
+    console.print(f"\n[bold]Building evaluation dataset[/bold] (source: synthetic)")
+
+    config = EvolutionConfig(
+        iterations=iterations,
+        optimizer_model=optimizer_model,
+        eval_model=eval_model,
+        judge_model=eval_model,
+    )
+    builder = SyntheticDatasetBuilder(config)
+    dataset = builder.generate(
+        artifact_text=persona_text,
+        artifact_type="persona",
+    )
+    save_path = Path("datasets") / "artifacts" / "persona"
+    dataset.save(save_path)
+    console.print(f"  Generated {len(dataset.all_examples)} synthetic examples")
+    console.print(f"  Split: {len(dataset.train)} train / {len(dataset.val)} val / {len(dataset.holdout)} holdout")
+
+    # ── 2. Configure DSPy ────────────────────────────────────────────────
+    api_base = os.environ.get("OPENAI_API_BASE") or os.environ.get("OPENAI_BASE_URL")
+    api_key = os.environ.get("OPENAI_API_KEY")
+    lm_kwargs = {}
+    if api_base:
+        lm_kwargs["api_base"] = api_base
+    if api_key:
+        lm_kwargs["api_key"] = api_key
+    lm = dspy.LM(eval_model, **lm_kwargs)
+    dspy.configure(lm=lm)
+
+    # ── 3. Baseline evaluation ───────────────────────────────────────────
+    console.print(f"\n[bold]Evaluating baseline persona[/bold]")
+    val_examples = dataset.to_dspy_examples("val")
+    baseline_score = evaluate_persona(persona_text, val_examples, lm)
+    console.print(f"  Baseline score: {baseline_score:.2f}/10")
+
+    # ── 4. Evolution loop ────────────────────────────────────────────────
+    console.print(f"\n[bold cyan]Running evolution ({iterations} iterations)...[/bold cyan]\n")
+
+    start_time = time.time()
+    best_persona = persona_text
+    best_score = baseline_score
+    history = [("baseline", baseline_score)]
+
+    for i in range(iterations):
+        console.print(f"  Iteration {i+1}/{iterations}")
+        variations = generate_variations(best_persona, val_examples, lm)
+
+        best_var_score = best_score
+        best_var_persona = best_persona
+
+        for j, var in enumerate(variations[:-1]):  # Exclude baseline (last)
+            score = evaluate_persona(var, val_examples, lm)
+            console.print(f"    Variant {j+1}: {score:.2f}/10")
+            if score > best_var_score:
+                best_var_score = score
+                best_var_persona = var
+
+        if best_var_score > best_score:
+            improvement = best_var_score - best_score
+            console.print(f"  [green]→ Improved by +{improvement:.2f}[/green]")
+            best_score = best_var_score
+            best_persona = best_var_persona
+            history.append((f"iter_{i+1}", best_score))
+        else:
+            console.print(f"  [yellow]→ No improvement[/yellow]")
+            history.append((f"iter_{i+1}", best_score))
+
+    elapsed = time.time() - start_time
+    console.print(f"\n  Evolution completed in {elapsed:.1f}s")
+
+    # ── 5. Validate constraints ──────────────────────────────────────────
+    console.print(f"\n[bold]Validating constraints[/bold]")
+    validator = ConstraintValidator(config)
+    constraints = validator.validate_all(best_persona, "skill", baseline_text=persona_text)
+
+    # For persona, skill_structure constraint may fail (no YAML frontmatter) — that's OK
+    all_pass = True
+    for c in constraints:
+        if c.constraint_name == "skill_structure":
+            # Persona doesn't need YAML frontmatter
+            console.print(f"  [yellow]⚑ {c.constraint_name}[/yellow]: {c.message} (skipped for persona)")
+            continue
+        icon = "✓" if c.passed else "✗"
+        color = "green" if c.passed else "red"
+        console.print(f"  [{color}]{icon} {c.constraint_name}[/{color}]: {c.message}")
+        if not c.passed:
+            all_pass = False
+
+    # ── 6. Holdout evaluation ────────────────────────────────────────────
+    console.print(f"\n[bold]Evaluating on holdout set ({len(dataset.holdout)} examples)[/bold]")
+    holdout_examples = dataset.to_dspy_examples("holdout")
+    holdout_baseline = evaluate_persona(persona_text, holdout_examples, lm)
+    holdout_evolved = evaluate_persona(best_persona, holdout_examples, lm)
+    improvement = holdout_evolved - holdout_baseline
+
+    # ── 7. Report ────────────────────────────────────────────────────────
+    table = Table(title="Persona Evolution Results")
+    table.add_column("Metric", style="bold")
+    table.add_column("Baseline", justify="right")
+    table.add_column("Evolved", justify="right")
+    table.add_column("Change", justify="right")
+
+    change_color = "green" if improvement > 0 else "red"
+    table.add_row(
+        "Holdout Score",
+        f"{holdout_baseline:.2f}",
+        f"{holdout_evolved:.2f}",
+        f"[{change_color}]{improvement:+.2f}[/{change_color}]",
+    )
+    table.add_row(
+        "Persona Size",
+        f"{len(persona_text):,} chars",
+        f"{len(best_persona):,} chars",
+        f"{len(best_persona) - len(persona_text):+,} chars",
+    )
+    table.add_row("Time", "", f"{elapsed:.1f}s", "")
+    table.add_row("Iterations", "", str(iterations), "")
+
+    console.print()
+    console.print(table)
+
+    # ── 8. Save output ───────────────────────────────────────────────────
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = Path("output") / "persona" / timestamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    (output_dir / "evolved_persona.md").write_text(best_persona)
+    (output_dir / "baseline_persona.md").write_text(persona_text)
+
+    metrics = {
+        "artifact_type": "persona",
+        "timestamp": timestamp,
+        "iterations": iterations,
+        "optimizer_model": optimizer_model,
+        "eval_model": eval_model,
+        "baseline_score": holdout_baseline,
+        "evolved_score": holdout_evolved,
+        "improvement": improvement,
+        "baseline_size": len(persona_text),
+        "evolved_size": len(best_persona),
+        "elapsed_seconds": elapsed,
+        "constraints_passed": all_pass,
+        "history": history,
+    }
+    (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+
+    console.print(f"\n  Output saved to {output_dir}/")
+
+    # ── 9. Deploy if improved ────────────────────────────────────────────
+    if improvement > 0:
+        console.print(f"\n[bold green]✓ Persona improved by {improvement:+.2f} on holdout[/bold green]")
+        save_persona(best_persona)
+        console.print(f"[bold green]✓ Deployed to {PERSONA_PATH}[/bold green]")
+    elif holdout_evolved >= holdout_baseline:
+        console.print(f"\n[yellow]⚠ No holdout improvement ({improvement:+.2f}). Keeping current.[/yellow]")
+    else:
+        console.print(f"\n[red]✗ Holdout degraded ({improvement:+.2f}). Keeping baseline.[/red]")
+
+
+@click.command()
+@click.option("--iterations", default=120, help="Number of evolution iterations")
+@click.option("--optimizer-model", default="openai/glm-5.1", help="Model for generating variations")
+@click.option("--eval-model", default="openai/glm-5.1", help="Model for evaluation")
+@click.option("--dry-run", is_flag=True, help="Validate setup without running")
+def main(iterations, optimizer_model, eval_model, dry_run):
+    """Evolve the Hermes Agent persona."""
+    evolve_persona(
+        iterations=iterations,
+        optimizer_model=optimizer_model,
+        eval_model=eval_model,
+        dry_run=dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/evolution/core/config.py
+++ b/evolution/core/config.py
@@ -14,13 +14,13 @@ class EvolutionConfig:
     hermes_agent_path: Path = field(default_factory=lambda: get_hermes_agent_path())
 
     # Optimization parameters
-    iterations: int = 10
+    iterations: int = 120
     population_size: int = 5
 
     # LLM configuration
-    optimizer_model: str = "openai/gpt-4.1"  # Model for GEPA reflections
-    eval_model: str = "openai/gpt-4.1-mini"  # Model for LLM-as-judge scoring
-    judge_model: str = "openai/gpt-4.1"  # Model for dataset generation
+    optimizer_model: str = "openai/glm-5.1"  # Model for GEPA reflections
+    eval_model: str = "openai/glm-5.1"  # Model for LLM-as-judge scoring
+    judge_model: str = "openai/glm-5.1"  # Model for dataset generation
 
     # Constraints
     max_skill_size: int = 15_000  # 15KB default

--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import dspy
+from json_repair import repair_json
 
 from evolution.core.config import EvolutionConfig
 
@@ -123,7 +124,15 @@ class SyntheticDatasetBuilder:
         n = num_cases or self.config.eval_dataset_size
 
         # Configure DSPy to use the judge model for generation
-        lm = dspy.LM(self.config.judge_model)
+        import os
+        api_base = os.environ.get("OPENAI_API_BASE") or os.environ.get("OPENAI_BASE_URL")
+        api_key = os.environ.get("OPENAI_API_KEY")
+        lm_kwargs = {}
+        if api_base:
+            lm_kwargs["api_base"] = api_base
+        if api_key:
+            lm_kwargs["api_key"] = api_key
+        lm = dspy.LM(self.config.judge_model, **lm_kwargs)
 
         with dspy.context(lm=lm):
             result = self.generator(
@@ -133,16 +142,23 @@ class SyntheticDatasetBuilder:
             )
 
         # Parse the generated test cases
+        raw = result.test_cases or "[]"
         try:
-            cases_raw = json.loads(result.test_cases)
-        except json.JSONDecodeError:
-            # Try to extract JSON from the response
+            cases_raw = json.loads(repair_json(raw))
+        except Exception:
+            # Try to extract JSON array from the response
             import re
-            match = re.search(r'\[.*\]', result.test_cases, re.DOTALL)
+            match = re.search(r'\[.*\]', raw, re.DOTALL)
             if match:
-                cases_raw = json.loads(match.group())
+                try:
+                    cases_raw = json.loads(repair_json(match.group()))
+                except Exception:
+                    cases_raw = []
             else:
-                raise ValueError(f"Could not parse test cases from LLM output: {result.test_cases[:200]}")
+                cases_raw = []
+
+        if not cases_raw:
+            raise ValueError(f"Could not parse test cases from LLM output: {raw[:200]}")
 
         examples = [
             EvalExample(

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -6,6 +6,7 @@ Usage:
 """
 
 import json
+import os
 import sys
 import time
 from pathlib import Path
@@ -65,7 +66,12 @@ def evolve(
         sys.exit(1)
 
     skill = load_skill(skill_path)
-    console.print(f"  Loaded: {skill_path.relative_to(config.hermes_agent_path)}")
+    try:
+        rel_path = skill_path.relative_to(config.hermes_agent_path)
+    except ValueError:
+        # Skill found in fallback dir (e.g. ~/.hermes/skills)
+        rel_path = skill_path.relative_to(Path.home() / ".hermes")
+    console.print(f"  Loaded: {rel_path}")
     console.print(f"  Name: {skill['name']}")
     console.print(f"  Size: {len(skill['raw']):,} chars")
     console.print(f"  Description: {skill['description'][:80]}...")
@@ -119,7 +125,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -137,8 +143,15 @@ def evolve(
     console.print(f"  Optimizer model: {optimizer_model}")
     console.print(f"  Eval model: {eval_model}")
 
-    # Configure DSPy
-    lm = dspy.LM(eval_model)
+    # Configure DSPy with custom API base/key for ZAI Coding
+    api_base = os.environ.get("OPENAI_API_BASE") or os.environ.get("OPENAI_BASE_URL")
+    api_key = os.environ.get("OPENAI_API_KEY")
+    lm_kwargs = {}
+    if api_base:
+        lm_kwargs["api_base"] = api_base
+    if api_key:
+        lm_kwargs["api_key"] = api_key
+    lm = dspy.LM(eval_model, **lm_kwargs)
     dspy.configure(lm=lm)
 
     # Create the baseline skill module
@@ -186,7 +199,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -36,11 +36,11 @@ console = Console()
 
 def evolve(
     skill_name: str,
-    iterations: int = 10,
+    iterations: int = 120,
     eval_source: str = "synthetic",
     dataset_path: Optional[str] = None,
-    optimizer_model: str = "openai/gpt-4.1",
-    eval_model: str = "openai/gpt-4.1-mini",
+    optimizer_model: str = "openai/glm-5.1",
+    eval_model: str = "openai/glm-5.1",
     hermes_repo: Optional[str] = None,
     run_tests: bool = False,
     dry_run: bool = False,
@@ -308,12 +308,12 @@ def evolve(
 
 @click.command()
 @click.option("--skill", required=True, help="Name of the skill to evolve")
-@click.option("--iterations", default=10, help="Number of GEPA iterations")
+@click.option("--iterations", default=120, help="Number of GEPA iterations")
 @click.option("--eval-source", default="synthetic", type=click.Choice(["synthetic", "golden", "sessiondb"]),
               help="Source for evaluation dataset")
 @click.option("--dataset-path", default=None, help="Path to existing eval dataset (JSONL)")
-@click.option("--optimizer-model", default="openai/gpt-4.1", help="Model for GEPA reflections")
-@click.option("--eval-model", default="openai/gpt-4.1-mini", help="Model for evaluations")
+@click.option("--optimizer-model", default="openai/glm-5.1", help="Model for GEPA reflections")
+@click.option("--eval-model", default="openai/glm-5.1", help="Model for evaluations")
 @click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
 @click.option("--run-tests", is_flag=True, help="Run full pytest suite as constraint gate")
 @click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -59,24 +59,37 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
     """Find a skill by name in the hermes-agent skills directory.
 
     Searches recursively for a SKILL.md in a directory matching the skill name.
+    Accepts both 'skill_name' and 'category/skill_name' formats.
+    Also falls back to ~/.hermes/skills if not found in hermes-agent/skills.
     """
-    skills_dir = hermes_agent_path / "skills"
-    if not skills_dir.exists():
-        return None
+    # Extract leaf name from 'category/skill_name' format
+    leaf_name = skill_name.split("/")[-1]
 
-    # Direct match: skills/<category>/<skill_name>/SKILL.md
-    for skill_md in skills_dir.rglob("SKILL.md"):
-        if skill_md.parent.name == skill_name:
-            return skill_md
+    # Search both possible skill directories
+    search_dirs = [hermes_agent_path / "skills"]
+    hermes_skills = Path.home() / ".hermes" / "skills"
+    if hermes_skills not in search_dirs:
+        search_dirs.append(hermes_skills)
 
-    # Fuzzy match: check the name field in frontmatter
-    for skill_md in skills_dir.rglob("SKILL.md"):
-        try:
-            content = skill_md.read_text()[:500]
-            if f"name: {skill_name}" in content or f'name: "{skill_name}"' in content:
-                return skill_md
-        except Exception:
+    for skills_dir in search_dirs:
+        if not skills_dir.exists():
             continue
+
+        # Direct match: skills/<category>/<skill_name>/SKILL.md
+        for skill_md in skills_dir.rglob("SKILL.md"):
+            if skill_md.parent.name == skill_name or skill_md.parent.name == leaf_name:
+                return skill_md
+
+        # Fuzzy match: check the name field in frontmatter
+        for skill_md in skills_dir.rglob("SKILL.md"):
+            try:
+                content = skill_md.read_text()[:500]
+                if f"name: {skill_name}" in content or f'name: "{skill_name}"' in content:
+                    return skill_md
+                if f"name: {leaf_name}" in content or f'name: "{leaf_name}"' in content:
+                    return skill_md
+            except Exception:
+                continue
 
     return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Evolutionary self-improvement for Hermes Agent — optimize skills, prompts, tool descriptions, and code using DSPy + GEPA"
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 authors = [
     {name = "Nous Research", email = "team@nousresearch.com"},
 ]
@@ -20,6 +20,7 @@ dependencies = [
     "pyyaml>=6.0",
     "click>=8.0",
     "rich>=13.0",
+    "json-repair>=0.35.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add artifact evolution modules used by local L3-L5 self-evolution wrappers
- make synthetic dataset generation honor OpenAI-compatible base URL/key env vars and tolerate repaired JSON
- add json-repair dependency and ignore local logs/output/operator scripts

## Verification
- venv/bin/python -m pytest -q
- venv/bin/python -m compileall -q evolution/artifacts evolution/core evolution/skills
- bash -n scripts/self_evolve_hourly.sh scripts/self_evolve_daily.sh scripts/run_l3_l5.sh
- secret scan for Discord webhook literals returned no matches