### PR TITLE
pass evolved_full to constraint validator so frontmatter check doesn't always fail

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -186,7 +186,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["body"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"


### PR DESCRIPTION
Fixes #93 (NousResearch/hermes-agent-self-evolution#93)

## Summary

`evolve_skill.py` step 7 passed `evolved_body` (markdown body only, no frontmatter) to `validator.validate_all()`, causing `_check_skill_structure` to always fail with "Skill missing: YAML frontmatter" even for valid skills.

`reassemble_skill()` was already building `evolved_full` (body + frontmatter) one line above, the validator just received the wrong variable.

**One-line fix:** pass `evolved_full` instead of `evolved_body` on line 189.

Without this fix every evolution run exits early, writes `evolved_FAILED.md`, and never produces `metrics.json`.
