### PR TITLE
fix(dataset_builder): json_repair fallback for non-strict judge JSON output

### DIFF
--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -7,6 +7,7 @@ C) Golden sets — hand-curated JSONL files
 """
 
 import json
+from json_repair import repair_json
 import random
 from pathlib import Path
 from dataclasses import dataclass, field
@@ -134,13 +135,24 @@ class SyntheticDatasetBuilder:
 
         # Parse the generated test cases
         try:
-            cases_raw = json.loads(result.test_cases)
+            try:
+                cases_raw = json.loads(result.test_cases)
+            except json.JSONDecodeError:
+                # Fallback: some judge / dataset-LM models (Qwen3.6, etc.) emit
+                # JSON with malformed escapes despite the schema constraint.
+                # json_repair tolerates and corrects common Qwen-class issues
+                # (invalid \escape, unquoted keys, trailing commas).
+                cases_raw = json.loads(repair_json(result.test_cases))
         except json.JSONDecodeError:
             # Try to extract JSON from the response
             import re
             match = re.search(r'\[.*\]', result.test_cases, re.DOTALL)
             if match:
-                cases_raw = json.loads(match.group())
+                try:
+                    cases_raw = json.loads(match.group())
+                except json.JSONDecodeError:
+                    # Same fallback as the primary parse — see note above.
+                    cases_raw = json.loads(repair_json(match.group()))
             else:
                 raise ValueError(f"Could not parse test cases from LLM output: {result.test_cases[:200]}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pyyaml>=6.0",
     "click>=8.0",
     "rich>=13.0",
+    "json-repair>=0.30",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

`SyntheticDatasetBuilder._generate_synthetic_with_dspy` calls
`json.loads(result.test_cases)` on output from whichever LM the operator
has configured. When that LM is a locally-hosted open-weights judge
like Qwen3.6-35B-A3B-FP8 (a common DGX Spark / single-GPU setup), the
generated JSON violates the strict `json.loads` grammar in roughly 15%
of generations:

- `Invalid \escape: line 1 column N` (most common — Qwen sometimes
  escapes characters Python's parser doesn't recognize as escapable)
- Unquoted keys
- Trailing commas after the last element of an array/object

The fallback regex (`re.search(r'\[.*\]', ...)`) finds the array slice,
but then re-applies `json.loads` to the same malformed payload, so the
whole evolve cycle fails with `ValueError: Could not parse test cases
from LLM output: ...` and the entire batch is lost.

## Fix

Add [`json-repair`](https://pypi.org/project/json-repair/) (MIT, 0 deps,
pure-Python, last released 2025-10) as a fallback for both parse sites:

1. After the primary `json.loads` raises `JSONDecodeError`, attempt
   `json.loads(repair_json(result.test_cases))` before falling through
   to the regex extraction.
2. After the regex extraction raises `JSONDecodeError`, attempt
   `json.loads(repair_json(match.group()))` before giving up.

Strict-JSON judges (gpt-5-mini, Claude, GPT-4-class models) stay on the
fast path because `json.loads` succeeds first and `repair_json` is never
invoked. Only the failing case pays the repair cost.

## Reproduction

On Qwen3.6-35B-A3B-FP8 (SGLang) configured as the DSPy LM:

Before patch:
```
$ for i in $(seq 1 50); do hermes-evolve --skill <name> 2>&1 | grep -c "Invalid.*escape"; done | awk '{s+=$1} END {print s}'
7
```

After patch:
```
$ for i in $(seq 1 50); do hermes-evolve --skill <name> 2>&1 | grep -c "Invalid.*escape"; done | awk '{s+=$1} END {print s}'
0
```

(7/50 batches recovered; previously they would have raised and dropped
the entire generated set.)

## Why json_repair specifically

- MIT-licensed (compatible with this repo's license)
- Zero runtime dependencies
- Pure Python (no C extension, works on any wheel target including
  aarch64 / DGX Spark)
- Well-maintained: continuous releases since 2024, active issue
  tracking
- Used by [llama-index](https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/output_parsers/utils.py)
  and other LM-output-parsing projects for the same purpose
- Pinned `>=0.30` (current 0.x line; semver-stable across the patch
  window we tested)

## Scope

Patch is intentionally minimal:

- 14 lines added to `evolution/core/dataset_builder.py`
- 1 line added to `pyproject.toml`
- No new public API
- No change to behavior on valid JSON input
- No change to error message when both parse paths fail (still raises
  `ValueError` with the same prefix)

## Risk

`repair_json` can theoretically silently "fix" malformed JSON in a way
that semantically diverges from operator intent. Mitigation:

- It only runs after `json.loads` has already failed (i.e., the data was
  going to be lost anyway)
- The downstream `_dict_to_test_case` shape validation still runs on the
  repaired output, so structurally-incorrect repairs are caught at the
  next stage
- Operators using strict-JSON judges never hit this code path at all