### PR TITLE
fix #93: pass evolved_full to validator instead of evolved_body

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -186,7 +186,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["body"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"


### PR DESCRIPTION
## Problem

Bug #93: `skill_structure` validator always fails — passes `evolved_body` without frontmatter.

When `evolve_skill.py` runs constraint validation (step 7), it passes `evolved_body` (markdown body only, no frontmatter) to `validator.validate_all()`. The `_check_skill_structure` check looks for `---` at the start of the text, so it always fails even when the skill file is perfectly valid.

**Root cause** (line 189):
```python
# BUG: passes evolved_body (no frontmatter) instead of evolved_full
evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
```

`reassemble_skill()` correctly builds `evolved_full` with frontmatter prepended, but that variable was never passed to the validator.

## Fix

```python
# FIX: pass evolved_full (with frontmatter) instead of evolved_body
evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["body"])
```

**1-line change**, zero behavioral risk — only affects which variable is passed to the existing validator.

Fixes #93