### PR TITLE
docs: Git Flow branching guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ python -m evolution.skills.evolve_skill \
 | **[DSPy](https://github.com/stanfordnlp/dspy) + [GEPA](https://github.com/gepa-ai/gepa)** | Reflective prompt evolution — reads execution traces, proposes targeted mutations | MIT |
 | **[Darwinian Evolver](https://github.com/imbue-ai/darwinian_evolver)** | Code evolution with Git-based organisms | AGPL v3 (external CLI only) |
 
+## Branching (Git Flow)
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Production-ready releases |
+| `develop` | Integration branch for day-to-day work |
+| `feature/*` | New work (branch from `develop`) |
+| `release/*` | Release prep (merge to `main` and `develop`) |
+| `hotfix/*` | Urgent production fixes (branch from `main`) |
+
+```bash
+git checkout develop && git pull
+git flow feature start my-change
+# ... commits ...
+git flow feature publish my-change
+gh pr create --base develop
+```
+
+Open pull requests against **`develop`**. Merges to **`main`** happen via `release/*` or `hotfix/*` (or maintainer-approved exceptions).
+
 ## Guardrails
 
 Every evolved variant must pass:


### PR DESCRIPTION
## Summary

- Documents Git Flow branch roles (`main`, `develop`, `feature/*`, `release/*`, `hotfix/*`).
- Adds **`develop`** on the fork at the same commit as `main` (integration branch for future PRs).

## Maintainer action (upstream)

This PR only updates docs on `main`. To complete Git Flow on the upstream repo, please **create a `develop` branch from `main`** (same SHA as after merge):

```bash
git fetch origin main
git branch develop origin/main
git push -u origin develop
```

Optional: set `develop` as the default branch for new PRs and protect `main`.

## Test plan

- [x] `git flow version` works locally
- [x] `develop` pushed to `jarrettj/hermes-agent-self-evolution`

Made with [Cursor](https://cursor.com)