### PR TITLE
fix(skills): strip duplicate frontmatter on reassembly + validate full file

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -186,7 +186,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["body"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -119,5 +119,15 @@ def reassemble_skill(frontmatter: str, evolved_body: str) -> str:
 
     Preserves the original YAML frontmatter (name, description, metadata)
     and replaces only the body with the evolved version.
+
+    If the evolved body already contains a frontmatter block (e.g. because
+    the optimizer was shown the full original SKILL.md and chose to include
+    it in its output), strip it before re-wrapping to avoid duplicate
+    ``---`` blocks.
     """
-    return f"---\n{frontmatter}\n---\n\n{evolved_body}\n"
+    body = evolved_body.lstrip()
+    if body.startswith("---"):
+        parts = body.split("---", 2)
+        if len(parts) >= 3:
+            body = parts[2].lstrip("\n")
+    return f"---\n{frontmatter}\n---\n\n{body}\n"

--- a/tests/skills/test_skill_module.py
+++ b/tests/skills/test_skill_module.py
@@ -90,3 +90,20 @@ class TestReassembleSkill:
 
         assert "EVOLVED" in result
         assert "New and improved" in result
+
+
+    def test_reassemble_strips_duplicate_frontmatter(self):
+        """If evolved body already contains a frontmatter block, it should
+        be stripped so the result has exactly one frontmatter."""
+        from evolution.skills.skill_module import reassemble_skill
+
+        frontmatter = 'name: foo\ndescription: bar'
+        evolved_with_fm = (
+            "---\nname: foo\ndescription: bar\n---\n\n# Evolved\n\ntext"
+        )
+        result = reassemble_skill(frontmatter, evolved_with_fm)
+
+        # Exactly one opening + one closing frontmatter delimiter
+        assert result.count("---") == 2
+        assert result.startswith("---\nname: foo")
+        assert "# Evolved" in result


### PR DESCRIPTION
## Summary
- Strip duplicate YAML frontmatter when reassembling evolved skill files
- Validate the full assembled SKILL.md (not just the body fragment)

## Test plan
- [x] `pytest tests/skills/test_skill_module.py -q`

Made with [Cursor](https://cursor.com)