### PR TITLE
chore: add optuna as explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ keywords = ["llm", "optimization", "evolution", "dspy", "gepa", "hermes", "agent
 
 dependencies = [
     "dspy>=3.0.0",
+    "optuna>=3.0.0",  # required by dspy.teleprompt.MIPROv2
     "openai>=1.0.0",
     "pyyaml>=6.0",
     "click>=8.0",


### PR DESCRIPTION
## Summary
Adds `optuna>=3.0.0` to core dependencies — required by `dspy.teleprompt.MIPROv2` at runtime but not always pulled transitively.

## Test plan
- [x] `pytest tests/ -q`

Made with [Cursor](https://cursor.com)