### PR TITLE
chore: add .gitleaks.toml allowlisting test fixtures

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,12 @@
+# gitleaks config — allowlist test fixtures that contain literal strings
+# passed to assertion helpers (not real secrets).
+title = "hermes-agent-self-evolution gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Test fixtures with literal secret-like strings"
+paths = [
+    '''tests/core/test_external_importers\.py''',
+]


### PR DESCRIPTION
## Summary
Allowlist test fixture strings in gitleaks so CI secret scans do not false-positive on assertion literals.

## Test plan
- [ ] `gitleaks detect --config .gitleaks.toml` (if gitleaks runs in CI)

Made with [Cursor](https://cursor.com)