### PR TITLE
Fix GEPA integration: kwarg mismatch, metric signature, explicit reflection_lm

### DIFF
--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -104,11 +104,14 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None, pred_name=None, pred_trace=None) -> float:
     """DSPy-compatible metric function for skill optimization.
 
     This is what gets passed to dspy.GEPA(metric=...).
     Returns a float 0-1 score.
+    
+    GEPAFeedbackMetric protocol requires pred_name and pred_trace parameters;
+    they are accepted but not used in this basic metric.
     """
     # The prediction should have an 'output' field with the agent's response
     agent_output = getattr(prediction, "output", "") or ""

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -156,7 +156,7 @@ def evolve(
     try:
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
-            max_steps=iterations,
+            max_full_evals=iterations,
         )
 
         optimized_module = optimizer.compile(

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -139,6 +139,7 @@ def evolve(
 
     # Configure DSPy
     lm = dspy.LM(eval_model)
+    reflection_lm = dspy.LM(optimizer_model, temperature=1.0, max_tokens=3000)
     dspy.configure(lm=lm)
 
     # Create the baseline skill module
@@ -157,6 +158,7 @@ def evolve(
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
             max_full_evals=iterations,
+            reflection_lm=reflection_lm,
         )
 
         optimized_module = optimizer.compile(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pyyaml>=6.0",
     "click>=8.0",
     "rich>=13.0",
+    "optuna>=3.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Fix GEPA integration: kwarg mismatch, metric signature, explicit reflection_lm

### Problem: Silent MIPROv2 Fallback

Currently, the `evolve_skill.py` module appears to use GEPA but **silently falls back to MIPROv2** when errors occur. This defeats the purpose of skill evolution, since:

- **MIPROv2 only tunes the DSPy wrapper instruction** — the high-level system prompt for the DSPy module.
- **GEPA is designed to mutate the skill body itself** — generating new, coherent skill text via reflective LM calls.
- Users see "Optimization completed" but the evolved skill is identical to the baseline, with no body mutations ever attempted.

### Root Causes

Three issues cause GEPA to fail silently and fall back to MIPROv2:

#### 1. **Incorrect kwarg: `max_steps` instead of `max_full_evals`**
```python
# ❌ Current (causes TypeError)
optimizer = dspy.GEPA(
    metric=skill_fitness_metric,
    max_steps=iterations,  # ← dspy.GEPA does not accept this
)

# ✅ Fixed
optimizer = dspy.GEPA(
    metric=skill_fitness_metric,
    max_full_evals=iterations,  # ← Correct kwarg
)
```

#### 2. **Missing `reflection_lm` — required for GEPA mutations**
```python
# ❌ Current
lm = dspy.LM(eval_model)
dspy.configure(lm=lm)
optimizer = dspy.GEPA(metric=skill_fitness_metric, max_full_evals=iterations)

# ✅ Fixed
lm = dspy.LM(eval_model)
reflection_lm = dspy.LM(optimizer_model, temperature=1.0, max_tokens=3000)
dspy.configure(lm=lm)
optimizer = dspy.GEPA(metric=skill_fitness_metric, max_full_evals=iterations, reflection_lm=reflection_lm)
```

Without `reflection_lm`, GEPA has no model to reflect on failed examples and generate mutations. DSPy silently falls back to MIPROv2, which only optimizes the instruction wrapper.

#### 3. **Metric signature mismatch: missing `pred_name` and `pred_trace` parameters**
```python
# ❌ Current
def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
    ...

# ✅ Fixed
def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None, pred_name=None, pred_trace=None) -> float:
    ...
```

GEPA's `GEPAFeedbackMetric` protocol passes `pred_name` and `pred_trace` when calling the metric. The original signature rejects these, causing TypeError.

#### 4. **Missing dependency: `optuna` not in pyproject.toml**
GEPA uses optuna for hyperparameter search. Fresh installs fail with `ImportError: No module named 'optuna'`. Added to dependencies.

### Verification: Run 02 Experiment

**With these fixes applied**, we executed a full 10-iteration GEPA run on `github-code-review` skill:

**Command:**
```bash
python -m evolution.skills.evolve_skill \
    --skill github-code-review \
    --iterations 10 \
    --eval-source synthetic \
    --optimizer-model openrouter/anthropic/claude-opus-4.8 \
    --eval-model openrouter/anthropic/claude-haiku-4.5
```

**Results:**
- ✅ **GEPA engaged end-to-end:** 18 metric rollouts, Pareto front tracking, reflective mutations generated
- ✅ **Mutations actively proposed:** Claude Opus generated ~18 skill text variants across 10 GEPA iterations (visible in logs: "Iteration N: Proposed new text for predictor.predict: [mutation]")
- ✅ **No silent fallback:** Logs show `dspy.teleprompt.gepa.gepa: Running GEPA for approx 15 metric calls...` — MIPROv2 fallback never triggered
- ✅ **Cost reasonable:** ~$10 with Opus reflection + Haiku judging via OpenRouter
- ⏱️ **Runtime:** ~19 min (1160.7 seconds)

**Log evidence (GEPA engagement):**
```
2026/06/07 22:41:03 INFO dspy.teleprompt.gepa.gepa: Running GEPA for approx 15 metric calls...
2026/06/07 22:41:03 INFO dspy.teleprompt.gepa.gepa: Using 5 examples for tracking Pareto scores.
2026/06/07 22:41:21 INFO dspy.evaluate.evaluate: Average Metric: 3.23964876910017 / 5 (64.8%)
2026/06/07 22:41:21 INFO dspy.teleprompt.gepa.gepa: Iteration 0: Base program full valset score: 0.647929753820034 over 5 / 5 examples
2026/06/07 22:42:14 INFO dspy.teleprompt.gepa.gepa: Iteration 1: Proposed new text for predictor.predict: # GitHub Code Review Agent
You are an AI agent that performs GitHub code reviews...
[mutation generated by reflection_lm]
```

### Test Results

All tests pass:
```
139 passed, 11 warnings in 1.62s
```

### Changes

- `evolution/skills/evolve_skill.py`: Fix `max_steps` → `max_full_evals` kwarg; add explicit `reflection_lm`
- `evolution/core/fitness.py`: Extend metric signature to accept `pred_name`, `pred_trace` parameters
- `pyproject.toml`: Add `optuna>=3.0.0` to dependencies

### Impact

After this fix:
- ✅ GEPA will no longer silently fall back to MIPROv2
- ✅ Skill body mutations will be actively generated and evaluated
- ✅ Users will see real skill evolution, not just instruction wrapper tuning
- ✅ The repo fulfills its intended purpose: evolutionary skill optimization

---

Found while building on this repo — thanks for open-sourcing it.
