### PR TITLE
fix(constraint-validator): validate reassembled full text, not body alone

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -185,8 +185,16 @@ def evolve(
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
+    # PATCH 2026-06-10 (WayneOS): validate the REASSEMBLED full text
+    # (`evolved_full`), not just the optimized body. The body alone has
+    # no YAML frontmatter (the optimizer never sees it), so the
+    # `skill_structure` constraint always rejected every evolution
+    # result on Wayne's stack — even when the LLM-as-judge found a real
+    # improvement. The fix is to validate what we'd actually deploy.
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(
+        evolved_full, "skill", baseline_text=skill["raw"]
+    )
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"

--- a/tests/core/test_constraints.py
+++ b/tests/core/test_constraints.py
@@ -96,3 +96,55 @@ class TestValidateAll:
         results = validator.validate_all("", "skill")
         failed = [r for r in results if not r.passed]
         assert len(failed) > 0
+
+    def test_evolved_full_reassembled_text_passes_skill_structure(self, validator):
+        """Regression test for the bug where `validate_all` was called with
+        `evolved_body` (the body slice with frontmatter already stripped by
+        `load_skill()`) and the `skill_structure` constraint falsely failed.
+
+        `reassemble_skill(frontmatter, evolved_body)` produces a complete
+        skill file with valid frontmatter. Validating the reassembled text
+        should pass all four constraints; validating the body alone should
+        not. This test pins the contract that the call site in
+        `evolution/skills/evolve_skill.py:189` depends on.
+        """
+        # Reassembled text — what the patched call site actually validates
+        reassembled = (
+            "---\n"
+            "name: evolved-skill\n"
+            "description: An evolved skill produced by the self-evolution pipeline\n"
+            "---\n"
+            "\n"
+            "# Procedure\n"
+            "1. Read the contract from the system prompt.\n"
+            "2. Verify the bridge is healthy.\n"
+            "3. Report pass/fail with evidence.\n"
+        )
+        results = validator.validate_all(reassembled, "skill")
+        skill_structure_result = next(r for r in results if r.constraint_name == "skill_structure")
+        assert skill_structure_result.passed, (
+            f"Reassembled skill text should pass skill_structure constraint, "
+            f"got: {skill_structure_result.message}"
+        )
+
+    def test_evolved_body_alone_fails_skill_structure(self, validator):
+        """Confirms the root cause: the body alone (no frontmatter) cannot
+        ever pass the skill_structure check. This is what the upstream bug
+        did — it validated the body, which structurally cannot pass.
+
+        This test exists so a future refactor that re-introduces
+        `validate_all(evolved_body, ...)` would fail loudly, with the
+        `skill_structure` constraint as the smoking gun.
+        """
+        body_only = (
+            "# Procedure\n"
+            "1. Read the contract from the system prompt.\n"
+            "2. Verify the bridge is healthy.\n"
+        )
+        results = validator.validate_all(body_only, "skill")
+        skill_structure_result = next(r for r in results if r.constraint_name == "skill_structure")
+        assert not skill_structure_result.passed, (
+            "Body-only text should fail skill_structure (no frontmatter) — "
+            "if this assertion fails, the constraint has changed shape and "
+            "the upstream call site may need a different fix."
+        )


### PR DESCRIPTION
# skill_structure constraint checks body, not reassembled text — false positives

## Problem

The `evolution.skills.evolve_skill` script extracts the YAML frontmatter and
body separately via `load_skill()`, runs the DSPy/MIPROv2 optimizer on the
body alone, then calls `reassemble_skill(frontmatter, evolved_body)` to
rebuild the full file. The `output/<skill>/evolved_FAILED.md` in the first
run on a typical install was 11,386 bytes — the correct reassembled file
with valid frontmatter.

But the script validates the evolved text BEFORE writing it, calling
`validator.validate_all(evolved_body, "skill", ...)` — i.e. it validates
**only the optimized body**, which by construction has no frontmatter
(the optimizer never sees it). The `skill_structure` constraint then
fails with "Skill missing: YAML frontmatter (---), name field,
description field" — and the script writes the file to
`evolved_FAILED.md` and exits without producing a metrics.json.

## Fix

Validate the **reassembled full text**, not just the optimized body. Either
of these two changes works:

**Option A (minimal):** swap the call site

```python
# Was:
evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])

# Becomes:
evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)  # hoist this up
evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
```

**Option B (cleaner):** make the validator format-aware

The constraint should know whether the input is a "body" or a "full skill".
If `type=skill` and the input lacks frontmatter, prepend the original
frontmatter before validating. This catches both real structural problems
(drift) and false positives (reassembly).

## Impact

- **Every successful evolution run on Hermes Agent that scores > baseline
  currently goes to `evolved_FAILED.md`** instead of being recorded as a
  valid improvement. The metrics.json is never written. The user sees
  "no improvement" even when the LLM-as-judge found one.
- This is the difference between a "0 deployed candidates" run and a
  "0 deployed, but the optimizer improved every one — they all failed
  structural validation for a stupid reason" situation.
- The fix is 1-2 lines and unblocks the entire evolution pipeline.

## Reproduction (on any install)

```bash
# 1. Run any evolution (this took ~13 min for 10 trials)
~/.hermes/hermes-agent/venv/bin/python \
    -m evolution.skills.evolve_skill \
    --skill <any-installed-skill> \
    --iterations 3 \
    --eval-source synthetic

# 2. Observe: "✗ Evolved skill FAILED constraints — not deploying"
#    The "FAILED" file IS structurally valid because the optimizer
#    scored an instruction variation that the body-only validator
#    couldn't recognize as having frontmatter.

# 3. Re-validate the FAILED file with the FULL text
cd ~/.hermes/hermes-agent && ~/.hermes/hermes-agent/venv/bin/python -c "
import sys
sys.path.insert(0, '<path-to-self-evolution-repo>')
from evolution.core.constraints import ConstraintValidator, EvolutionConfig
evolved = open('output/<skill>/evolved_FAILED.md').read()
v = ConstraintValidator(EvolutionConfig())
for c in v.validate_all(evolved, 'skill'):
    print(f'  {c.passed!r} {c.constraint_name}: {c.message}')
"
# Output: all constraints pass on the FAILED file when validated as
# the reassembled full text.
```

## Severity

Medium-to-high. Blocks all evolution deployments. Affects every Hermes
user who runs the self-evolution pipeline. The fact that no PRs have been
opened about it suggests most people don't run the pipeline end-to-end yet.

## Files affected

`evolution/skills/evolve_skill.py` — one call site at the constraint
validation step (around line 189, just before the save).

## Tests

Added two regression tests in `tests/core/test_constraints.py`:

- `test_evolved_full_reassembled_text_passes_skill_structure` — pins the
  contract that the call site depends on (reassembled text passes).
- `test_evolved_body_alone_fails_skill_structure` — confirms the root
  cause (body alone cannot pass), so a future refactor that
  reintroduces `validate_all(evolved_body, ...)` fails loudly.

The existing 16 unit tests in `test_constraints.py` all call
`_check_skill_structure` directly with hand-crafted strings. None of them
exercise the broken call site in `evolve_skill.py`, which is how the bug
shipped in the first place. The new tests go through `validate_all` with
realistic inputs (reassembled text vs body alone).

---

Closes #74. Also addresses the same bug filed in #11 and #93. The fix is the 1-line call-site swap; the two new tests are the regression guard so this doesn't silently regress in a future refactor.
