### PR TITLE
ci: add Phase 5 monitor read-only lane

### DIFF
--- a/.github/workflows/phase5-monitor-readonly-lane.yml
+++ b/.github/workflows/phase5-monitor-readonly-lane.yml
@@ -1,0 +1,45 @@
+name: Phase 5 monitor read-only lane
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/phase5-monitor-readonly-lane.yml"
+      - "evolution/monitor/**"
+      - "tests/monitor/test_phase5_*.py"
+      - "reports/phase5_*"
+      - "PLAN.md"
+      - "README.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  phase5-monitor-readonly:
+    name: Phase 5 monitor read-only lane
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # refs/tags/v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # refs/tags/v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package with test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run focused Phase 5 monitor tests
+        run: python -m pytest tests/monitor -q
+
+      - name: Compile Phase 5 monitor code and tests
+        run: python -m compileall -q evolution/monitor tests/monitor
+
+      - name: PR diff whitespace hygiene
+        run: git diff --check "origin/${{ github.base_ref }}...HEAD"


### PR DESCRIPTION
## Summary

Adds a dedicated base-branch GitHub Actions workflow for the Phase 5 monitor read-only lane so future Phase 5 monitor PRs can receive a normal pull_request check surface.

## Scope

- Adds only `.github/workflows/phase5-monitor-readonly-lane.yml`.
- Does not change branch protection, required checks, merge policy, runtime config, deployment, restart/reload, or active apply behavior.
- Does not mutate PR #117.

## Workflow gates

- `python -m pytest tests/monitor -q`
- `python -m compileall -q evolution/monitor tests/monitor`
- `git diff --check "origin/${ github.base_ref }...HEAD"`

## Local validation before publication

- Candidate SHA-256: `5c545d1fd61c2c4679c26eabaf749a0785506c380604ee1a76ad5339b412b0b0`
- YAML parse/structure validation: PASS
- Path filters exact validation: PASS
- Command surface validation: PASS
- Secret-marker scan: PASS
- Staged diff hygiene: PASS
- Changed files: `.github/workflows/phase5-monitor-readonly-lane.yml`
- Commit: `f1aa5d9e45bf59d5ac7d10f541300a45823ee2dd`
- Base observed: `4693c8f0eed21e39f065c6f38d98d2a403a04095`

## Changed files

```text
.github/workflows/phase5-monitor-readonly-lane.yml
```

## Diff stat

```text
.github/workflows/phase5-monitor-readonly-lane.yml | 45 ++++++++++++++++++++++
 1 file changed, 45 insertions(+)
```

## Follow-up boundary

Branch protection / required-check configuration is intentionally not included. If needed, it should be proposed only after a real successful workflow run reveals the exact check-run context name.
