### PR TITLE
fix(config): honor explicit --hermes-repo and make config construction non-fatal

### DIFF
--- a/evolution/core/config.py
+++ b/evolution/core/config.py
@@ -10,8 +10,11 @@ from typing import Optional
 class EvolutionConfig:
     """Configuration for a self-evolution optimization run."""
 
-    # hermes-agent repo path
-    hermes_agent_path: Path = field(default_factory=lambda: get_hermes_agent_path())
+    # hermes-agent repo path. Discovered lazily and non-fatally so the config
+    # can be constructed even when no repo is present (e.g. unit tests, or
+    # callers that pass an explicit path). Use resolve_hermes_agent_path() when
+    # an explicit override should win, or get_hermes_agent_path() to require one.
+    hermes_agent_path: Optional[Path] = field(default_factory=lambda: _discover_hermes_agent_path())
 
     # Optimization parameters
     iterations: int = 10
@@ -44,6 +47,19 @@ class EvolutionConfig:
     create_pr: bool = True
 
 
+def _discover_hermes_agent_path() -> Optional[Path]:
+    """Best-effort hermes-agent repo discovery that never raises.
+
+    Returns the discovered path, or None when no repo can be found. Used as
+    the EvolutionConfig default so construction never crashes; callers that
+    truly require the repo should use get_hermes_agent_path().
+    """
+    try:
+        return get_hermes_agent_path()
+    except FileNotFoundError:
+        return None
+
+
 def get_hermes_agent_path() -> Path:
     """Discover the hermes-agent repo path.
 
@@ -70,3 +86,17 @@ def get_hermes_agent_path() -> Path:
         "Cannot find hermes-agent repo. Set HERMES_AGENT_REPO env var "
         "or ensure it exists at ~/.hermes/hermes-agent"
     )
+
+
+def resolve_hermes_agent_path(hermes_repo: Optional[str] = None) -> Path:
+    """Return the hermes-agent repo path, honoring an explicit override.
+
+    An explicit path (for example from ``--hermes-repo``) is expanded and used
+    as-is, taking precedence over auto-discovery. This lets callers point at a
+    repo in a non-default location without the tool crashing just because
+    ``~/.hermes/hermes-agent`` happens to be absent. When no override is given,
+    falls back to :func:`get_hermes_agent_path`.
+    """
+    if hermes_repo:
+        return Path(hermes_repo).expanduser()
+    return get_hermes_agent_path()

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -18,7 +18,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from evolution.core.config import EvolutionConfig, get_hermes_agent_path
+from evolution.core.config import EvolutionConfig, resolve_hermes_agent_path
 from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset, GoldenDatasetLoader
 from evolution.core.external_importers import build_dataset_from_external
 from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore
@@ -47,14 +47,13 @@ def evolve(
     """Main evolution function — orchestrates the full optimization loop."""
 
     config = EvolutionConfig(
+        hermes_agent_path=resolve_hermes_agent_path(hermes_repo),
         iterations=iterations,
         optimizer_model=optimizer_model,
         eval_model=eval_model,
         judge_model=eval_model,  # Use same model for dataset generation
         run_pytest=run_tests,
     )
-    if hermes_repo:
-        config.hermes_agent_path = Path(hermes_repo)
 
     # ── 1. Find and load the skill ──────────────────────────────────────
     console.print(f"\n[bold cyan]🧬 Hermes Agent Self-Evolution[/bold cyan] — Evolving skill: [bold]{skill_name}[/bold]\n")

--- a/tests/core/test_config_repo_path.py
+++ b/tests/core/test_config_repo_path.py
@@ -1,0 +1,101 @@
+"""Regression tests for hermes-agent repo path resolution.
+
+Background
+----------
+Before this fix, ``EvolutionConfig.hermes_agent_path`` used a default factory
+that ran ``get_hermes_agent_path()`` at construction time. That meant:
+
+* constructing a bare ``EvolutionConfig()`` raised ``FileNotFoundError`` whenever
+  the default ``~/.hermes/hermes-agent`` location was absent (this is what made
+  16 tests in ``tests/core/test_constraints.py`` error on a clean checkout), and
+* ``evolve(..., hermes_repo=...)`` crashed before the explicit ``--hermes-repo``
+  override could be applied, so the documented flag did nothing.
+
+These tests lock in the fixed behavior at three levels: the resolver helper,
+the config dataclass, and the CLI end to end.
+"""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+
+def _make_skill_repo(tmp_path) -> Path:
+    """Create a minimal hermes-agent-style repo with one skill."""
+    repo = tmp_path / "my-hermes"
+    skill_dir = repo / "skills" / "testing" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Demo skill\n---\n\n# Demo\n\n1. Do the thing.\n"
+    )
+    return repo
+
+
+# ── resolver helper ────────────────────────────────────────────────────────
+
+def test_resolve_honors_explicit_path_without_default(tmp_path, monkeypatch):
+    from evolution.core.config import resolve_hermes_agent_path
+
+    monkeypatch.delenv("HERMES_AGENT_REPO", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "empty"))  # no default location
+
+    explicit = tmp_path / "somewhere" / "hermes-agent"
+    assert resolve_hermes_agent_path(str(explicit)) == explicit
+
+
+def test_resolve_expands_user_home(monkeypatch):
+    from evolution.core.config import resolve_hermes_agent_path
+
+    monkeypatch.setenv("HOME", "/home/example")
+    assert resolve_hermes_agent_path("~/code/hermes-agent") == Path("/home/example/code/hermes-agent")
+
+
+def test_resolve_falls_back_to_env_var_when_no_override(tmp_path, monkeypatch):
+    from evolution.core.config import resolve_hermes_agent_path
+
+    repo = tmp_path / "env-hermes"
+    repo.mkdir()
+    monkeypatch.setenv("HERMES_AGENT_REPO", str(repo))
+    assert resolve_hermes_agent_path() == repo
+
+
+# ── config dataclass (root cause) ──────────────────────────────────────────
+
+def test_config_constructs_without_repo(tmp_path, monkeypatch):
+    """A bare EvolutionConfig() must not raise when no repo is present."""
+    from evolution.core.config import EvolutionConfig
+
+    monkeypatch.delenv("HERMES_AGENT_REPO", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "empty"))
+
+    config = EvolutionConfig()  # must not raise
+    assert config.hermes_agent_path is None
+
+
+def test_config_preserves_explicit_path(tmp_path):
+    """An explicitly supplied path is kept as-is, never overwritten by discovery."""
+    from evolution.core.config import EvolutionConfig
+
+    explicit = tmp_path / "explicit" / "hermes-agent"
+    assert EvolutionConfig(hermes_agent_path=explicit).hermes_agent_path == explicit
+
+
+# ── CLI end to end ─────────────────────────────────────────────────────────
+
+def test_cli_dry_run_honors_explicit_repo(tmp_path, monkeypatch):
+    """`evolve_skill --hermes-repo <path> --dry-run` must work when the default
+    location is absent. This is the exact scenario the bug broke."""
+    from evolution.skills.evolve_skill import main
+
+    monkeypatch.delenv("HERMES_AGENT_REPO", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "empty"))
+    repo = _make_skill_repo(tmp_path)
+
+    result = CliRunner().invoke(
+        main,
+        ["--skill", "demo", "--hermes-repo", str(repo), "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "DRY RUN" in result.output
+    assert "Cannot find hermes-agent repo" not in result.output


### PR DESCRIPTION
I ran the skill evolver against a hermes-agent checkout outside the default location and it crashed even though I passed `--hermes-repo`, so I dug in.

The problem is the order things happen in. `EvolutionConfig` resolves the repo path in its `default_factory` the instant it is constructed, and `evolve_skill` only applies the `--hermes-repo` override on the next line, after the config already exists. The factory has already raised by then, so the override never lands. The same eager lookup also makes a plain `EvolutionConfig()` impossible to build with no repo around, which is why 16 tests in `tests/core/test_constraints.py` error on a clean checkout.

## What I changed

- Added `resolve_hermes_agent_path(hermes_repo)` in `config.py`. An explicit path is expanded and used as-is and takes precedence; with no override it falls back to the existing `get_hermes_agent_path()`.
- `evolve_skill` now passes `hermes_agent_path=resolve_hermes_agent_path(hermes_repo)` straight into `EvolutionConfig`, so the override is in place before anything is resolved.
- Made the `EvolutionConfig` default non-fatal: it discovers the repo through a helper that returns `None` instead of raising, so the config is constructible without a repo. `get_hermes_agent_path()` still raises for callers that genuinely require a repo, and `evolve_skill` still fails fast with the same clear message when there is no repo and no override.
- Added `tests/core/test_config_repo_path.py` covering the override, `~` expansion, env-var fallback, repo-less construction, and a CLI dry-run that no longer crashes.

## Testing

All offline, no API key. The new tests fail on a clean checkout of main and pass with this change. Running the repo suite the way CI does, `python -m pytest tests/ -q`, goes from 123 passed with 16 errors on main to 145 passed with 0 errors here. I also ran ruff on the changed files.

No new dependencies, no public signature changes, pathlib throughout so it behaves the same on macOS, Linux, and Windows.

Fixes #121