### PR TITLE
Add Phase 4 verifier harness

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -515,6 +515,8 @@ The system prompt is assembled in `run_agent.py` / `agent/prompt_builder.py` fro
 
 **Prerequisite:** Phases 1-3 complete — strong evaluation pipeline, validated benchmark gating, confidence in the optimization loop.
 
+Initial verifier support lives in `evolution/code/verifier_harness.py`. This is not a mutation engine. It is the admission layer Phase 4 candidates must pass: public workspace files and visible checks are exposed to the candidate, hidden checks stay in harness memory, adaptive candidates are compared against a frozen baseline, rejected candidate keys are cached, rollback/action traces are digested, and the full-suite gate remains mandatory before acceptance.
+
 **Week 1-2 (Build):** Set up Darwinian Evolver as external CLI. Build code-as-organism wrapper mapping tool files to GitBasedOrganism. Build composite fitness function (pytest + benchmarks + bug reproduction). This phase uses a different engine (Darwinian Evolver instead of DSPy+GEPA) so there's new infrastructure to build.
 
 **Week 2-3 (Run):** Start with known bugs from GitHub issues — create reproduction scripts, run evolution to find fixes. Then try edge case hardening on 1-2 tools (e.g., `file_tools.py`, `search_files`).

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Every evolved variant must pass:
 4. **Semantic preservation** — Must not drift from original purpose
 5. **PR review** — All changes go through human review, never direct commit
 
+6. **Phase 4 verifier gate** - Code candidates must beat a frozen baseline on sealed hidden checks, keep rollback traces, and pass the full-suite gate
+
 ## Full Plan
 
 See [PLAN.md](PLAN.md) for the complete architecture, evaluation data strategy, constraints, benchmarks integration, and phased timeline.

--- a/evolution/code/__init__.py
+++ b/evolution/code/__init__.py
@@ -1,1 +1,21 @@
-"""Phase placeholder: code evolution."""
+"""Phase 4 code-evolution support."""
+
+from evolution.code.verifier_harness import (
+    ActionTrace,
+    CheckResult,
+    CodeEvalTask,
+    CodeFitnessHarness,
+    GateDecision,
+    RunResult,
+    ToolActionSession,
+)
+
+__all__ = [
+    "ActionTrace",
+    "CheckResult",
+    "CodeEvalTask",
+    "CodeFitnessHarness",
+    "GateDecision",
+    "RunResult",
+    "ToolActionSession",
+]

--- a/evolution/code/verifier_harness.py
+++ b/evolution/code/verifier_harness.py
@@ -1,0 +1,439 @@
+"""Verifier gate for Phase 4 code-evolution candidates.
+
+This module is a small, repo-native adaptation of the verifier pattern used in
+``sunghunkwag/rsi-metaforge-core``: candidate code sees public files and visible
+checks, while the harness keeps hidden checks in memory and accepts a candidate
+only when it beats a frozen baseline without failing the regression gate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Mapping, Optional, Sequence
+
+
+CheckFn = Callable[[Path], "CheckResult"]
+CandidateRunner = Callable[["ToolActionSession"], None]
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Result from a visible, hidden, or regression-suite check."""
+
+    passed: bool
+    score: float = 0.0
+    detail: str = ""
+    residues: tuple[str, ...] = ()
+
+    @classmethod
+    def pass_(cls, detail: str = "passed", score: float = 1.0) -> "CheckResult":
+        return cls(True, score, detail, ())
+
+    @classmethod
+    def fail(
+        cls,
+        detail: str,
+        residues: Sequence[str] = (),
+        score: float = 0.0,
+    ) -> "CheckResult":
+        return cls(False, score, detail, tuple(residues))
+
+
+@dataclass(frozen=True)
+class ActionTrace:
+    """Deterministic audit record for one tool-layer action."""
+
+    action: str
+    input_hash: str
+    output_hash: str
+    status: str
+    failure_type: str = ""
+    cost: float = 1.0
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "action": self.action,
+            "input_hash": self.input_hash,
+            "output_hash": self.output_hash,
+            "status": self.status,
+            "failure_type": self.failure_type,
+            "cost": self.cost,
+        }
+
+
+@dataclass(frozen=True)
+class CodeEvalTask:
+    """A file-backed code repair task with visible and sealed hidden checks.
+
+    ``workspace_files`` are the only files provisioned for the candidate. The
+    hidden check remains a harness-side callable and is never written into the
+    workspace.
+    """
+
+    name: str
+    workspace_files: Mapping[str, str | bytes]
+    visible_check: CheckFn
+    hidden_check: CheckFn
+    full_suite_check: Optional[CheckFn] = None
+    allowed_tools: tuple[str, ...] = (
+        "read_file",
+        "write_file",
+        "apply_patch",
+        "revert_file",
+        "run_visible_check",
+    )
+
+    def provision(self, root: Path) -> Path:
+        workspace = Path(root) / self.name
+        if workspace.exists():
+            shutil.rmtree(workspace)
+        workspace.mkdir(parents=True, exist_ok=True)
+        for rel_path, payload in sorted(self.workspace_files.items()):
+            target = _safe_child(workspace, rel_path)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(payload, bytes):
+                target.write_bytes(payload)
+            else:
+                target.write_text(payload, encoding="utf-8")
+        return workspace
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """Complete result for one arm: frozen or adaptive."""
+
+    arm: str
+    visible: CheckResult
+    hidden: CheckResult
+    full_suite: CheckResult
+    traces: tuple[ActionTrace, ...] = ()
+    trace_digest: str = ""
+    skipped: bool = False
+
+    @classmethod
+    def skipped_result(cls, arm: str, reason: str) -> "RunResult":
+        skipped = CheckResult.fail(reason, ("skipped",))
+        return cls(arm, skipped, skipped, skipped, (), "", True)
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Final admission decision for a candidate against one task."""
+
+    accepted: bool
+    reason: str
+    adaptive: RunResult
+    frozen: RunResult
+    candidate_key: str
+    cached: bool = False
+
+
+class ToolActionSession:
+    """Restricted file-operation surface exposed to candidate runners."""
+
+    def __init__(
+        self,
+        root: Path,
+        visible_check: CheckFn,
+        allowed_tools: Sequence[str],
+    ) -> None:
+        self.root = Path(root).resolve()
+        self.visible_check = visible_check
+        self.allowed_tools = tuple(allowed_tools)
+        self.traces: list[ActionTrace] = []
+
+    def read_file(self, rel_path: str) -> str:
+        action = "read_file"
+        payload = {"path": rel_path}
+        before = self._tree_digest()
+        self._ensure_tool(action, payload, before)
+        path = self._resolve(action, payload, before, rel_path)
+        try:
+            out = path.read_text(encoding="utf-8")
+        except Exception:
+            self._reject(action, payload, before, "read_failed")
+            raise
+        self._record(action, payload, before, self._tree_digest(), "observed")
+        return out
+
+    def write_file(self, rel_path: str, content: str) -> None:
+        action = "write_file"
+        payload = {
+            "path": rel_path,
+            "content_hash": _digest_bytes(content.encode("utf-8")),
+        }
+        before = self._tree_digest()
+        self._ensure_tool(action, payload, before)
+        path = self._resolve(action, payload, before, rel_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        self._record(action, payload, before, self._tree_digest(), "committed")
+
+    def apply_patch(self, rel_path: str, old: str, new: str) -> bool:
+        action = "apply_patch"
+        payload = {
+            "path": rel_path,
+            "old_hash": _digest_bytes(old.encode("utf-8")),
+            "new_hash": _digest_bytes(new.encode("utf-8")),
+        }
+        before = self._tree_digest()
+        self._ensure_tool(action, payload, before)
+        path = self._resolve(action, payload, before, rel_path)
+        text = path.read_text(encoding="utf-8")
+        if text.count(old) != 1:
+            self._record(
+                action,
+                payload,
+                before,
+                before,
+                "reverted",
+                failure_type="patch_not_unique",
+            )
+            return False
+        path.write_text(text.replace(old, new, 1), encoding="utf-8")
+        self._record(action, payload, before, self._tree_digest(), "committed")
+        return True
+
+    def revert_file(self, rel_path: str, content: str) -> None:
+        action = "revert_file"
+        payload = {
+            "path": rel_path,
+            "content_hash": _digest_bytes(content.encode("utf-8")),
+        }
+        before = self._tree_digest()
+        self._ensure_tool(action, payload, before)
+        path = self._resolve(action, payload, before, rel_path)
+        path.write_text(content, encoding="utf-8")
+        self._record(action, payload, before, self._tree_digest(), "reverted")
+
+    def run_visible_check(self) -> CheckResult:
+        action = "run_visible_check"
+        payload = {"checker": getattr(self.visible_check, "__name__", "visible_check")}
+        before = self._tree_digest()
+        self._ensure_tool(action, payload, before)
+        try:
+            result = self.visible_check(self.root)
+        except Exception as exc:
+            result = CheckResult.fail(str(exc), ("visible_check_exception",))
+        self._record(
+            action,
+            payload,
+            before,
+            self._tree_digest(),
+            "observed",
+            failure_type="" if result.passed else "visible_check_failed",
+        )
+        return result
+
+    def _tree_digest(self) -> str:
+        entries: list[tuple[str, str]] = []
+        for path in sorted(p for p in self.root.rglob("*") if p.is_file()):
+            rel = path.relative_to(self.root).as_posix()
+            entries.append((rel, _digest_bytes(path.read_bytes())))
+        return _digest_json(entries)
+
+    def _record(
+        self,
+        action: str,
+        payload: object,
+        before: str,
+        after: str,
+        status: str,
+        failure_type: str = "",
+    ) -> None:
+        self.traces.append(
+            ActionTrace(
+                action=action,
+                input_hash=_digest_json(
+                    {"action": action, "payload": payload, "before": before}
+                ),
+                output_hash=_digest_json(
+                    {"after": after, "failure_type": failure_type}
+                ),
+                status=status,
+                failure_type=failure_type,
+            )
+        )
+
+    def _reject(
+        self,
+        action: str,
+        payload: object,
+        before: str,
+        failure_type: str,
+    ) -> None:
+        self._record(action, payload, before, before, "reverted", failure_type)
+        raise ValueError(f"{action} rejected: {failure_type}")
+
+    def _ensure_tool(self, action: str, payload: object, before: str) -> None:
+        if action not in self.allowed_tools:
+            self._reject(action, payload, before, "tool_not_allowed")
+
+    def _resolve(
+        self,
+        action: str,
+        payload: object,
+        before: str,
+        rel_path: str,
+    ) -> Path:
+        try:
+            return _safe_child(self.root, rel_path)
+        except ValueError:
+            self._reject(action, payload, before, "path_escape")
+            raise
+
+
+class CodeFitnessHarness:
+    """Admission gate for a Phase 4 candidate versus a frozen baseline."""
+
+    def __init__(
+        self,
+        *,
+        min_hidden_delta: float = 0.0,
+        cache_rejections: bool = True,
+    ) -> None:
+        self.min_hidden_delta = min_hidden_delta
+        self.cache_rejections = cache_rejections
+        self.rejected_candidate_keys: set[str] = set()
+
+    def evaluate(
+        self,
+        task: CodeEvalTask,
+        *,
+        adaptive_runner: CandidateRunner,
+        frozen_runner: CandidateRunner,
+        candidate_id: str,
+        root: Optional[Path] = None,
+    ) -> GateDecision:
+        candidate_key = _digest_json({"task": task.name, "candidate": candidate_id})
+        if candidate_key in self.rejected_candidate_keys:
+            return GateDecision(
+                accepted=False,
+                reason="rejected_cached",
+                adaptive=RunResult.skipped_result("adaptive", "rejected_cached"),
+                frozen=RunResult.skipped_result("frozen", "rejected_cached"),
+                candidate_key=candidate_key,
+                cached=True,
+            )
+
+        if root is None:
+            with tempfile.TemporaryDirectory(prefix="phase4_harness_") as tmp:
+                return self._evaluate_in_root(
+                    task, adaptive_runner, frozen_runner, candidate_id, Path(tmp)
+                )
+        return self._evaluate_in_root(
+            task, adaptive_runner, frozen_runner, candidate_id, Path(root)
+        )
+
+    def _evaluate_in_root(
+        self,
+        task: CodeEvalTask,
+        adaptive_runner: CandidateRunner,
+        frozen_runner: CandidateRunner,
+        candidate_id: str,
+        root: Path,
+    ) -> GateDecision:
+        candidate_key = _digest_json({"task": task.name, "candidate": candidate_id})
+        frozen = _run_arm(task, frozen_runner, root / "frozen", "frozen")
+        adaptive = _run_arm(task, adaptive_runner, root / "adaptive", "adaptive")
+
+        accepted, reason = self._decide(frozen, adaptive)
+        if not accepted and self.cache_rejections:
+            self.rejected_candidate_keys.add(candidate_key)
+        return GateDecision(
+            accepted=accepted,
+            reason=reason,
+            adaptive=adaptive,
+            frozen=frozen,
+            candidate_key=candidate_key,
+        )
+
+    def _decide(self, frozen: RunResult, adaptive: RunResult) -> tuple[bool, str]:
+        if not adaptive.visible.passed:
+            return False, "visible_gate_failed"
+        if not adaptive.hidden.passed:
+            return False, "hidden_gate_failed"
+        if not adaptive.full_suite.passed:
+            return False, "full_suite_failed"
+        required = frozen.hidden.score + self.min_hidden_delta
+        if adaptive.hidden.score <= required:
+            return False, "no_hidden_improvement"
+        return True, "accepted"
+
+
+def _run_arm(
+    task: CodeEvalTask,
+    runner: CandidateRunner,
+    root: Path,
+    arm: str,
+) -> RunResult:
+    workspace = task.provision(root)
+    session = ToolActionSession(workspace, task.visible_check, task.allowed_tools)
+    runner_error: Optional[Exception] = None
+    try:
+        runner(session)
+    except Exception as exc:
+        runner_error = exc
+
+    visible = _safe_check(task.visible_check, workspace, "visible_check_exception")
+    hidden = _safe_check(task.hidden_check, workspace, "hidden_check_exception")
+    full_suite = (
+        _safe_check(task.full_suite_check, workspace, "full_suite_exception")
+        if task.full_suite_check is not None
+        else CheckResult.pass_("full suite not configured")
+    )
+    if runner_error is not None:
+        visible = CheckResult.fail(str(runner_error), ("runner_exception",))
+
+    traces = tuple(session.traces)
+    return RunResult(
+        arm=arm,
+        visible=visible,
+        hidden=hidden,
+        full_suite=full_suite,
+        traces=traces,
+        trace_digest=_digest_json([trace.as_dict() for trace in traces]),
+    )
+
+
+def _safe_check(
+    check: CheckFn,
+    workspace: Path,
+    residue: str,
+) -> CheckResult:
+    try:
+        return check(workspace)
+    except Exception as exc:
+        return CheckResult.fail(str(exc), (residue,))
+
+
+def _safe_child(root: Path, rel_path: str) -> Path:
+    rel = Path(str(rel_path))
+    if rel.is_absolute():
+        raise ValueError(f"absolute path rejected: {rel_path}")
+    base = Path(root).resolve()
+    target = (base / rel).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(f"path escapes workspace: {rel_path}") from exc
+    return target
+
+
+def _digest_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()[:16]
+
+
+def _digest_json(payload: object) -> str:
+    raw = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return _digest_bytes(raw)

--- a/evolution/core/config.py
+++ b/evolution/core/config.py
@@ -70,11 +70,11 @@ def get_hermes_agent_path() -> Path:
     """
     env_path = os.getenv("HERMES_AGENT_REPO")
     if env_path:
-        p = Path(env_path).expanduser()
+        p = _expand_user_path(env_path)
         if p.exists():
             return p
 
-    home_path = Path.home() / ".hermes" / "hermes-agent"
+    home_path = _expand_user_path("~") / ".hermes" / "hermes-agent"
     if home_path.exists():
         return home_path
 
@@ -98,5 +98,23 @@ def resolve_hermes_agent_path(hermes_repo: Optional[str] = None) -> Path:
     falls back to :func:`get_hermes_agent_path`.
     """
     if hermes_repo:
-        return Path(hermes_repo).expanduser()
+        return _expand_user_path(hermes_repo)
     return get_hermes_agent_path()
+
+
+def _expand_user_path(path_value: str) -> Path:
+    """Expand ``~`` while honoring HOME in tests and CLI environments.
+
+    On Windows, ``Path.expanduser()`` prefers USERPROFILE over HOME. The CLI
+    tests monkeypatch HOME to simulate non-default repo locations, so this
+    helper keeps explicit paths and discovery behavior consistent across
+    platforms.
+    """
+    if path_value == "~":
+        home = os.getenv("HOME")
+        return Path(home) if home else Path(path_value).expanduser()
+    if path_value.startswith("~/") or path_value.startswith("~\\"):
+        home = os.getenv("HOME")
+        if home:
+            return Path(home) / path_value[2:]
+    return Path(path_value).expanduser()

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -25,7 +25,7 @@ def load_skill(skill_path: Path) -> dict:
             "description": str,
         }
     """
-    raw = skill_path.read_text()
+    raw = skill_path.read_text(encoding="utf-8")
 
     # Parse YAML frontmatter
     frontmatter = ""
@@ -72,7 +72,7 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
     # Fuzzy match: check the name field in frontmatter
     for skill_md in skills_dir.rglob("SKILL.md"):
         try:
-            content = skill_md.read_text()[:500]
+            content = skill_md.read_text(encoding="utf-8")[:500]
             if f"name: {skill_name}" in content or f'name: "{skill_name}"' in content:
                 return skill_md
         except Exception:

--- a/tests/code/__init__.py
+++ b/tests/code/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Phase 4 code-evolution support."""

--- a/tests/code/test_verifier_harness.py
+++ b/tests/code/test_verifier_harness.py
@@ -1,0 +1,227 @@
+"""Tests for the Phase 4 verifier/fitness harness."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+
+from evolution.code.verifier_harness import (
+    CheckResult,
+    CodeEvalTask,
+    CodeFitnessHarness,
+    ToolActionSession,
+)
+
+
+BUGGY_MATH_UTILS = """def add(a, b):
+    return a - b
+
+def add_all(values):
+    total = 0
+    for value in values:
+        total = add(total, value)
+    return total
+"""
+
+
+TRAIN_ONLY_MATH_UTILS = """def add(a, b):
+    if a == 2 and b == 3:
+        return 5
+    return a - b
+
+def add_all(values):
+    total = 0
+    for value in values:
+        total = add(total, value)
+    return total
+"""
+
+
+def _load_math_utils(workspace: Path):
+    path = workspace / "repo" / "math_utils.py"
+    shutil.rmtree(path.parent / "__pycache__", ignore_errors=True)
+    importlib.invalidate_caches()
+    module_name = f"math_utils_{abs(hash(path))}"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _visible_check(workspace: Path) -> CheckResult:
+    try:
+        mod = _load_math_utils(workspace)
+        if mod.add(2, 3) == 5:
+            return CheckResult.pass_("visible add case passed")
+    except Exception as exc:
+        return CheckResult.fail(str(exc), ("visible_exception",))
+    return CheckResult.fail("visible add case failed", ("visible_add_failed",))
+
+
+def _hidden_check(workspace: Path) -> CheckResult:
+    try:
+        mod = _load_math_utils(workspace)
+        probes = [
+            mod.add(-2, 5) == 3,
+            mod.add_all([1, 2, 3]) == 6,
+        ]
+    except Exception as exc:
+        return CheckResult.fail(str(exc), ("hidden_exception",))
+    score = sum(1 for ok in probes if ok) / len(probes)
+    if score == 1.0:
+        return CheckResult.pass_("hidden repo repair passed")
+    residues = tuple(f"hidden_probe_{i}_failed" for i, ok in enumerate(probes) if not ok)
+    return CheckResult.fail("hidden repo repair failed", residues, score=score)
+
+
+def _full_suite_passes(_: Path) -> CheckResult:
+    return CheckResult.pass_("pytest gate passed")
+
+
+def _full_suite_fails(_: Path) -> CheckResult:
+    return CheckResult.fail("pytest gate failed", ("pytest_failed",))
+
+
+def _repo_repair_task(*, full_suite=_full_suite_passes) -> CodeEvalTask:
+    return CodeEvalTask(
+        name="repo_repair",
+        workspace_files={
+            "repo/math_utils.py": BUGGY_MATH_UTILS,
+            "visible_cases.json": json.dumps({"add": [[2, 3, 5]]}, sort_keys=True),
+        },
+        visible_check=_visible_check,
+        hidden_check=_hidden_check,
+        full_suite_check=full_suite,
+    )
+
+
+def _frozen_noop(session: ToolActionSession) -> None:
+    session.read_file("repo/math_utils.py")
+
+
+def _train_only_candidate(session: ToolActionSession) -> None:
+    session.write_file("repo/math_utils.py", TRAIN_ONLY_MATH_UTILS)
+    session.run_visible_check()
+
+
+def _adaptive_candidate_with_rollback(session: ToolActionSession) -> None:
+    original = session.read_file("repo/math_utils.py")
+    assert session.apply_patch("repo/math_utils.py", "return a - b", "return a * b")
+    if not session.run_visible_check().passed:
+        session.revert_file("repo/math_utils.py", original)
+    assert session.apply_patch("repo/math_utils.py", "return a - b", "return a + b")
+    session.run_visible_check()
+
+
+def test_hidden_gate_rejects_train_only_candidate(tmp_path):
+    harness = CodeFitnessHarness()
+
+    decision = harness.evaluate(
+        _repo_repair_task(),
+        adaptive_runner=_train_only_candidate,
+        frozen_runner=_frozen_noop,
+        candidate_id="train-only-visible-fit",
+        root=tmp_path,
+    )
+
+    assert not decision.accepted
+    assert decision.reason == "hidden_gate_failed"
+    assert decision.adaptive.visible.passed
+    assert not decision.adaptive.hidden.passed
+
+
+def test_adaptive_patch_beats_frozen_and_records_rollback_trace(tmp_path):
+    harness = CodeFitnessHarness()
+
+    decision = harness.evaluate(
+        _repo_repair_task(),
+        adaptive_runner=_adaptive_candidate_with_rollback,
+        frozen_runner=_frozen_noop,
+        candidate_id="single-line-add-fix",
+        root=tmp_path,
+    )
+
+    assert decision.accepted
+    assert decision.reason == "accepted"
+    assert decision.frozen.hidden.score < decision.adaptive.hidden.score
+    assert decision.adaptive.full_suite.passed
+    statuses = [(trace.action, trace.status) for trace in decision.adaptive.traces]
+    assert ("revert_file", "reverted") in statuses
+    assert statuses.count(("apply_patch", "committed")) == 2
+    assert decision.adaptive.trace_digest
+
+
+def test_rejection_cache_blocks_repeat_candidate(tmp_path):
+    harness = CodeFitnessHarness()
+    task = _repo_repair_task()
+
+    first = harness.evaluate(
+        task,
+        adaptive_runner=_train_only_candidate,
+        frozen_runner=_frozen_noop,
+        candidate_id="same-bad-candidate",
+        root=tmp_path / "first",
+    )
+    second = harness.evaluate(
+        task,
+        adaptive_runner=_train_only_candidate,
+        frozen_runner=_frozen_noop,
+        candidate_id="same-bad-candidate",
+        root=tmp_path / "second",
+    )
+
+    assert not first.accepted
+    assert second.cached
+    assert second.reason == "rejected_cached"
+    assert second.adaptive.skipped
+    assert not list((tmp_path / "second").glob("**/*"))
+
+
+def test_hidden_expectations_stay_out_of_workspace(tmp_path):
+    hidden_canary = "SECRET_HIDDEN_CASE_ADD_NEGATIVE_AND_ADD_ALL"
+
+    def hidden_check_with_canary(workspace: Path) -> CheckResult:
+        assert hidden_canary
+        return _hidden_check(workspace)
+
+    task = _repo_repair_task()
+    task = CodeEvalTask(
+        name=task.name,
+        workspace_files=task.workspace_files,
+        visible_check=task.visible_check,
+        hidden_check=hidden_check_with_canary,
+        full_suite_check=task.full_suite_check,
+        allowed_tools=task.allowed_tools,
+    )
+
+    workspace = task.provision(tmp_path)
+    blob = ""
+    for path in workspace.rglob("*"):
+        if path.is_file():
+            assert "hidden" not in path.name.lower()
+            blob += path.read_text(encoding="utf-8")
+
+    assert hidden_canary not in blob
+    assert "visible_cases.json" in {path.name for path in workspace.rglob("*")}
+
+
+def test_full_suite_gate_blocks_hidden_success(tmp_path):
+    harness = CodeFitnessHarness()
+
+    decision = harness.evaluate(
+        _repo_repair_task(full_suite=_full_suite_fails),
+        adaptive_runner=_adaptive_candidate_with_rollback,
+        frozen_runner=_frozen_noop,
+        candidate_id="hidden-pass-regression-fail",
+        root=tmp_path,
+    )
+
+    assert not decision.accepted
+    assert decision.reason == "full_suite_failed"
+    assert decision.adaptive.hidden.passed
+    assert not decision.adaptive.full_suite.passed

--- a/tests/core/test_config_repo_path.py
+++ b/tests/core/test_config_repo_path.py
@@ -26,7 +26,8 @@ def _make_skill_repo(tmp_path) -> Path:
     skill_dir = repo / "skills" / "testing" / "demo"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
-        "---\nname: demo\ndescription: Demo skill\n---\n\n# Demo\n\n1. Do the thing.\n"
+        "---\nname: demo\ndescription: Demo skill\n---\n\n# Demo\n\n1. Do the thing.\n",
+        encoding="utf-8",
     )
     return repo
 

--- a/tests/skills/test_skill_module.py
+++ b/tests/skills/test_skill_module.py
@@ -32,7 +32,7 @@ Use this when you need to test things.
 class TestLoadSkill:
     def test_parses_frontmatter(self, tmp_path):
         skill_file = tmp_path / "SKILL.md"
-        skill_file.write_text(SAMPLE_SKILL)
+        skill_file.write_text(SAMPLE_SKILL, encoding="utf-8")
         skill = load_skill(skill_file)
 
         assert skill["name"] == "test-skill"
@@ -41,7 +41,7 @@ class TestLoadSkill:
 
     def test_parses_body(self, tmp_path):
         skill_file = tmp_path / "SKILL.md"
-        skill_file.write_text(SAMPLE_SKILL)
+        skill_file.write_text(SAMPLE_SKILL, encoding="utf-8")
         skill = load_skill(skill_file)
 
         assert "# Test Skill" in skill["body"]
@@ -50,14 +50,14 @@ class TestLoadSkill:
 
     def test_raw_contains_everything(self, tmp_path):
         skill_file = tmp_path / "SKILL.md"
-        skill_file.write_text(SAMPLE_SKILL)
+        skill_file.write_text(SAMPLE_SKILL, encoding="utf-8")
         skill = load_skill(skill_file)
 
         assert skill["raw"] == SAMPLE_SKILL
 
     def test_path_is_stored(self, tmp_path):
         skill_file = tmp_path / "SKILL.md"
-        skill_file.write_text(SAMPLE_SKILL)
+        skill_file.write_text(SAMPLE_SKILL, encoding="utf-8")
         skill = load_skill(skill_file)
 
         assert skill["path"] == skill_file
@@ -66,7 +66,7 @@ class TestLoadSkill:
 class TestReassembleSkill:
     def test_roundtrip(self, tmp_path):
         skill_file = tmp_path / "SKILL.md"
-        skill_file.write_text(SAMPLE_SKILL)
+        skill_file.write_text(SAMPLE_SKILL, encoding="utf-8")
         skill = load_skill(skill_file)
 
         reassembled = reassemble_skill(skill["frontmatter"], skill["body"])


### PR DESCRIPTION
Refs #118.

## Summary
- Add a small Phase 4 code verifier harness under `evolution/code/verifier_harness.py`.
- Model the admission gate as visible checks plus sealed hidden checks, adaptive-vs-frozen comparison, rejection caching, rollback/action trace digests, and a mandatory full-suite gate.
- Export the harness from `evolution.code` and document the Phase 4 verifier boundary in the README and plan.
- Make local path and skill-file tests portable by honoring `HOME` for explicit `~` paths and reading/writing skill fixtures as UTF-8.

## Why
Issue #118 argues that Phase 4 needs a verifier/fitness layer around code mutation, not only mutate-and-pytest. This PR adds a minimal repo-native admission layer that future Darwinian/code-evolution runners can call without importing the reference artifact wholesale.

## Validation
- `python -m pytest tests\code\test_verifier_harness.py -q` -> `5 passed`
- `python -m pytest -q` -> `150 passed, 11 warnings`