### PR TITLE
Add Phase 4 verifier harness

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -515,6 +515,8 @@ The system prompt is assembled in `run_agent.py` / `agent/prompt_builder.py` fro
 
 **Prerequisite:** Phases 1-3 complete — strong evaluation pipeline, validated benchmark gating, confidence in the optimization loop.
 
+Initial verifier support lives in `evolution/code/verifier_harness.py`. This is not a mutation engine. It is the admission layer Phase 4 candidates must pass: public workspace files and visible checks are exposed to the candidate, hidden checks stay in harness memory, adaptive candidates are compared against a frozen baseline, rejected candidate keys are cached, rollback/action traces are digested, and the full-suite gate remains mandatory before acceptance.
+
 **Week 1-2 (Build):** Set up Darwinian Evolver as external CLI. Build code-as-organism wrapper mapping tool files to GitBasedOrganism. Build composite fitness function (pytest + benchmarks + bug reproduction). This phase uses a different engine (Darwinian Evolver instead of DSPy+GEPA) so there's new infrastructure to build.
 
 **Week 2-3 (Run):** Start with known bugs from GitHub issues — create reproduction scripts, run evolution to find fixes. Then try edge case hardening on 1-2 tools (e.g., `file_tools.py`, `search_files`).

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Every evolved variant must pass:
 4. **Semantic preservation** — Must not drift from original purpose
 5. **PR review** — All changes go through human review, never direct commit
 
+6. **Phase 4 verifier gate** - Code candidates must beat a frozen baseline on sealed hidden checks, keep rollback traces, and pass the full-suite gate
+
 ## Full Plan
 
 See [PLAN.md](PLAN.md) for the complete architecture, evaluation data strategy, constraints, benchmarks integration, and phased timeline.

--- a/evolution/code/__init__.py
+++ b/evolution/code/__init__.py
@@ -1,1 +1,21 @@
-"""Phase placeholder: code evolution."""
+"""Phase 4 code-evolution support."""
+
+from evolution.code.verifier_harness import (
+    ActionTrace,
+    CheckResult,
+    CodeEvalTask,
+    CodeFitnessHarness,
+    GateDecision,
+    RunResult,
+    ToolActionSession,
+)
+
+__all__ = [
+    "ActionTrace",
+    "CheckResult",
+    "CodeEvalTask",
+    "CodeFitnessHarness",
+    "GateDecision",
+    "RunResult",
+    "ToolActionSession",
+]

--- a/evolution/code/phase4_mvp.py
+++ b/evolution/code/phase4_mvp.py
@@ -1,0 +1,524 @@
+"""Phase 4 MVP: the fitness/verifier *layer* assembled on the verifier_harness primitives.
+
+``verifier_harness.py`` provides the executable primitives. This module turns them
+into the full set of guarantees advertised in issue #118, so that the issue's
+claims and the code match one-to-one:
+
+    issue #118 layer                     delivered by
+    ----------------------------------   -------------------------------------------
+    sealed hidden evaluations            verifier_harness (CodeEvalTask.hidden_check)
+    adaptive-vs-frozen baseline          verifier_harness (CodeFitnessHarness._decide)
+    patch/revert traces                  verifier_harness (ToolActionSession/ActionTrace)
+    rejection caching                    verifier_harness (rejected_candidate_keys)
+    full-suite gating before accept      StrictCodeFitnessHarness          (here)
+    unseen-seed held-out evaluation      evaluate_on_unseen_seed           (here)
+    residue-driven curriculum            ResidueCurriculum                 (here)
+    deterministic lineage/archive        LineageArchive                    (here)
+    deterministic replay of accepted     LineageArchive.verify_replay /
+                                         LineageArchive.replay_evaluation  (here)
+    issue/PR summary emission            summarize_decision / render_markdown (here)
+
+GATE-PRESERVATION INVARIANT
+    The curriculum only *reorders and generates tasks*. It holds no reference to,
+    and never mutates, the acceptance thresholds in the harness. Failed attempts
+    make the search harder-targeted (a more representative visible surface), never
+    the gate softer. This is the same discipline as negative-grammar induction:
+    reorder exploration, do not lower the bar.
+"""
+
+from __future__ import annotations
+
+import difflib
+import hashlib
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Optional, Sequence
+
+from evolution.code.verifier_harness import (
+    CodeEvalTask,
+    CodeFitnessHarness,
+    GateDecision,
+    RunResult,
+)
+
+# A task factory takes (visible_seed, hidden_seed) and builds a held-out task whose
+# visible checks key off visible_seed and whose sealed hidden checks key off hidden_seed.
+TaskFactory = Callable[[int, int], CodeEvalTask]
+
+# Maps a failure residue string to a follow-up task that specifically targets it.
+ResidueTaskFactory = Callable[[str], Optional[CodeEvalTask]]
+
+
+def _sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()[:16]
+
+
+def _sha_json(payload: object) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return _sha(raw.encode("utf-8"))
+
+
+# --------------------------------------------------------------------------- #
+# 1. full-suite gating: refuse the free pass when no full suite is configured  #
+# --------------------------------------------------------------------------- #
+class StrictCodeFitnessHarness(CodeFitnessHarness):
+    """CodeFitnessHarness that refuses to accept a candidate that was never run
+    through a full suite.
+
+    The base harness treats a missing ``full_suite_check`` as a pass
+    (``CheckResult.pass_("full suite not configured")``). For a real Phase 4
+    target the MVP requires "full test-suite pass after accepted patch", so an
+    unconfigured suite must be a *non-acceptance*, not a silent free pass.
+    """
+
+    _NOT_CONFIGURED = "full suite not configured"
+
+    def __init__(
+        self,
+        *,
+        min_hidden_delta: float = 0.0,
+        cache_rejections: bool = True,
+        require_full_suite: bool = True,
+    ) -> None:
+        super().__init__(
+            min_hidden_delta=min_hidden_delta, cache_rejections=cache_rejections
+        )
+        self.require_full_suite = require_full_suite
+
+    def _decide(self, frozen: RunResult, adaptive: RunResult) -> tuple[bool, str]:
+        if (
+            self.require_full_suite
+            and adaptive.full_suite.passed
+            and adaptive.full_suite.detail == self._NOT_CONFIGURED
+        ):
+            return False, "full_suite_required"
+        return super()._decide(frozen, adaptive)
+
+
+# --------------------------------------------------------------------------- #
+# 2. unseen-seed held-out evaluation                                          #
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class HeldOutEvaluation:
+    decision: GateDecision
+    visible_seed: int
+    hidden_seed: int
+
+
+def evaluate_on_unseen_seed(
+    harness: CodeFitnessHarness,
+    factory: TaskFactory,
+    *,
+    adaptive_runner,
+    frozen_runner,
+    candidate_id: str,
+    visible_seed: int,
+    hidden_seed: int,
+    root: Optional[Path] = None,
+) -> HeldOutEvaluation:
+    """Evaluate adaptive vs frozen where the hidden/full-suite seed is *unseen*.
+
+    The candidate only ever observes the visible-seed checks during its run; the
+    gate scores it on the hidden-seed checks it never had access to. We refuse to
+    run with ``hidden_seed == visible_seed`` so the held-out property cannot be
+    accidentally collapsed.
+    """
+    if visible_seed == hidden_seed:
+        raise ValueError(
+            "hidden_seed must differ from visible_seed; otherwise the evaluation "
+            "is not held-out and the gate proves nothing about unseen behavior"
+        )
+    task = factory(visible_seed, hidden_seed)
+    decision = harness.evaluate(
+        task,
+        adaptive_runner=adaptive_runner,
+        frozen_runner=frozen_runner,
+        candidate_id=candidate_id,
+        root=root,
+    )
+    return HeldOutEvaluation(decision, visible_seed, hidden_seed)
+
+
+# --------------------------------------------------------------------------- #
+# 3. residue-driven curriculum (gate-preserving)                              #
+# --------------------------------------------------------------------------- #
+@dataclass
+class _Pending:
+    task: CodeEvalTask
+    residue: str
+    priority: int
+
+
+class ResidueCurriculum:
+    """Turns failure residues into a prioritized queue of follow-up tasks.
+
+    Contract: this object never sees or changes acceptance thresholds. It only
+    decides *which task to attempt next*. A residue is "covered" once it has
+    produced a follow-up task, so the same failure is not rediscovered into the
+    same task twice.
+    """
+
+    def __init__(
+        self, residue_factories: Optional[Mapping[str, ResidueTaskFactory]] = None
+    ) -> None:
+        self._factories: dict[str, ResidueTaskFactory] = dict(residue_factories or {})
+        self._base: list[CodeEvalTask] = []
+        self._pending: dict[str, _Pending] = {}
+        self._covered: set[str] = set()
+        self._residue_counts: Counter = Counter()
+
+    def register(self, residue: str, factory: ResidueTaskFactory) -> None:
+        self._factories[residue] = factory
+
+    def seed(self, tasks: Sequence[CodeEvalTask]) -> None:
+        self._base.extend(tasks)
+
+    def observe(self, decision: GateDecision) -> list[CodeEvalTask]:
+        """Consume an evaluation result; schedule targeted follow-ups for any
+        new failure residue. Returns the tasks newly scheduled (for logging)."""
+        if decision.accepted:
+            return []
+        new_tasks: list[CodeEvalTask] = []
+        for residue in self._collect_residues(decision):
+            self._residue_counts[residue] += 1
+            if residue in self._covered:
+                continue
+            factory = self._factories.get(residue)
+            if factory is None:
+                continue
+            task = factory(residue)
+            if task is None:
+                continue
+            self._covered.add(residue)
+            self._pending[task.name] = _Pending(
+                task, residue, self._residue_counts[residue]
+            )
+            new_tasks.append(task)
+        return new_tasks
+
+    def next_task(self) -> Optional[CodeEvalTask]:
+        """Highest-priority pending follow-up (impact x frequency proxy), then the
+        base queue. Deterministic tie-break by task name."""
+        if self._pending:
+            name = sorted(
+                self._pending, key=lambda n: (-self._pending[n].priority, n)
+            )[0]
+            return self._pending.pop(name).task
+        if self._base:
+            return self._base.pop(0)
+        return None
+
+    def residue_counts(self) -> dict[str, int]:
+        return dict(self._residue_counts)
+
+    @staticmethod
+    def _collect_residues(decision: GateDecision) -> list[str]:
+        arm = decision.adaptive
+        residues: list[str] = []
+        for check in (arm.visible, arm.hidden, arm.full_suite):
+            residues.extend(check.residues)
+        for trace in arm.traces:
+            if trace.failure_type:
+                residues.append(trace.failure_type)
+        # stable de-dup preserving first-seen order
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for r in residues:
+            if r not in seen:
+                seen.add(r)
+                ordered.append(r)
+        return ordered
+
+
+# --------------------------------------------------------------------------- #
+# 4. deterministic lineage/archive + replay                                   #
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class LineageEntry:
+    candidate_id: str
+    parent_id: Optional[str]
+    task_name: str
+    accepted: bool
+    reason: str
+    frozen_hidden: float
+    adaptive_hidden: float
+    hidden_delta: float
+    trace_digest: str
+    initial_files: tuple[tuple[str, str], ...]
+    final_files: tuple[tuple[str, str], ...]
+    final_tree_digest: str
+
+    def as_dict(self) -> dict[str, object]:
+        # bodies excluded for compact audit records; digests preserved
+        return {
+            "candidate_id": self.candidate_id,
+            "parent_id": self.parent_id,
+            "task_name": self.task_name,
+            "accepted": self.accepted,
+            "reason": self.reason,
+            "frozen_hidden": self.frozen_hidden,
+            "adaptive_hidden": self.adaptive_hidden,
+            "hidden_delta": self.hidden_delta,
+            "trace_digest": self.trace_digest,
+            "final_tree_digest": self.final_tree_digest,
+        }
+
+
+class LineageArchive:
+    """Append-only, deterministic archive of every candidate evaluated.
+
+    Preserves accepted *and* rejected candidates, parent->child lineage, patch
+    trace digests, and the initial/final workspace contents needed to audit a
+    diff and to deterministically replay an accepted candidate.
+    """
+
+    def __init__(self) -> None:
+        self._entries: list[LineageEntry] = []
+        self._by_id: dict[str, LineageEntry] = {}
+
+    def record(
+        self,
+        *,
+        decision: GateDecision,
+        task: CodeEvalTask,
+        final_files: Sequence[tuple[str, str]],
+        parent_id: Optional[str] = None,
+    ) -> LineageEntry:
+        initial = _normalize_files(
+            (name, payload)
+            for name, payload in task.workspace_files.items()
+        )
+        final = _normalize_files(final_files)
+        entry = LineageEntry(
+            candidate_id=decision.candidate_key,
+            parent_id=parent_id,
+            task_name=task.name,
+            accepted=decision.accepted,
+            reason=decision.reason,
+            frozen_hidden=decision.frozen.hidden.score,
+            adaptive_hidden=decision.adaptive.hidden.score,
+            hidden_delta=round(
+                decision.adaptive.hidden.score - decision.frozen.hidden.score, 6
+            ),
+            trace_digest=decision.adaptive.trace_digest,
+            initial_files=initial,
+            final_files=final,
+            final_tree_digest=_sha_json(list(final)),
+        )
+        self._entries.append(entry)
+        self._by_id[entry.candidate_id] = entry
+        return entry
+
+    def entries(self) -> tuple[LineageEntry, ...]:
+        return tuple(self._entries)
+
+    def get(self, candidate_id: str) -> LineageEntry:
+        return self._by_id[candidate_id]
+
+    def lineage_of(self, candidate_id: str) -> list[LineageEntry]:
+        chain: list[LineageEntry] = []
+        cur: Optional[str] = candidate_id
+        seen: set[str] = set()
+        while cur is not None and cur in self._by_id and cur not in seen:
+            seen.add(cur)
+            entry = self._by_id[cur]
+            chain.append(entry)
+            cur = entry.parent_id
+        chain.reverse()
+        return chain
+
+    def rejected_count(self) -> int:
+        return sum(1 for e in self._entries if not e.accepted)
+
+    def unified_diff(self, entry: LineageEntry) -> str:
+        initial = dict(entry.initial_files)
+        final = dict(entry.final_files)
+        chunks: list[str] = []
+        for name in sorted(set(initial) | set(final)):
+            before = initial.get(name, "").splitlines(keepends=True)
+            after = final.get(name, "").splitlines(keepends=True)
+            diff = difflib.unified_diff(
+                before, after, fromfile=f"a/{name}", tofile=f"b/{name}"
+            )
+            chunks.append("".join(diff))
+        return "".join(c for c in chunks if c)
+
+    def verify_replay(self, entry: LineageEntry) -> bool:
+        """Tamper-evident integrity replay: recompute the digest of the archived
+        final artifact and confirm it matches what was recorded at accept time."""
+        return _sha_json(list(entry.final_files)) == entry.final_tree_digest
+
+    def replay_evaluation(self, entry: LineageEntry, task: CodeEvalTask) -> bool:
+        """Stronger replay: re-materialize the archived final artifact and re-run
+        the task's hidden + full-suite checks, confirming the recorded adaptive
+        hidden score reproduces. Deterministic given deterministic checks."""
+        import shutil
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="phase4_replay_") as tmp:
+            workspace = Path(tmp) / task.name
+            if workspace.exists():
+                shutil.rmtree(workspace)
+            workspace.mkdir(parents=True, exist_ok=True)
+            for name, content in entry.final_files:
+                target = workspace / name
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(content, encoding="utf-8")
+            hidden = task.hidden_check(workspace)
+            if task.full_suite_check is not None:
+                full = task.full_suite_check(workspace)
+                if not full.passed:
+                    return False
+        return abs(hidden.score - entry.adaptive_hidden) < 1e-9
+
+
+def _normalize_files(
+    items,
+) -> tuple[tuple[str, str], ...]:
+    out: list[tuple[str, str]] = []
+    for name, payload in items:
+        if isinstance(payload, bytes):
+            out.append((str(name), f"<bytes:{_sha(payload)}>"))
+        else:
+            out.append((str(name), str(payload)))
+    out.sort(key=lambda kv: kv[0])
+    return tuple(out)
+
+
+def evaluate_with_lineage(
+    harness: CodeFitnessHarness,
+    task: CodeEvalTask,
+    *,
+    adaptive_runner,
+    frozen_runner,
+    candidate_id: str,
+    archive: LineageArchive,
+    root: Path,
+    parent_id: Optional[str] = None,
+) -> tuple[GateDecision, LineageEntry]:
+    """Run an evaluation under a caller-owned root so the adaptive workspace can
+    be snapshotted into the archive *without modifying the core harness*.
+
+    The base harness, when given an explicit ``root``, leaves the adaptive
+    workspace on disk at ``root/adaptive/<task.name>``; we read it back after the
+    decision and hand it to the archive.
+    """
+    decision = harness.evaluate(
+        task,
+        adaptive_runner=adaptive_runner,
+        frozen_runner=frozen_runner,
+        candidate_id=candidate_id,
+        root=root,
+    )
+    adaptive_ws = Path(root) / "adaptive" / task.name
+    final_files = _read_tree(adaptive_ws)
+    entry = archive.record(
+        decision=decision, task=task, final_files=final_files, parent_id=parent_id
+    )
+    return decision, entry
+
+
+def _read_tree(root: Path) -> list[tuple[str, str]]:
+    root = Path(root)
+    if not root.exists():
+        return []
+    out: list[tuple[str, str]] = []
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        rel = path.relative_to(root).as_posix()
+        try:
+            out.append((rel, path.read_text(encoding="utf-8")))
+        except UnicodeDecodeError:
+            out.append((rel, f"<bytes:{_sha(path.read_bytes())}>"))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# 5. issue/PR summary emission                                                #
+# --------------------------------------------------------------------------- #
+def summarize_decision(
+    decision: GateDecision,
+    *,
+    rejected_count: int = 0,
+    lineage_entry: Optional[LineageEntry] = None,
+    diff_summary: Optional[str] = None,
+) -> dict[str, object]:
+    """Build the MVP acceptance summary required by issue #118: hidden score
+    delta, frozen vs adaptive comparison, patch trace digest, rejected count,
+    final diff summary."""
+    adaptive, frozen = decision.adaptive, decision.frozen
+    summary: dict[str, object] = {
+        "accepted": decision.accepted,
+        "reason": decision.reason,
+        "candidate_key": decision.candidate_key,
+        "hidden_score_delta": round(
+            adaptive.hidden.score - frozen.hidden.score, 6
+        ),
+        "frozen_vs_adaptive": {
+            "frozen": {
+                "visible_passed": frozen.visible.passed,
+                "hidden_score": frozen.hidden.score,
+                "full_suite_passed": frozen.full_suite.passed,
+            },
+            "adaptive": {
+                "visible_passed": adaptive.visible.passed,
+                "hidden_score": adaptive.hidden.score,
+                "full_suite_passed": adaptive.full_suite.passed,
+            },
+        },
+        "patch_trace_digest": {
+            "adaptive": adaptive.trace_digest,
+            "frozen": frozen.trace_digest,
+        },
+        "rejected_candidate_count": rejected_count,
+        "diff_summary": diff_summary
+        if diff_summary is not None
+        else _trace_diff_summary(adaptive),
+    }
+    if lineage_entry is not None:
+        summary["lineage"] = {
+            "candidate_id": lineage_entry.candidate_id,
+            "parent_id": lineage_entry.parent_id,
+            "final_tree_digest": lineage_entry.final_tree_digest,
+        }
+    return summary
+
+
+def _trace_diff_summary(run: RunResult) -> dict[str, object]:
+    committed = Counter()
+    files: set[str] = set()
+    for trace in run.traces:
+        if trace.status == "committed":
+            committed[trace.action] += 1
+    return {
+        "writes": committed.get("write_file", 0),
+        "patches": committed.get("apply_patch", 0),
+        "reverts": committed.get("revert_file", 0),
+        "committed_actions": int(sum(committed.values())),
+    }
+
+
+def render_markdown(summary: Mapping[str, object]) -> str:
+    """Render the summary as the issue/PR comment block #118 asks for."""
+    fa = summary["frozen_vs_adaptive"]  # type: ignore[index]
+    frozen = fa["frozen"]  # type: ignore[index]
+    adaptive = fa["adaptive"]  # type: ignore[index]
+    digest = summary["patch_trace_digest"]  # type: ignore[index]
+    lines = [
+        f"### Phase 4 verifier decision: {'ACCEPTED' if summary['accepted'] else 'REJECTED'} ({summary['reason']})",
+        "",
+        f"- hidden score delta: `{summary['hidden_score_delta']}`",
+        f"- frozen hidden: `{frozen['hidden_score']}`  |  adaptive hidden: `{adaptive['hidden_score']}`",
+        f"- frozen full-suite: `{frozen['full_suite_passed']}`  |  adaptive full-suite: `{adaptive['full_suite_passed']}`",
+        f"- patch trace digest (adaptive): `{digest['adaptive']}`",
+        f"- rejected candidate count: `{summary['rejected_candidate_count']}`",
+        f"- diff summary: `{json.dumps(summary['diff_summary'], sort_keys=True)}`",
+    ]
+    if "lineage" in summary:
+        lineage = summary["lineage"]  # type: ignore[index]
+        lines.append(
+            f"- lineage: `{lineage['candidate_id']}` <- parent `{lineage['parent_id']}` "
+            f"(final tree `{lineage['final_tree_digest']}`)"
+        )
+    return "\n".join(lines)

--- a/evolution/code/verifier_harness.py
+++ b/evolution/code/verifier_harness.py
@@ -1,0 +1,443 @@
+"""Verifier gate for Phase 4 code-evolution candidates.
+
+This module is a small, repo-native adaptation of the verifier pattern used in
+``sunghunkwag/rsi-metaforge-core``: candidate code sees public files and visible
+checks, while the harness keeps hidden checks in memory and accepts a candidate
+only when it beats a frozen baseline without failing the regression gate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import (
+    Callable,
+    Mapping,
+    Optional,
+    Sequence,
+)
+
+CheckFn = Callable[[Path], "CheckResult"]
+CandidateRunner = Callable[["ToolActionSession"], None]
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Result from a visible, hidden, or regression-suite check."""
+
+    passed: bool
+    score: float = 0.0
+    detail: str = ""
+    residues: tuple[str, ...] = ()
+
+    @classmethod
+    def pass_(cls, detail: str = "passed", score: float = 1.0) -> "CheckResult":
+        return cls(True, score, detail, ())
+
+    @classmethod
+    def fail(
+        cls,
+        detail: str,
+        residues: Sequence[str] = (),
+        score: float = 0.0,
+    ) -> "CheckResult":
+        return cls(False, score, detail, tuple(residues))
+
+
+@dataclass(frozen=True)
+class ActionTrace:
+    """Deterministic audit record for one tool-layer action."""
+
+    action: str
+    input_hash: str
+    output_hash: str
+    status: str
+    failure_type: str = ""
+    cost: float = 1.0
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "action": self.action,
+            "input_hash": self.input_hash,
+            "output_hash": self.output_hash,
+            "status": self.status,
+            "failure_type": self.failure_type,
+            "cost": self.cost,
+        }
+
+
+@dataclass(frozen=True)
+class CodeEvalTask:
+    """A file-backed code repair task with visible and sealed hidden checks.
+
+    ``workspace_files`` are the only files provisioned for the candidate. The
+    hidden check remains a harness-side callable and is never written into the
+    workspace.
+    """
+
+    name: str
+    workspace_files: Mapping[str, str | bytes]
+    visible_check: CheckFn
+    hidden_check: CheckFn
+    full_suite_check: Optional[CheckFn] = None
+    allowed_tools: tuple[str, ...] = (
+        "read_file",
+        "write_file",
+        "apply_patch",
+        "revert_file",
+        "run_visible_check",
+    )
+
+    def provision(self, root: Path) -> Path:
+        workspace = Path(root) / self.name
+        if workspace.exists():
+            shutil.rmtree(workspace)
+        workspace.mkdir(parents=True, exist_ok=True)
+        for rel_path, payload in sorted(self.workspace_files.items()):
+            target = _safe_child(workspace, rel_path)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(payload, bytes):
+                target.write_bytes(payload)
+            else:
+                target.write_text(payload, encoding="utf-8")
+        return workspace
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """Complete result for one arm: frozen or adaptive."""
+
+    arm: str
+    visible: CheckResult
+    hidden: CheckResult
+    full_suite: CheckResult
+    traces: tuple[ActionTrace, ...] = ()
+    trace_digest: str = ""
+    skipped: bool = False
+
+    @classmethod
+    def skipped_result(cls, arm: str, reason: str) -> "RunResult":
+        skipped = CheckResult.fail(reason, ("skipped",))
+        return cls(arm, skipped, skipped, skipped, (), "", True)
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Final admission decision for a candidate against one task."""
+
+    accepted: bool
+    reason: str
+    adaptive: RunResult
+    frozen: RunResult
+    candidate_key: str
+    cached: bool = False
+
+
+class ToolActionSession:
+    """Restricted file-operation surface exposed to candidate runners."""
+
+    def __init__(
+        self,
+        root: Path,
+        visible_check: CheckFn,
+        allowed_tools: Sequence[str],
+    ) -> None:
+        self.root = Path(root).resolve()
+        self.visible_check = visible_check
+        self.allowed_tools = tuple(allowed_tools)
+        self.traces: list[ActionTrace] = []
+
+    def read_file(self, rel_path: str) -> str:
+        action = "read_file"
+        payload = {"path": rel_path}
+        before = self._tree_digest()
+        self._ensure_tool(action, payload, before)
+        path = self._resolve(action, payload, before, rel_path)
+        try:
+            out = path.read_text(encoding="utf-8")
+        except Exception:
+            self._reject(action, payload, before, "read_failed")
+            raise
+        self._record(action, payload, before, self._tree_digest(), "observed")
+        return out
+
+    def write_file(self, rel_path: str, content: str) -> None:
+        action = "write_file"
+        payload = {
+            "path": rel_path,
+            "content_hash": _digest_bytes(content.encode("utf-8")),
+        }
+        before = self._tree_digest()
+        self._ensure_tool(action, payload, before)
+        path = self._resolve(action, payload, before, rel_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        self._record(action, payload, before, self._tree_digest(), "committed")
+
+    def apply_patch(self, rel_path: str, old: str, new: str) -> bool:
+        action = "apply_patch"
+        payload = {
+            "path": rel_path,
+            "old_hash": _digest_bytes(old.encode("utf-8")),
+            "new_hash": _digest_bytes(new.encode("utf-8")),
+        }
+        before = self._tree_digest()
+        self._ensure_tool(action, payload, before)
+        path = self._resolve(action, payload, before, rel_path)
+        text = path.read_text(encoding="utf-8")
+        if text.count(old) != 1:
+            self._record(
+                action,
+                payload,
+                before,
+                before,
+                "reverted",
+                failure_type="patch_not_unique",
+            )
+            return False
+        path.write_text(text.replace(old, new, 1), encoding="utf-8")
+        self._record(action, payload, before, self._tree_digest(), "committed")
+        return True
+
+    def revert_file(self, rel_path: str, content: str) -> None:
+        action = "revert_file"
+        payload = {
+            "path": rel_path,
+            "content_hash": _digest_bytes(content.encode("utf-8")),
+        }
+        before = self._tree_digest()
+        self._ensure_tool(action, payload, before)
+        path = self._resolve(action, payload, before, rel_path)
+        path.write_text(content, encoding="utf-8")
+        self._record(action, payload, before, self._tree_digest(), "reverted")
+
+    def run_visible_check(self) -> CheckResult:
+        action = "run_visible_check"
+        payload = {"checker": getattr(self.visible_check, "__name__", "visible_check")}
+        before = self._tree_digest()
+        self._ensure_tool(action, payload, before)
+        try:
+            result = self.visible_check(self.root)
+        except Exception as exc:
+            result = CheckResult.fail(str(exc), ("visible_check_exception",))
+        self._record(
+            action,
+            payload,
+            before,
+            self._tree_digest(),
+            "observed",
+            failure_type="" if result.passed else "visible_check_failed",
+        )
+        return result
+
+    def _tree_digest(self) -> str:
+        entries: list[tuple[str, str]] = []
+        for path in sorted(p for p in self.root.rglob("*") if p.is_file()):
+            rel = path.relative_to(self.root).as_posix()
+            entries.append((rel, _digest_bytes(path.read_bytes())))
+        return _digest_json(entries)
+
+    def _record(
+        self,
+        action: str,
+        payload: object,
+        before: str,
+        after: str,
+        status: str,
+        failure_type: str = "",
+    ) -> None:
+        self.traces.append(
+            ActionTrace(
+                action=action,
+                input_hash=_digest_json(
+                    {"action": action, "payload": payload, "before": before}
+                ),
+                output_hash=_digest_json(
+                    {"after": after, "failure_type": failure_type}
+                ),
+                status=status,
+                failure_type=failure_type,
+            )
+        )
+
+    def _reject(
+        self,
+        action: str,
+        payload: object,
+        before: str,
+        failure_type: str,
+    ) -> None:
+        self._record(action, payload, before, before, "reverted", failure_type)
+        raise ValueError(f"{action} rejected: {failure_type}")
+
+    def _ensure_tool(self, action: str, payload: object, before: str) -> None:
+        if action not in self.allowed_tools:
+            self._reject(action, payload, before, "tool_not_allowed")
+
+    def _resolve(
+        self,
+        action: str,
+        payload: object,
+        before: str,
+        rel_path: str,
+    ) -> Path:
+        try:
+            return _safe_child(self.root, rel_path)
+        except ValueError:
+            self._reject(action, payload, before, "path_escape")
+            raise
+
+
+class CodeFitnessHarness:
+    """Admission gate for a Phase 4 candidate versus a frozen baseline."""
+
+    def __init__(
+        self,
+        *,
+        min_hidden_delta: float = 0.0,
+        cache_rejections: bool = True,
+    ) -> None:
+        self.min_hidden_delta = min_hidden_delta
+        self.cache_rejections = cache_rejections
+        self.rejected_candidate_keys: set[str] = set()
+
+    def evaluate(
+        self,
+        task: CodeEvalTask,
+        *,
+        adaptive_runner: CandidateRunner,
+        frozen_runner: CandidateRunner,
+        candidate_id: str,
+        root: Optional[Path] = None,
+    ) -> GateDecision:
+        candidate_key = _digest_json({"task": task.name, "candidate": candidate_id})
+        if candidate_key in self.rejected_candidate_keys:
+            return GateDecision(
+                accepted=False,
+                reason="rejected_cached",
+                adaptive=RunResult.skipped_result("adaptive", "rejected_cached"),
+                frozen=RunResult.skipped_result("frozen", "rejected_cached"),
+                candidate_key=candidate_key,
+                cached=True,
+            )
+
+        if root is None:
+            with tempfile.TemporaryDirectory(prefix="phase4_harness_") as tmp:
+                return self._evaluate_in_root(
+                    task, adaptive_runner, frozen_runner, candidate_id, Path(tmp)
+                )
+        return self._evaluate_in_root(
+            task, adaptive_runner, frozen_runner, candidate_id, Path(root)
+        )
+
+    def _evaluate_in_root(
+        self,
+        task: CodeEvalTask,
+        adaptive_runner: CandidateRunner,
+        frozen_runner: CandidateRunner,
+        candidate_id: str,
+        root: Path,
+    ) -> GateDecision:
+        candidate_key = _digest_json({"task": task.name, "candidate": candidate_id})
+        frozen = _run_arm(task, frozen_runner, root / "frozen", "frozen")
+        adaptive = _run_arm(task, adaptive_runner, root / "adaptive", "adaptive")
+
+        accepted, reason = self._decide(frozen, adaptive)
+        if not accepted and self.cache_rejections:
+            self.rejected_candidate_keys.add(candidate_key)
+        return GateDecision(
+            accepted=accepted,
+            reason=reason,
+            adaptive=adaptive,
+            frozen=frozen,
+            candidate_key=candidate_key,
+        )
+
+    def _decide(self, frozen: RunResult, adaptive: RunResult) -> tuple[bool, str]:
+        if not adaptive.visible.passed:
+            return False, "visible_gate_failed"
+        if not adaptive.hidden.passed:
+            return False, "hidden_gate_failed"
+        if not adaptive.full_suite.passed:
+            return False, "full_suite_failed"
+        required = frozen.hidden.score + self.min_hidden_delta
+        if adaptive.hidden.score <= required:
+            return False, "no_hidden_improvement"
+        return True, "accepted"
+
+
+def _run_arm(
+    task: CodeEvalTask,
+    runner: CandidateRunner,
+    root: Path,
+    arm: str,
+) -> RunResult:
+    workspace = task.provision(root)
+    session = ToolActionSession(workspace, task.visible_check, task.allowed_tools)
+    runner_error: Optional[Exception] = None
+    try:
+        runner(session)
+    except Exception as exc:
+        runner_error = exc
+
+    visible = _safe_check(task.visible_check, workspace, "visible_check_exception")
+    hidden = _safe_check(task.hidden_check, workspace, "hidden_check_exception")
+    full_suite = (
+        _safe_check(task.full_suite_check, workspace, "full_suite_exception")
+        if task.full_suite_check is not None
+        else CheckResult.pass_("full suite not configured")
+    )
+    if runner_error is not None:
+        visible = CheckResult.fail(str(runner_error), ("runner_exception",))
+
+    traces = tuple(session.traces)
+    return RunResult(
+        arm=arm,
+        visible=visible,
+        hidden=hidden,
+        full_suite=full_suite,
+        traces=traces,
+        trace_digest=_digest_json([trace.as_dict() for trace in traces]),
+    )
+
+
+def _safe_check(
+    check: CheckFn,
+    workspace: Path,
+    residue: str,
+) -> CheckResult:
+    try:
+        return check(workspace)
+    except Exception as exc:
+        return CheckResult.fail(str(exc), (residue,))
+
+
+def _safe_child(root: Path, rel_path: str) -> Path:
+    rel = Path(str(rel_path))
+    if rel.is_absolute():
+        raise ValueError(f"absolute path rejected: {rel_path}")
+    base = Path(root).resolve()
+    target = (base / rel).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(f"path escapes workspace: {rel_path}") from exc
+    return target
+
+
+def _digest_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()[:16]
+
+
+def _digest_json(payload: object) -> str:
+    raw = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return _digest_bytes(raw)

--- a/tests/code/__init__.py
+++ b/tests/code/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Phase 4 code-evolution support."""

--- a/tests/code/test_phase4_mvp.py
+++ b/tests/code/test_phase4_mvp.py
@@ -1,0 +1,309 @@
+"""Tests + runnable end-to-end demo for the Phase 4 verifier MVP.
+
+Realistic target: a buggy ``clamp(value, low, high)`` whose low branch returns
+``high`` instead of ``low``. The bug only manifests on ``value < low`` inputs, so
+a partial fix can pass a visible suite that lacks such cases yet regress on the
+sealed hidden suite that contains them. That is exactly the overfit-to-visible
+failure the verifier layer exists to catch.
+"""
+
+from __future__ import annotations
+
+import random
+import tempfile
+from pathlib import Path
+
+from evolution.code.verifier_harness import CheckResult, CodeEvalTask, ToolActionSession
+from evolution.code.phase4_mvp import (
+    LineageArchive,
+    ResidueCurriculum,
+    StrictCodeFitnessHarness,
+    evaluate_on_unseen_seed,
+    evaluate_with_lineage,
+    render_markdown,
+    summarize_decision,
+)
+
+BUGGY_SRC = (
+    "def clamp(value, low, high):\n"
+    "    if value < low:\n"
+    "        return high\n"  # BUG: should return low
+    "    if value > high:\n"
+    "        return high\n"
+    "    return value\n"
+)
+CORRECT_OLD = "    if value < low:\n        return high\n"
+CORRECT_NEW = "    if value < low:\n        return low\n"
+COSMETIC_OLD = "    if value > high:\n        return high\n"
+COSMETIC_NEW = "    if value > high:\n        return high  # clamp high\n"
+
+
+# --- check construction --------------------------------------------------- #
+def _load_clamp(workspace: Path):
+    ns: dict = {}
+    src = (workspace / "clamp.py").read_text(encoding="utf-8")
+    exec(compile(src, "clamp.py", "exec"), ns)
+    return ns["clamp"]
+
+
+def _cases(seed: int, n: int, include_low: bool) -> list[tuple[int, int, int, int]]:
+    rng = random.Random(seed)
+    cases: list[tuple[int, int, int, int]] = []
+    for _ in range(n):
+        low = rng.randint(-5, 5)
+        high = low + rng.randint(1, 10)
+        if include_low and rng.random() < 0.5:
+            value = low - rng.randint(1, 5)  # exercises the buggy branch
+        else:
+            value = rng.randint(low, high)
+        expected = low if value < low else high if value > high else value
+        cases.append((value, low, high, expected))
+    if include_low and not any(v < lo for (v, lo, _h, _e) in cases):
+        cases[0] = (-99, 0, 10, 0)  # guarantee at least one low case
+    return cases
+
+
+def _run_cases(workspace: Path, cases) -> tuple[float, bool]:
+    fn = _load_clamp(workspace)
+    passed = 0
+    low_failed = False
+    for value, low, high, expected in cases:
+        try:
+            got = fn(value, low, high)
+        except Exception:
+            got = object()
+        if got == expected:
+            passed += 1
+        elif value < low:
+            low_failed = True
+    return passed / len(cases), low_failed
+
+
+def _make_check(seed: int, n: int, include_low: bool):
+    cases = _cases(seed, n, include_low)
+
+    def check(workspace: Path) -> CheckResult:
+        score, low_failed = _run_cases(workspace, cases)
+        if score >= 1.0:
+            return CheckResult.pass_(f"{len(cases)} cases passed", score=1.0)
+        residues = ("clamp_low_failed",) if low_failed else ("cases_failed",)
+        return CheckResult.fail(f"{score:.3f} of cases passed", residues, score=score)
+
+    return check
+
+
+def _task(name: str, visible_seed: int, hidden_seed: int, *, full_suite: bool = True,
+          visible_low: bool = False) -> CodeEvalTask:
+    return CodeEvalTask(
+        name=name,
+        workspace_files={"clamp.py": BUGGY_SRC},
+        visible_check=_make_check(visible_seed, 6, include_low=visible_low),
+        hidden_check=_make_check(hidden_seed, 12, include_low=True),
+        full_suite_check=_make_check(hidden_seed + 777, 20, include_low=True)
+        if full_suite
+        else None,
+    )
+
+
+# --- candidate runners ---------------------------------------------------- #
+def correct_runner(session: ToolActionSession) -> None:
+    session.read_file("clamp.py")
+    session.apply_patch("clamp.py", CORRECT_OLD, CORRECT_NEW)
+    session.run_visible_check()
+
+
+def cosmetic_runner(session: ToolActionSession) -> None:
+    """Passes a no-low visible suite, leaves the low bug in place -> fails hidden."""
+    session.read_file("clamp.py")
+    session.apply_patch("clamp.py", COSMETIC_OLD, COSMETIC_NEW)
+    session.run_visible_check()
+
+
+def frozen_runner(session: ToolActionSession) -> None:
+    session.read_file("clamp.py")
+    session.run_visible_check()
+
+
+# --- tests ---------------------------------------------------------------- #
+def test_correct_candidate_accepted_on_unseen_seed():
+    harness = StrictCodeFitnessHarness(require_full_suite=True)
+    factory = lambda vs, hs: _task(f"clamp_{vs}_{hs}", vs, hs, visible_low=True)
+    result = evaluate_on_unseen_seed(
+        harness, factory,
+        adaptive_runner=correct_runner, frozen_runner=frozen_runner,
+        candidate_id="correct", visible_seed=1, hidden_seed=2,
+    )
+    assert result.decision.accepted
+    assert result.decision.reason == "accepted"
+    assert result.decision.adaptive.hidden.score > result.decision.frozen.hidden.score
+
+
+def test_cosmetic_candidate_rejected_by_hidden_gate():
+    harness = StrictCodeFitnessHarness(require_full_suite=True)
+    task = _task("clamp_overfit", visible_seed=10, hidden_seed=20, visible_low=False)
+    decision = harness.evaluate(
+        task, adaptive_runner=cosmetic_runner, frozen_runner=frozen_runner,
+        candidate_id="cosmetic",
+    )
+    # passes visible (no low cases) but regresses on sealed hidden cases
+    assert decision.adaptive.visible.passed
+    assert not decision.accepted
+    assert decision.reason == "hidden_gate_failed"
+
+
+def test_unseen_seed_must_differ():
+    harness = StrictCodeFitnessHarness()
+    factory = lambda vs, hs: _task("x", vs, hs)
+    try:
+        evaluate_on_unseen_seed(
+            harness, factory, adaptive_runner=correct_runner,
+            frozen_runner=frozen_runner, candidate_id="c",
+            visible_seed=5, hidden_seed=5,
+        )
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for non-held-out seeds")
+
+
+def test_full_suite_required_blocks_free_pass():
+    strict = StrictCodeFitnessHarness(require_full_suite=True)
+    task = _task("no_suite", 1, 2, full_suite=False, visible_low=True)
+    decision = strict.evaluate(
+        task, adaptive_runner=correct_runner, frozen_runner=frozen_runner,
+        candidate_id="correct",
+    )
+    assert not decision.accepted
+    assert decision.reason == "full_suite_required"
+
+    lenient = StrictCodeFitnessHarness(require_full_suite=False)
+    decision2 = lenient.evaluate(
+        _task("no_suite2", 1, 2, full_suite=False, visible_low=True),
+        adaptive_runner=correct_runner, frozen_runner=frozen_runner,
+        candidate_id="correct",
+    )
+    assert decision2.accepted  # base behavior: missing suite is a free pass
+
+
+def test_residue_curriculum_hardens_visible_without_touching_gate():
+    # a follow-up task for clamp_low_failed makes the *visible* surface include
+    # low cases; the harness thresholds are identical objects throughout.
+    curriculum = ResidueCurriculum()
+    curriculum.register(
+        "clamp_low_failed",
+        lambda r: _task("clamp_hardened", visible_seed=31, hidden_seed=32, visible_low=True),
+    )
+    harness = StrictCodeFitnessHarness(require_full_suite=True)
+    base = _task("clamp_base", visible_seed=10, hidden_seed=20, visible_low=False)
+    decision = harness.evaluate(
+        base, adaptive_runner=cosmetic_runner, frozen_runner=frozen_runner,
+        candidate_id="cosmetic",
+    )
+    scheduled = curriculum.observe(decision)
+    assert any(t.name == "clamp_hardened" for t in scheduled)
+
+    followup = curriculum.next_task()
+    assert followup is not None and followup.name == "clamp_hardened"
+    # the cosmetic candidate now fails the *visible* gate on the hardened task
+    redo = harness.evaluate(
+        followup, adaptive_runner=cosmetic_runner, frozen_runner=frozen_runner,
+        candidate_id="cosmetic2",
+    )
+    assert not redo.adaptive.visible.passed  # hardened visible catches it early
+
+
+def test_lineage_archive_diff_and_replay():
+    harness = StrictCodeFitnessHarness(require_full_suite=True)
+    archive = LineageArchive()
+    task = _task("clamp_lin", visible_seed=3, hidden_seed=4, visible_low=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        decision, entry = evaluate_with_lineage(
+            harness, task, adaptive_runner=correct_runner, frozen_runner=frozen_runner,
+            candidate_id="correct", archive=archive, root=Path(tmp),
+        )
+        assert decision.accepted
+        # the recorded patch is auditable
+        diff = archive.unified_diff(entry)
+        assert "return low" in diff and "return high" in diff
+        # deterministic integrity replay + stronger evaluation replay
+        assert archive.verify_replay(entry) is True
+        assert archive.replay_evaluation(entry, task) is True
+
+
+def test_summary_emitter_has_all_mvp_fields():
+    harness = StrictCodeFitnessHarness(require_full_suite=True)
+    task = _task("clamp_sum", visible_seed=7, hidden_seed=8, visible_low=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        decision, entry = evaluate_with_lineage(
+            harness, task, adaptive_runner=correct_runner, frozen_runner=frozen_runner,
+            candidate_id="correct", archive=LineageArchive(), root=Path(tmp),
+        )
+    summary = summarize_decision(decision, rejected_count=2, lineage_entry=entry)
+    for key in (
+        "hidden_score_delta", "frozen_vs_adaptive", "patch_trace_digest",
+        "rejected_candidate_count", "diff_summary", "lineage",
+    ):
+        assert key in summary
+    md = render_markdown(summary)
+    assert "Phase 4 verifier decision" in md and "hidden score delta" in md
+
+
+# --- end-to-end demo ------------------------------------------------------ #
+def _demo() -> None:
+    print("=" * 70)
+    print("PHASE 4 VERIFIER MVP - end-to-end run")
+    print("=" * 70)
+    harness = StrictCodeFitnessHarness(min_hidden_delta=0.0, require_full_suite=True)
+    archive = LineageArchive()
+    curriculum = ResidueCurriculum()
+    curriculum.register(
+        "clamp_low_failed",
+        lambda r: _task("clamp_hardened", visible_seed=31, hidden_seed=32, visible_low=True),
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+
+        # 1) a cosmetic candidate that overfits a low-free visible suite
+        base = _task("clamp_base", visible_seed=10, hidden_seed=20, visible_low=False)
+        d1, e1 = evaluate_with_lineage(
+            harness, base, adaptive_runner=cosmetic_runner, frozen_runner=frozen_runner,
+            candidate_id="cosmetic", archive=archive, root=root / "r1",
+        )
+        print(f"\n[1] cosmetic candidate -> accepted={d1.accepted} reason={d1.reason}")
+        print(f"    visible passed={d1.adaptive.visible.passed} "
+              f"hidden score={d1.adaptive.hidden.score:.3f} (overfit caught by sealed gate)")
+        scheduled = curriculum.observe(d1)
+        print(f"    residues={curriculum.residue_counts()} -> scheduled follow-up: "
+              f"{[t.name for t in scheduled]}")
+
+        # 2) curriculum hands back a hardened task; correct candidate solves it
+        followup = curriculum.next_task()
+        d2, e2 = evaluate_with_lineage(
+            harness, followup, adaptive_runner=correct_runner, frozen_runner=frozen_runner,
+            candidate_id="correct", archive=archive, root=root / "r2", parent_id=e1.candidate_id,
+        )
+        print(f"\n[2] correct candidate on hardened task -> accepted={d2.accepted} "
+              f"reason={d2.reason}")
+        print(f"    frozen hidden={d2.frozen.hidden.score:.3f}  "
+              f"adaptive hidden={d2.adaptive.hidden.score:.3f}  "
+              f"delta={e2.hidden_delta:+.3f}")
+
+        # 3) audit: lineage, diff, replay
+        print(f"\n[3] lineage chain: "
+              f"{[e.candidate_id for e in archive.lineage_of(e2.candidate_id)]}")
+        print(f"    deterministic integrity replay: {archive.verify_replay(e2)}")
+        print(f"    full-suite evaluation replay:    {archive.replay_evaluation(e2, followup)}")
+        print("    audited patch diff:")
+        for line in archive.unified_diff(e2).splitlines():
+            print("      " + line)
+
+        # 4) the issue/PR summary block
+        summary = summarize_decision(
+            d2, rejected_count=archive.rejected_count(), lineage_entry=e2,
+        )
+        print("\n[4] emitted PR summary:\n")
+        print(render_markdown(summary))
+
+
+if __name__ == "__main__":
+    _demo()

--- a/tests/code/test_verifier_harness.py
+++ b/tests/code/test_verifier_harness.py
@@ -1,0 +1,229 @@
+"""Tests for the Phase 4 verifier/fitness harness."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+
+from evolution.code.verifier_harness import (
+    CheckResult,
+    CodeEvalTask,
+    CodeFitnessHarness,
+    ToolActionSession,
+)
+
+BUGGY_MATH_UTILS = """def add(a, b):
+    return a - b
+
+def add_all(values):
+    total = 0
+    for value in values:
+        total = add(total, value)
+    return total
+"""
+
+
+TRAIN_ONLY_MATH_UTILS = """def add(a, b):
+    if a == 2 and b == 3:
+        return 5
+    return a - b
+
+def add_all(values):
+    total = 0
+    for value in values:
+        total = add(total, value)
+    return total
+"""
+
+
+def _load_math_utils(workspace: Path):
+    path = workspace / "repo" / "math_utils.py"
+    shutil.rmtree(path.parent / "__pycache__", ignore_errors=True)
+    importlib.invalidate_caches()
+    module_name = f"math_utils_{abs(hash(path))}"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _visible_check(workspace: Path) -> CheckResult:
+    try:
+        mod = _load_math_utils(workspace)
+        if mod.add(2, 3) == 5:
+            return CheckResult.pass_("visible add case passed")
+    except Exception as exc:
+        return CheckResult.fail(str(exc), ("visible_exception",))
+    return CheckResult.fail("visible add case failed", ("visible_add_failed",))
+
+
+def _hidden_check(workspace: Path) -> CheckResult:
+    try:
+        mod = _load_math_utils(workspace)
+        probes = [
+            mod.add(-2, 5) == 3,
+            mod.add_all([1, 2, 3]) == 6,
+        ]
+    except Exception as exc:
+        return CheckResult.fail(str(exc), ("hidden_exception",))
+    score = sum(1 for ok in probes if ok) / len(probes)
+    if score == 1.0:
+        return CheckResult.pass_("hidden repo repair passed")
+    residues = tuple(
+        f"hidden_probe_{i}_failed" for i, ok in enumerate(probes) if not ok
+    )
+    return CheckResult.fail("hidden repo repair failed", residues, score=score)
+
+
+def _full_suite_passes(_: Path) -> CheckResult:
+    return CheckResult.pass_("pytest gate passed")
+
+
+def _full_suite_fails(_: Path) -> CheckResult:
+    return CheckResult.fail("pytest gate failed", ("pytest_failed",))
+
+
+def _repo_repair_task(*, full_suite=_full_suite_passes) -> CodeEvalTask:
+    return CodeEvalTask(
+        name="repo_repair",
+        workspace_files={
+            "repo/math_utils.py": BUGGY_MATH_UTILS,
+            "visible_cases.json": json.dumps({"add": [[2, 3, 5]]}, sort_keys=True),
+        },
+        visible_check=_visible_check,
+        hidden_check=_hidden_check,
+        full_suite_check=full_suite,
+    )
+
+
+def _frozen_noop(session: ToolActionSession) -> None:
+    session.read_file("repo/math_utils.py")
+
+
+def _train_only_candidate(session: ToolActionSession) -> None:
+    session.write_file("repo/math_utils.py", TRAIN_ONLY_MATH_UTILS)
+    session.run_visible_check()
+
+
+def _adaptive_candidate_with_rollback(session: ToolActionSession) -> None:
+    original = session.read_file("repo/math_utils.py")
+    assert session.apply_patch("repo/math_utils.py", "return a - b", "return a * b")
+    if not session.run_visible_check().passed:
+        session.revert_file("repo/math_utils.py", original)
+    assert session.apply_patch("repo/math_utils.py", "return a - b", "return a + b")
+    session.run_visible_check()
+
+
+def test_hidden_gate_rejects_train_only_candidate(tmp_path):
+    harness = CodeFitnessHarness()
+
+    decision = harness.evaluate(
+        _repo_repair_task(),
+        adaptive_runner=_train_only_candidate,
+        frozen_runner=_frozen_noop,
+        candidate_id="train-only-visible-fit",
+        root=tmp_path,
+    )
+
+    assert not decision.accepted
+    assert decision.reason == "hidden_gate_failed"
+    assert decision.adaptive.visible.passed
+    assert not decision.adaptive.hidden.passed
+
+
+def test_adaptive_patch_beats_frozen_and_records_rollback_trace(tmp_path):
+    harness = CodeFitnessHarness()
+
+    decision = harness.evaluate(
+        _repo_repair_task(),
+        adaptive_runner=_adaptive_candidate_with_rollback,
+        frozen_runner=_frozen_noop,
+        candidate_id="single-line-add-fix",
+        root=tmp_path,
+    )
+
+    assert decision.accepted
+    assert decision.reason == "accepted"
+    assert decision.frozen.hidden.score < decision.adaptive.hidden.score
+    assert decision.adaptive.full_suite.passed
+    statuses = [(trace.action, trace.status) for trace in decision.adaptive.traces]
+    assert ("revert_file", "reverted") in statuses
+    assert statuses.count(("apply_patch", "committed")) == 2
+    assert decision.adaptive.trace_digest
+
+
+def test_rejection_cache_blocks_repeat_candidate(tmp_path):
+    harness = CodeFitnessHarness()
+    task = _repo_repair_task()
+
+    first = harness.evaluate(
+        task,
+        adaptive_runner=_train_only_candidate,
+        frozen_runner=_frozen_noop,
+        candidate_id="same-bad-candidate",
+        root=tmp_path / "first",
+    )
+    second = harness.evaluate(
+        task,
+        adaptive_runner=_train_only_candidate,
+        frozen_runner=_frozen_noop,
+        candidate_id="same-bad-candidate",
+        root=tmp_path / "second",
+    )
+
+    assert not first.accepted
+    assert second.cached
+    assert second.reason == "rejected_cached"
+    assert second.adaptive.skipped
+    assert not list((tmp_path / "second").glob("**/*"))
+
+
+def test_hidden_expectations_stay_out_of_workspace(tmp_path):
+    hidden_canary = "SECRET_HIDDEN_CASE_ADD_NEGATIVE_AND_ADD_ALL"
+
+    def hidden_check_with_canary(workspace: Path) -> CheckResult:
+        assert hidden_canary
+        return _hidden_check(workspace)
+
+    task = _repo_repair_task()
+    task = CodeEvalTask(
+        name=task.name,
+        workspace_files=task.workspace_files,
+        visible_check=task.visible_check,
+        hidden_check=hidden_check_with_canary,
+        full_suite_check=task.full_suite_check,
+        allowed_tools=task.allowed_tools,
+    )
+
+    workspace = task.provision(tmp_path)
+    blob = ""
+    for path in workspace.rglob("*"):
+        if path.is_file():
+            assert "hidden" not in path.name.lower()
+            blob += path.read_text(encoding="utf-8")
+
+    workspace_filenames = {path.name for path in workspace.rglob("*")}
+    assert hidden_canary not in blob
+    assert "visible_cases.json" in workspace_filenames
+
+
+def test_full_suite_gate_blocks_hidden_success(tmp_path):
+    harness = CodeFitnessHarness()
+
+    decision = harness.evaluate(
+        _repo_repair_task(full_suite=_full_suite_fails),
+        adaptive_runner=_adaptive_candidate_with_rollback,
+        frozen_runner=_frozen_noop,
+        candidate_id="hidden-pass-regression-fail",
+        root=tmp_path,
+    )
+
+    assert not decision.accepted
+    assert decision.reason == "full_suite_failed"
+    assert decision.adaptive.hidden.passed
+    assert not decision.adaptive.full_suite.passed


### PR DESCRIPTION
Closes #118.

## Summary
- Add a repo-native Phase 4 verifier harness with visible checks, sealed hidden checks, adaptive-vs-frozen comparison, rejection caching, restricted patch/revert actions, deterministic trace digests, and full-suite gating.
- Add a Phase 4 MVP assembly that requires a configured full suite, evaluates unseen seeds, turns failure residues into gate-preserving curriculum tasks, archives candidate lineage and final artifacts, replays accepted evaluations, and emits review summaries.
- Add focused tests and an end-to-end file-backed clamp repair scenario covering hidden-gate rejection, curriculum hardening, accepted repair, lineage, replay, unified diff output, and PR-summary output.
- Export the core verifier primitives from `evolution.code` and document the verifier boundary in the README and plan.

## Scope
The clamp repair scenario is a deterministic file-backed verifier example, not a production Hermes tool integration. It demonstrates the Phase 4 contract without coupling this PR to a mutation engine or a specific Hermes tool implementation.

The residue curriculum can schedule harder visible tasks, but it has no access to and cannot modify verifier thresholds. Failed attempts can improve task selection without weakening acceptance gates.

Unrelated path-expansion and skill-encoding changes were removed so this PR remains limited to the verifier harness, MVP assembly, tests, and documentation.

## Validation
- `python -m py_compile evolution/code/verifier_harness.py`
- `python -m py_compile evolution/code/phase4_mvp.py`
- `python -m py_compile tests/code/test_verifier_harness.py`
- `python -m py_compile tests/code/test_phase4_mvp.py`
- `python -m pytest tests/code/test_verifier_harness.py tests/code/test_phase4_mvp.py -q` -> `12 passed`
- Full suite in a UTF-8 environment -> `157 passed, 11 warnings`
- `python -m tests.code.test_phase4_mvp` -> end-to-end verifier demo completed successfully
