### PR TITLE
fix: restore GEPA optimizer compatibility

### DIFF
--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -104,10 +104,18 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+def skill_fitness_metric(
+    example: dspy.Example,
+    prediction: dspy.Prediction,
+    trace=None,
+    pred_name=None,
+    pred_trace=None,
+) -> float:
     """DSPy-compatible metric function for skill optimization.
 
-    This is what gets passed to dspy.GEPA(metric=...).
+    This is what gets passed to dspy.GEPA(metric=...). DSPy 3.x GEPA calls
+    metrics with predictor-level trace arguments, while other optimizers only
+    pass the example, prediction, and optional trace.
     Returns a float 0-1 score.
     """
     # The prediction should have an 'output' field with the agent's response

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -33,6 +33,16 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+def _build_gepa_optimizer(iterations: int, optimizer_model: str):
+    """Create a DSPy GEPA optimizer using the DSPy 3.x API."""
+    reflection_lm = dspy.LM(optimizer_model)
+    return dspy.GEPA(
+        metric=skill_fitness_metric,
+        max_full_evals=max(1, iterations),
+        reflection_lm=reflection_lm,
+    )
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -118,7 +128,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -153,10 +163,7 @@ def evolve(
     start_time = time.time()
 
     try:
-        optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
-            max_steps=iterations,
-        )
+        optimizer = _build_gepa_optimizer(iterations, optimizer_model)
 
         optimized_module = optimizer.compile(
             baseline_module,
@@ -185,7 +192,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"

--- a/tests/skills/test_evolve_skill_optimizer.py
+++ b/tests/skills/test_evolve_skill_optimizer.py
@@ -1,0 +1,69 @@
+"""Tests for evolve_skill optimizer compatibility."""
+
+import inspect
+
+import dspy
+
+from evolution.core.fitness import skill_fitness_metric
+from evolution.skills import evolve_skill
+
+
+def test_skill_fitness_metric_accepts_gepa_trace_arguments():
+    """DSPy 3.x GEPA requires metrics to accept predictor trace arguments."""
+    inspect.signature(skill_fitness_metric).bind(None, None, None, None, None)
+
+    example = dspy.Example(
+        task_input="Sort notes",
+        expected_behavior="group email tasks separately",
+    )
+    prediction = dspy.Prediction(output="Email tasks: contact Sam")
+
+    score = skill_fitness_metric(
+        example,
+        prediction,
+        trace=[],
+        pred_name="predictor",
+        pred_trace=[],
+    )
+
+    assert 0.0 <= score <= 1.0
+
+
+def test_build_gepa_optimizer_uses_dspy_3_api(monkeypatch):
+    calls = {}
+
+    class FakeGEPA:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+    def fake_lm(model):
+        return {"model": model}
+
+    monkeypatch.setattr(evolve_skill.dspy, "GEPA", FakeGEPA)
+    monkeypatch.setattr(evolve_skill.dspy, "LM", fake_lm)
+
+    optimizer = evolve_skill._build_gepa_optimizer(
+        iterations=7,
+        optimizer_model="openai/gpt-4.1",
+    )
+
+    assert isinstance(optimizer, FakeGEPA)
+    assert calls["metric"] is skill_fitness_metric
+    assert calls["max_full_evals"] == 7
+    assert calls["reflection_lm"] == {"model": "openai/gpt-4.1"}
+    assert "max_steps" not in calls
+
+
+def test_build_gepa_optimizer_clamps_empty_budget(monkeypatch):
+    calls = {}
+
+    class FakeGEPA:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+    monkeypatch.setattr(evolve_skill.dspy, "GEPA", FakeGEPA)
+    monkeypatch.setattr(evolve_skill.dspy, "LM", lambda model: model)
+
+    evolve_skill._build_gepa_optimizer(iterations=0, optimizer_model="openai/gpt-4.1")
+
+    assert calls["max_full_evals"] == 1


### PR DESCRIPTION
## Summary

This PR restores the intended GEPA path in the Phase 1 skill evolution flow for current DSPy 3.x releases.

Before this change, `evolve_skill.py` attempted to construct GEPA with `max_steps=iterations`. DSPy 3.x GEPA no longer accepts `max_steps`, so the primary optimizer failed during construction and the command immediately fell back to MIPROv2. That meant a user running the documented GEPA-based skill evolution command was not actually running GEPA.

This PR updates the optimizer setup to use the DSPy 3.x GEPA API and adds regression coverage so the same fallback regression is caught before release.

Fixes #10.

Also addresses the full-skill validation path described in #11, #34, #74, #93, and #110 by validating complete `SKILL.md` artifacts instead of body-only text.

## Why This Matters

Phase 1 is the core working path in this repository:

1. Load a Hermes Agent `SKILL.md` file.
2. Build or load an evaluation dataset.
3. Run DSPy/GEPA to optimize the skill behavior.
4. Validate constraints.
5. Compare baseline and evolved outputs.

The project README and plan describe GEPA as the primary engine. If GEPA fails before optimization starts, users cannot trust that the Phase 1 command is exercising the advertised path. The command may still continue through fallback behavior, but the experiment is no longer validating GEPA-based skill evolution.

## What Changed

- Added `_build_gepa_optimizer()` in `evolution.skills.evolve_skill`.
- Construct GEPA with `max_full_evals=max(1, iterations)` instead of the removed `max_steps` parameter.
- Pass a `reflection_lm` created from the existing `optimizer_model` option, which DSPy 3.x GEPA requires for reflective prompt mutation.
- Updated `skill_fitness_metric()` to accept the five-argument metric shape used by DSPy 3.x GEPA: `example`, `prediction`, `trace`, `pred_name`, and `pred_trace`.
- Changed Phase 1 constraint validation to validate complete `SKILL.md` text for both baseline and evolved artifacts, rather than validating only the markdown body.
- Added tests that assert GEPA setup uses the DSPy 3.x API and that the skill fitness metric accepts GEPA trace arguments.

## User Impact

Before:

```text
User runs: python -m evolution.skills.evolve_skill --skill demo --iterations 1
GEPA construction fails: unexpected keyword argument max_steps
Command falls back to MIPROv2
User thinks GEPA is being tested, but it is not
```

After:

```text
User runs the same command
GEPA is constructed with the current DSPy API
GEPA optimization starts normally
If credentials are missing, failure happens at the expected LLM call boundary, not at optimizer construction
```

In practical terms, this makes the Phase 1 command line behavior match the project promise more closely: GEPA is now the primary optimizer path again instead of being skipped by an API mismatch.

## Manual Verification

I created a temporary hermes-agent-style repository with an arbitrary demo skill:

```text
/private/tmp/.../hermes-agent/
  skills/testing/demo-skill/SKILL.md
```

I also created a small golden dataset:

```text
train.jsonl
val.jsonl
holdout.jsonl
```

Before the fix, running the command reached this failure and fallback path:

```text
GEPA.__init__() got an unexpected keyword argument max_steps
falling back to MIPROv2
```

After the fix, running the same command reached actual GEPA execution:

```text
Running GEPA for approx 3 metric calls
```

The run then reached the expected local environment limit:

```text
Missing credentials. Please pass an api_key or set OPENAI_API_KEY
```

That remaining failure is not the regression fixed here. It means the optimizer reached the model-call boundary and the local environment had no OpenAI credentials configured.

## Automated Verification

```text
./.venv/bin/python -m pytest -q
148 passed, 11 warnings
```

The warnings are existing DSPy deprecation warnings from installed dependencies.

## Scope

This PR intentionally does not add a new optimizer, a new phase, or an API-key-free end-to-end optimization mode. It only repairs the existing Phase 1 GEPA path and locks the compatibility behavior with tests.

## Notes

This change keeps the existing `--iterations` CLI surface. Internally it maps that value to GEPA full-evaluation budget via `max_full_evals`, because DSPy 3.x requires exactly one budget control among `auto`, `max_full_evals`, or `max_metric_calls`.