### PR TITLE
Fix Phase 1 skill evolution correctness gates

### DIFF
--- a/evolution/core/benchmark_gate.py
+++ b/evolution/core/benchmark_gate.py
@@ -1,0 +1,122 @@
+"""Benchmark regression gates for evolved artifacts.
+
+The Phase-1 plan treats TBLite/YC-Bench as gates, not fitness functions: a
+candidate that improves the task-specific eval but regresses broad benchmarks
+must be rejected. This module wires the configured TBLite command into a
+fail-closed comparison gate while keeping the expensive benchmark opt-in.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from evolution.core.config import EvolutionConfig
+
+
+@dataclass
+class BenchmarkResult:
+    passed: bool
+    name: str
+    baseline_score: Optional[float] = None
+    evolved_score: Optional[float] = None
+    message: str = ""
+    details: str = ""
+
+
+class BenchmarkGate:
+    """Run and compare benchmark scores for baseline vs evolved artifacts."""
+
+    def __init__(self, config: EvolutionConfig):
+        self.config = config
+
+    def run_tblite_score(self, hermes_repo: Path) -> float:
+        """Run the configured TBLite command and return its numeric score.
+
+        ``HERMES_TBLITE_COMMAND``/``tblite_command`` must print JSON containing
+        either ``score`` or ``pass_rate``. The command is executed in
+        ``hermes_repo``. The caller controls which skill file is present in the
+        working tree before invoking this method.
+        """
+
+        if not self.config.tblite_command:
+            raise ValueError("TBLite gate requested but HERMES_TBLITE_COMMAND is not set")
+        return self._run_score_command(hermes_repo)
+
+    def compare_tblite_scores(self, baseline_score: float, evolved_score: float) -> BenchmarkResult:
+        """Compare baseline and evolved TBLite scores using the configured threshold."""
+
+        baseline = float(baseline_score)
+        evolved = float(evolved_score)
+        allowed = baseline - self.config.tblite_regression_threshold
+        passed = evolved >= allowed
+        delta = evolved - baseline
+        return BenchmarkResult(
+            passed=passed,
+            name="tblite",
+            baseline_score=baseline,
+            evolved_score=evolved,
+            message=(
+                f"TBLite {'passed' if passed else 'regressed'}: "
+                f"baseline={baseline:.3f}, evolved={evolved:.3f}, delta={delta:+.3f}, "
+                f"allowed_floor={allowed:.3f}"
+            ),
+        )
+
+    def run_tblite_comparison(self, hermes_repo: Path) -> BenchmarkResult:
+        """Run the current tree and compare with configured baseline score.
+
+        This convenience method is useful for tests and scripts that already
+        measured the baseline externally. The main evolution pipeline usually
+        runs baseline and evolved scores itself so the comparison is fully
+        self-contained.
+        """
+
+        if self.config.tblite_baseline_score is None:
+            return BenchmarkResult(
+                passed=False,
+                name="tblite",
+                message=(
+                    "TBLite gate needs a baseline score. Provide --tblite-baseline-score, "
+                    "set HERMES_TBLITE_BASELINE_SCORE, or let evolve_skill run the "
+                    "baseline before temporarily writing the evolved skill."
+                ),
+            )
+
+        try:
+            evolved = self.run_tblite_score(hermes_repo)
+        except Exception as exc:
+            return BenchmarkResult(
+                passed=False,
+                name="tblite",
+                message=f"TBLite gate failed: {exc}",
+            )
+        return self.compare_tblite_scores(self.config.tblite_baseline_score, evolved)
+
+    def _run_score_command(self, hermes_repo: Path) -> float:
+        command = shlex.split(self.config.tblite_command or "")
+        result = subprocess.run(
+            command,
+            cwd=str(hermes_repo),
+            capture_output=True,
+            text=True,
+            timeout=7200,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"TBLite command failed ({result.returncode}): {result.stderr or result.stdout}"
+            )
+
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise ValueError("TBLite command must print JSON with score/pass_rate") from exc
+
+        score = payload.get("score", payload.get("pass_rate"))
+        if score is None:
+            raise ValueError("TBLite JSON output must include score or pass_rate")
+        return float(score)

--- a/evolution/core/config.py
+++ b/evolution/core/config.py
@@ -1,9 +1,48 @@
 """Configuration and hermes-agent repo discovery."""
 
+from __future__ import annotations
+
 import os
-from pathlib import Path
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional
+
+
+def _default_api_base() -> Optional[str]:
+    """Return the configured OpenAI-compatible API base, if any."""
+
+    return (
+        os.getenv("OPENROUTER_BASE_URL")
+        or os.getenv("DSPY_API_BASE")
+        or os.getenv("OPENAI_API_BASE")
+    )
+
+
+def _default_lm_max_tokens() -> Optional[int]:
+    """Return an optional LM max_tokens cap from the environment."""
+
+    raw = os.getenv("HERMES_EVOLUTION_MAX_TOKENS")
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError("HERMES_EVOLUTION_MAX_TOKENS must be an integer") from None
+    if value <= 0:
+        raise ValueError("HERMES_EVOLUTION_MAX_TOKENS must be positive")
+    return value
+
+
+def _default_tblite_baseline_score() -> Optional[float]:
+    """Return an optional precomputed TBLite baseline score from the environment."""
+
+    raw = os.getenv("HERMES_TBLITE_BASELINE_SCORE")
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        raise ValueError("HERMES_TBLITE_BASELINE_SCORE must be a number") from None
 
 
 @dataclass
@@ -22,14 +61,20 @@ class EvolutionConfig:
 
     # LLM configuration
     optimizer_model: str = "openai/gpt-4.1"  # Model for GEPA reflections
-    eval_model: str = "openai/gpt-4.1-mini"  # Model for LLM-as-judge scoring
-    judge_model: str = "openai/gpt-4.1"  # Model for dataset generation
+    eval_model: str = "openai/gpt-4.1-mini"  # Student/eval model
+    judge_model: str = "openai/gpt-4.1"  # LLM-as-judge + dataset generation model
+    api_base: Optional[str] = field(default_factory=_default_api_base)
+    lm_max_tokens: Optional[int] = field(default_factory=_default_lm_max_tokens)
 
     # Constraints
-    max_skill_size: int = 15_000  # 15KB default
+    max_skill_size: int = 15_000  # Default cap; evolve_skill raises this to baseline+growth when needed.
     max_tool_desc_size: int = 500  # chars
     max_param_desc_size: int = 200  # chars
     max_prompt_growth: float = 0.2  # 20% max growth over baseline
+
+    # Promotion gates
+    min_skill_improvement: float = 0.10  # Phase-1 gate: >=10% relative score lift
+    allow_heuristic_fallback: bool = False  # LLM-judge failures should fail closed by default
 
     # Eval dataset
     eval_dataset_size: int = 20  # Total examples to generate
@@ -40,7 +85,9 @@ class EvolutionConfig:
     # Benchmark gating
     run_pytest: bool = True
     run_tblite: bool = False  # Expensive — opt-in
-    tblite_regression_threshold: float = 0.02  # Max 2% regression allowed
+    tblite_regression_threshold: float = 0.02  # Max 2% absolute regression allowed
+    tblite_command: Optional[str] = field(default_factory=lambda: os.getenv("HERMES_TBLITE_COMMAND"))
+    tblite_baseline_score: Optional[float] = field(default_factory=_default_tblite_baseline_score)
 
     # Output
     output_dir: Path = field(default_factory=lambda: Path("./output"))
@@ -50,10 +97,11 @@ class EvolutionConfig:
 def _discover_hermes_agent_path() -> Optional[Path]:
     """Best-effort hermes-agent repo discovery that never raises.
 
-    Returns the discovered path, or None when no repo can be found. Used as
-    the EvolutionConfig default so construction never crashes; callers that
-    truly require the repo should use get_hermes_agent_path().
+    Returns the discovered path, or None when no repo can be found. Used as the
+    EvolutionConfig default so construction never crashes; callers that truly
+    require the repo should use get_hermes_agent_path().
     """
+
     try:
         return get_hermes_agent_path()
     except FileNotFoundError:
@@ -68,19 +116,20 @@ def get_hermes_agent_path() -> Path:
     2. ~/.hermes/hermes-agent (standard install location)
     3. ../hermes-agent (sibling directory)
     """
+
     env_path = os.getenv("HERMES_AGENT_REPO")
     if env_path:
         p = Path(env_path).expanduser()
         if p.exists():
-            return p
+            return p.resolve()
 
     home_path = Path.home() / ".hermes" / "hermes-agent"
     if home_path.exists():
-        return home_path
+        return home_path.resolve()
 
     sibling_path = Path(__file__).parent.parent.parent / "hermes-agent"
     if sibling_path.exists():
-        return sibling_path
+        return sibling_path.resolve()
 
     raise FileNotFoundError(
         "Cannot find hermes-agent repo. Set HERMES_AGENT_REPO env var "
@@ -94,9 +143,11 @@ def resolve_hermes_agent_path(hermes_repo: Optional[str] = None) -> Path:
     An explicit path (for example from ``--hermes-repo``) is expanded and used
     as-is, taking precedence over auto-discovery. This lets callers point at a
     repo in a non-default location without the tool crashing just because
-    ``~/.hermes/hermes-agent`` happens to be absent. When no override is given,
-    falls back to :func:`get_hermes_agent_path`.
+    ``~/.hermes/hermes-agent`` happens to be absent.
+
+    When no override is given, falls back to :func:`get_hermes_agent_path`.
     """
+
     if hermes_repo:
         return Path(hermes_repo).expanduser()
     return get_hermes_agent_path()

--- a/evolution/core/constraints.py
+++ b/evolution/core/constraints.py
@@ -1,20 +1,30 @@
 """Constraint validators for evolved artifacts.
 
-Every candidate variant must pass ALL constraints before it can be
-considered valid. Failed constraints = immediate rejection.
+Every candidate variant must pass ALL constraints before it can be considered
+valid. Failed constraints = immediate rejection.
 """
 
+from __future__ import annotations
+
+import re
 import subprocess
-from pathlib import Path
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 from evolution.core.config import EvolutionConfig
 
 
+_SKILL_FRONTMATTER_RE = re.compile(
+    r"\A[ \t]*---[ \t]*\r?\n(?P<frontmatter>.*?)(?:\r?\n)---[ \t]*(?:\r?\n|\Z)(?P<body>.*)\Z",
+    re.DOTALL,
+)
+
+
 @dataclass
 class ConstraintResult:
     """Result of constraint validation."""
+
     passed: bool
     constraint_name: str
     message: str
@@ -33,27 +43,20 @@ class ConstraintValidator:
         artifact_type: str,
         baseline_text: Optional[str] = None,
     ) -> list[ConstraintResult]:
-        """Run all applicable constraints. Returns list of results."""
+        """Run all applicable constraints."""
+
         results = []
-
-        # 1. Size limits
         results.append(self._check_size(artifact_text, artifact_type))
-
-        # 2. Growth limit (if baseline provided)
         if baseline_text:
             results.append(self._check_growth(artifact_text, baseline_text, artifact_type))
-
-        # 3. Non-empty
         results.append(self._check_non_empty(artifact_text))
-
-        # 4. Structural integrity
         if artifact_type == "skill":
             results.append(self._check_skill_structure(artifact_text))
-
         return results
 
     def run_test_suite(self, hermes_repo: Path) -> ConstraintResult:
         """Run the full hermes-agent test suite. Must pass 100%."""
+
         try:
             result = subprocess.run(
                 ["python", "-m", "pytest", "tests/", "-q", "--tb=no"],
@@ -62,7 +65,6 @@ class ConstraintValidator:
                 timeout=300,
                 cwd=str(hermes_repo),
             )
-
             if result.returncode == 0:
                 return ConstraintResult(
                     passed=True,
@@ -70,15 +72,14 @@ class ConstraintValidator:
                     message="All tests passed",
                     details=result.stdout.strip().split("\n")[-1] if result.stdout else "",
                 )
-            else:
-                # Extract failure summary
-                last_lines = result.stdout.strip().split("\n")[-5:] if result.stdout else []
-                return ConstraintResult(
-                    passed=False,
-                    constraint_name="test_suite",
-                    message="Test suite failed",
-                    details="\n".join(last_lines),
-                )
+
+            last_lines = result.stdout.strip().split("\n")[-5:] if result.stdout else []
+            return ConstraintResult(
+                passed=False,
+                constraint_name="test_suite",
+                message="Test suite failed",
+                details="\n".join(last_lines),
+            )
         except subprocess.TimeoutExpired:
             return ConstraintResult(
                 passed=False,
@@ -101,7 +102,7 @@ class ConstraintValidator:
         elif artifact_type == "param_description":
             limit = self.config.max_param_desc_size
         else:
-            limit = self.config.max_skill_size  # Default
+            limit = self.config.max_skill_size
 
         if size <= limit:
             return ConstraintResult(
@@ -109,29 +110,26 @@ class ConstraintValidator:
                 constraint_name="size_limit",
                 message=f"Size OK: {size}/{limit} chars",
             )
-        else:
-            return ConstraintResult(
-                passed=False,
-                constraint_name="size_limit",
-                message=f"Size exceeded: {size}/{limit} chars ({size - limit} over)",
-            )
+        return ConstraintResult(
+            passed=False,
+            constraint_name="size_limit",
+            message=f"Size exceeded: {size}/{limit} chars ({size - limit} over)",
+        )
 
     def _check_growth(self, text: str, baseline: str, artifact_type: str) -> ConstraintResult:
         growth = (len(text) - len(baseline)) / max(1, len(baseline))
         max_growth = self.config.max_prompt_growth
-
         if growth <= max_growth:
             return ConstraintResult(
                 passed=True,
                 constraint_name="growth_limit",
                 message=f"Growth OK: {growth:+.1%} (max {max_growth:+.1%})",
             )
-        else:
-            return ConstraintResult(
-                passed=False,
-                constraint_name="growth_limit",
-                message=f"Growth exceeded: {growth:+.1%} (max {max_growth:+.1%})",
-            )
+        return ConstraintResult(
+            passed=False,
+            constraint_name="growth_limit",
+            message=f"Growth exceeded: {growth:+.1%} (max {max_growth:+.1%})",
+        )
 
     def _check_non_empty(self, text: str) -> ConstraintResult:
         if text.strip():
@@ -140,35 +138,43 @@ class ConstraintValidator:
                 constraint_name="non_empty",
                 message="Artifact is non-empty",
             )
-        else:
-            return ConstraintResult(
-                passed=False,
-                constraint_name="non_empty",
-                message="Artifact is empty",
-            )
+        return ConstraintResult(
+            passed=False,
+            constraint_name="non_empty",
+            message="Artifact is empty",
+        )
 
     def _check_skill_structure(self, text: str) -> ConstraintResult:
-        """Check that a skill file has valid YAML frontmatter and markdown body."""
-        has_frontmatter = text.strip().startswith("---")
-        has_name = "name:" in text[:500] if has_frontmatter else False
-        has_description = "description:" in text[:500] if has_frontmatter else False
+        """Check that a full skill file has a closed YAML frontmatter block and body."""
 
-        if has_frontmatter and has_name and has_description:
+        stripped = text.strip()
+        match = _SKILL_FRONTMATTER_RE.match(stripped)
+        frontmatter = match.group("frontmatter").strip() if match else ""
+        body = match.group("body").strip() if match else ""
+
+        has_frontmatter = match is not None
+        has_name = bool(re.search(r"(?m)^name\s*:\s*\S+", frontmatter))
+        has_description = bool(re.search(r"(?m)^description\s*:\s*\S+", frontmatter))
+        has_body = bool(body)
+
+        if has_frontmatter and has_name and has_description and has_body:
             return ConstraintResult(
                 passed=True,
                 constraint_name="skill_structure",
-                message="Skill has valid frontmatter (name + description)",
+                message="Skill has closed frontmatter (name + description) and body",
             )
-        else:
-            missing = []
-            if not has_frontmatter:
-                missing.append("YAML frontmatter (---)")
-            if not has_name:
-                missing.append("name field")
-            if not has_description:
-                missing.append("description field")
-            return ConstraintResult(
-                passed=False,
-                constraint_name="skill_structure",
-                message=f"Skill missing: {', '.join(missing)}",
-            )
+
+        missing = []
+        if not has_frontmatter:
+            missing.append("closed YAML frontmatter block (--- ... ---)")
+        if not has_name:
+            missing.append("name field")
+        if not has_description:
+            missing.append("description field")
+        if not has_body:
+            missing.append("markdown body")
+        return ConstraintResult(
+            passed=False,
+            constraint_name="skill_structure",
+            message=f"Skill missing: {', '.join(missing)}",
+        )

--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -6,25 +6,30 @@ B) SessionDB mining — extract real usage patterns and score with LLM-as-judge
 C) Golden sets — hand-curated JSONL files
 """
 
+from __future__ import annotations
+
 import json
 import random
-from pathlib import Path
+import re
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional
 
 import dspy
 
 from evolution.core.config import EvolutionConfig
+from evolution.core.lm import make_lm
 
 
 @dataclass
 class EvalExample:
     """A single evaluation example."""
-    task_input: str  # What the user asks
-    expected_behavior: str  # Rubric — what a good response looks like
-    difficulty: str = "medium"  # easy, medium, hard
-    category: str = "general"  # Category for stratified eval
-    source: str = "synthetic"  # synthetic, sessiondb, golden
+
+    task_input: str
+    expected_behavior: str
+    difficulty: str = "medium"
+    category: str = "general"
+    source: str = "synthetic"
 
     def to_dict(self) -> dict:
         return {
@@ -43,6 +48,7 @@ class EvalExample:
 @dataclass
 class EvalDataset:
     """Train/val/holdout split of evaluation examples."""
+
     train: list[EvalExample] = field(default_factory=list)
     val: list[EvalExample] = field(default_factory=list)
     holdout: list[EvalExample] = field(default_factory=list)
@@ -53,8 +59,13 @@ class EvalDataset:
 
     def save(self, path: Path):
         """Save dataset splits to JSONL files."""
+
         path.mkdir(parents=True, exist_ok=True)
-        for split_name, split_data in [("train", self.train), ("val", self.val), ("holdout", self.holdout)]:
+        for split_name, split_data in [
+            ("train", self.train),
+            ("val", self.val),
+            ("holdout", self.holdout),
+        ]:
             with open(path / f"{split_name}.jsonl", "w") as f:
                 for ex in split_data:
                     f.write(json.dumps(ex.to_dict()) + "\n")
@@ -62,6 +73,7 @@ class EvalDataset:
     @classmethod
     def load(cls, path: Path) -> "EvalDataset":
         """Load dataset splits from JSONL files."""
+
         dataset = cls()
         for split_name in ["train", "val", "holdout"]:
             split_file = path / f"{split_name}.jsonl"
@@ -76,6 +88,7 @@ class EvalDataset:
 
     def to_dspy_examples(self, split: str = "train") -> list[dspy.Example]:
         """Convert a split to DSPy Example objects."""
+
         data = getattr(self, split)
         return [
             dspy.Example(
@@ -87,26 +100,31 @@ class EvalDataset:
 
 
 class SyntheticDatasetBuilder:
-    """Generate evaluation datasets using a strong LLM.
-
-    Reads the target artifact (skill file, tool description, etc.)
-    and generates realistic (task_input, expected_behavior) pairs.
-    """
+    """Generate evaluation datasets using a strong LLM."""
 
     class GenerateTestCases(dspy.Signature):
         """Generate realistic evaluation test cases for an agent skill or tool.
 
-        Given the full text of a skill/tool description, generate diverse test cases
-        that would exercise different aspects of the skill. Each test case should include:
+        Given the full text of a skill/tool description, generate diverse test
+        cases that would exercise different aspects of the skill.
+
+        Each test case should include:
         - A realistic task_input (what a user would actually ask)
         - An expected_behavior rubric (what a good response should contain/do, NOT exact text)
         - A difficulty level (easy, medium, hard)
         - A category (what aspect of the skill this tests)
         """
-        artifact_text: str = dspy.InputField(desc="The full text of the skill/tool/prompt being tested")
-        artifact_type: str = dspy.InputField(desc="Type: 'skill', 'tool_description', or 'prompt_section'")
+
+        artifact_text: str = dspy.InputField(
+            desc="The full text of the skill/tool/prompt being tested"
+        )
+        artifact_type: str = dspy.InputField(
+            desc="Type: 'skill', 'tool_description', or 'prompt_section'"
+        )
         num_cases: int = dspy.InputField(desc="Number of test cases to generate")
-        test_cases: str = dspy.OutputField(desc="JSON array of test cases, each with: task_input, expected_behavior, difficulty, category")
+        test_cases: str = dspy.OutputField(
+            desc="JSON array of test cases, each with: task_input, expected_behavior, difficulty, category"
+        )
 
     def __init__(self, config: EvolutionConfig):
         self.config = config
@@ -121,10 +139,7 @@ class SyntheticDatasetBuilder:
         """Generate a full eval dataset with train/val/holdout splits."""
 
         n = num_cases or self.config.eval_dataset_size
-
-        # Configure DSPy to use the judge model for generation
-        lm = dspy.LM(self.config.judge_model)
-
+        lm = make_lm(self.config.judge_model, self.config)
         with dspy.context(lm=lm):
             result = self.generator(
                 artifact_text=artifact_text,
@@ -132,17 +147,16 @@ class SyntheticDatasetBuilder:
                 num_cases=n,
             )
 
-        # Parse the generated test cases
         try:
             cases_raw = json.loads(result.test_cases)
         except json.JSONDecodeError:
-            # Try to extract JSON from the response
-            import re
-            match = re.search(r'\[.*\]', result.test_cases, re.DOTALL)
+            match = re.search(r"\[.*\]", result.test_cases, re.DOTALL)
             if match:
                 cases_raw = json.loads(match.group())
             else:
-                raise ValueError(f"Could not parse test cases from LLM output: {result.test_cases[:200]}")
+                raise ValueError(
+                    f"Could not parse test cases from LLM output: {result.test_cases[:200]}"
+                ) from None
 
         examples = [
             EvalExample(
@@ -156,16 +170,14 @@ class SyntheticDatasetBuilder:
             if c.get("task_input") and c.get("expected_behavior")
         ]
 
-        # Shuffle and split
         random.shuffle(examples)
         n_total = len(examples)
         n_train = max(1, int(n_total * self.config.train_ratio))
         n_val = max(1, int(n_total * self.config.val_ratio))
-
         return EvalDataset(
             train=examples[:n_train],
-            val=examples[n_train:n_train + n_val],
-            holdout=examples[n_train + n_val:],
+            val=examples[n_train : n_train + n_val],
+            holdout=examples[n_train + n_val :],
         )
 
 
@@ -175,10 +187,10 @@ class GoldenDatasetLoader:
     @staticmethod
     def load(path: Path) -> EvalDataset:
         """Load a golden dataset. If no splits exist, auto-split the single file."""
+
         if (path / "train.jsonl").exists():
             return EvalDataset.load(path)
 
-        # Single file — auto-split
         golden_file = path if path.suffix == ".jsonl" else path / "golden.jsonl"
         if not golden_file.exists():
             raise FileNotFoundError(f"No golden dataset found at {golden_file}")
@@ -193,9 +205,8 @@ class GoldenDatasetLoader:
         n = len(examples)
         n_train = max(1, int(n * 0.5))
         n_val = max(1, int(n * 0.25))
-
         return EvalDataset(
             train=examples[:n_train],
-            val=examples[n_train:n_train + n_val],
-            holdout=examples[n_train + n_val:],
+            val=examples[n_train : n_train + n_val],
+            holdout=examples[n_train + n_val :],
         )

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -1,19 +1,25 @@
 """Fitness functions for evaluating evolved artifacts.
 
-Uses LLM-as-judge with rubrics to score agent outputs.
-Supports length penalties and multi-dimensional scoring.
+Uses LLM-as-judge with rubrics to score agent outputs. Supports length
+penalties and multi-dimensional scoring.
 """
 
-import dspy
+from __future__ import annotations
+
+import re
 from dataclasses import dataclass
 from typing import Optional
 
+import dspy
+
 from evolution.core.config import EvolutionConfig
+from evolution.core.lm import make_lm
 
 
 @dataclass
 class FitnessScore:
     """Multi-dimensional fitness score."""
+
     correctness: float = 0.0  # Did the agent produce correct output? (0-1)
     procedure_following: float = 0.0  # Did it follow the skill's procedure? (0-1)
     conciseness: float = 0.0  # Was it appropriately concise? (0-1)
@@ -23,20 +29,17 @@ class FitnessScore:
     @property
     def composite(self) -> float:
         """Weighted composite score."""
+
         raw = (
             0.5 * self.correctness
             + 0.3 * self.procedure_following
             + 0.2 * self.conciseness
         )
-        return max(0.0, raw - self.length_penalty)
+        return max(0.0, min(1.0, raw - self.length_penalty))
 
 
 class LLMJudge:
-    """LLM-as-judge scorer with rubric-based evaluation.
-
-    Scores agent outputs on multiple dimensions and provides
-    textual feedback that GEPA can use for reflective mutation.
-    """
+    """LLM-as-judge scorer with rubric-based evaluation."""
 
     class JudgeSignature(dspy.Signature):
         """Evaluate an agent's response against an expected behavior rubric.
@@ -48,14 +51,24 @@ class LLMJudge:
 
         Also provide specific, actionable feedback on what could be improved.
         """
+
         task_input: str = dspy.InputField(desc="The task the agent was given")
-        expected_behavior: str = dspy.InputField(desc="Rubric describing what a good response looks like")
+        expected_behavior: str = dspy.InputField(
+            desc="Rubric describing what a good response looks like"
+        )
         agent_output: str = dspy.InputField(desc="The agent's actual response")
-        skill_text: str = dspy.InputField(desc="The skill/instructions the agent was following")
-        correctness: float = dspy.OutputField(desc="Score 0.0-1.0: Did the response correctly address the task?")
-        procedure_following: float = dspy.OutputField(desc="Score 0.0-1.0: Did it follow the expected procedure?")
+        skill_text: str = dspy.InputField(desc="The current skill/instructions being evaluated")
+
+        correctness: float = dspy.OutputField(
+            desc="Score 0.0-1.0: Did the response correctly address the task?"
+        )
+        procedure_following: float = dspy.OutputField(
+            desc="Score 0.0-1.0: Did it follow the expected procedure?"
+        )
         conciseness: float = dspy.OutputField(desc="Score 0.0-1.0: Appropriately concise?")
-        feedback: str = dspy.OutputField(desc="Specific, actionable feedback on what could be improved")
+        feedback: str = dspy.OutputField(
+            desc="Specific, actionable feedback on what could be improved"
+        )
 
     def __init__(self, config: EvolutionConfig):
         self.config = config
@@ -72,8 +85,7 @@ class LLMJudge:
     ) -> FitnessScore:
         """Score an agent output using LLM-as-judge."""
 
-        lm = dspy.LM(self.config.eval_model)
-
+        lm = make_lm(self.config.judge_model, self.config)
         with dspy.context(lm=lm):
             result = self.judge(
                 task_input=task_input,
@@ -82,14 +94,12 @@ class LLMJudge:
                 skill_text=skill_text,
             )
 
-        # Parse scores (clamp to 0-1)
         correctness = _parse_score(result.correctness)
         procedure_following = _parse_score(result.procedure_following)
         conciseness = _parse_score(result.conciseness)
 
-        # Length penalty
         length_penalty = 0.0
-        if artifact_size is not None and max_size is not None:
+        if artifact_size is not None and max_size is not None and max_size > 0:
             ratio = artifact_size / max_size
             if ratio > 0.9:
                 # Penalty ramps from 0 at 90% to 0.3 at 100%+
@@ -104,43 +114,140 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
-    """DSPy-compatible metric function for skill optimization.
+def make_skill_fitness_metric(
+    config: EvolutionConfig,
+    fallback_skill_text: str = "",
+    *,
+    return_feedback: bool = False,
+):
+    """Build the Phase-1 metric using LLM-as-judge scoring.
 
-    This is what gets passed to dspy.GEPA(metric=...).
-    Returns a float 0-1 score.
+    This is intentionally stricter than the legacy lexical proxy. The whole
+    point of Phase 1 is to optimize skill quality, not keyword overlap. If the
+    judge cannot run, the pipeline fails closed unless
+    ``allow_heuristic_fallback`` is explicitly enabled.
+
+    ``SkillModule.forward`` returns the candidate's current skill instructions
+    on the prediction object. That allows the judge to evaluate each GEPA
+    candidate against its own evolved instructions rather than against the
+    original baseline skill.
+
+    GEPA can use textual feedback for reflection, so callers running GEPA pass
+    ``return_feedback=True`` to receive ``dspy.Prediction(score=...,
+    feedback=...)``. Scalar-only optimizers such as the MIPROv2 fallback use
+    the same judge with ``return_feedback=False``.
     """
-    # The prediction should have an 'output' field with the agent's response
+
+    judge = LLMJudge(config)
+
+    def _format_score(score: FitnessScore):
+        if return_feedback:
+            return dspy.Prediction(score=score.composite, feedback=score.feedback)
+        return score.composite
+
+    def _format_zero(feedback: str):
+        if return_feedback:
+            return dspy.Prediction(score=0.0, feedback=feedback)
+        return 0.0
+
+    def metric(
+        example: dspy.Example,
+        prediction: dspy.Prediction,
+        trace=None,
+        pred_name=None,
+        pred_trace=None,
+    ):
+        agent_output = getattr(prediction, "output", "") or ""
+        if not agent_output.strip():
+            return _format_zero("The candidate produced an empty output.")
+
+        task_input = getattr(example, "task_input", "") or ""
+        expected_behavior = getattr(example, "expected_behavior", "") or ""
+        candidate_skill_text = (
+            getattr(prediction, "skill_text", "")
+            or getattr(example, "skill_text", "")
+            or fallback_skill_text
+        )
+        try:
+            score = judge.score(
+                task_input=task_input,
+                expected_behavior=expected_behavior,
+                agent_output=agent_output,
+                skill_text=candidate_skill_text,
+                artifact_size=len(candidate_skill_text),
+                max_size=config.max_skill_size,
+            )
+            return _format_score(score)
+        except Exception as exc:
+            if config.allow_heuristic_fallback:
+                scalar = skill_fitness_metric(
+                    example,
+                    prediction,
+                    trace=trace,
+                    pred_name=pred_name,
+                    pred_trace=pred_trace,
+                )
+                if return_feedback:
+                    return dspy.Prediction(
+                        score=scalar,
+                        feedback=f"LLM judge failed ({type(exc).__name__}); used lexical fallback.",
+                    )
+                return scalar
+            raise
+
+    return metric
+
+
+def skill_fitness_metric(
+    example: dspy.Example,
+    prediction: dspy.Prediction,
+    trace=None,
+    pred_name=None,
+    pred_trace=None,
+) -> float:
+    """Legacy lexical proxy metric retained as an explicit fallback.
+
+    This function is not the default Phase-1 optimization objective anymore.
+    It exists for cheap smoke tests and for explicitly configured fallback mode.
+    """
+
     agent_output = getattr(prediction, "output", "") or ""
     expected = getattr(example, "expected_behavior", "") or ""
-    task = getattr(example, "task_input", "") or ""
-
     if not agent_output.strip():
         return 0.0
 
-    # Quick heuristic scoring (for speed during optimization)
-    # Full LLM-as-judge scoring is expensive — use it selectively
-    score = 0.5  # Base score for non-empty output
+    expected_words = _content_words(expected)
+    output_words = _content_words(agent_output)
+    if not expected_words:
+        return 0.5
 
-    # Check if key phrases from expected behavior appear
-    expected_lower = expected.lower()
-    output_lower = agent_output.lower()
+    overlap = len(expected_words & output_words) / len(expected_words)
+    return min(1.0, max(0.0, 0.3 + (0.7 * overlap)))
 
-    # Simple keyword overlap as a fast proxy
-    expected_words = set(expected_lower.split())
-    output_words = set(output_lower.split())
-    if expected_words:
-        overlap = len(expected_words & output_words) / len(expected_words)
-        score = 0.3 + (0.7 * overlap)
 
-    return min(1.0, max(0.0, score))
+def _content_words(text: str) -> set[str]:
+    return {word for word in re.findall(r"[a-z0-9_]+", text.lower()) if len(word) > 2}
 
 
 def _parse_score(value) -> float:
     """Parse a score value, handling various LLM output formats."""
+
     if isinstance(value, (int, float)):
         return min(1.0, max(0.0, float(value)))
+
+    text = str(value).strip()
     try:
-        return min(1.0, max(0.0, float(str(value).strip())))
+        return min(1.0, max(0.0, float(text)))
     except (ValueError, TypeError):
-        return 0.5  # Default to neutral on parse failure
+        pass
+
+    # Handle common judge outputs like "0.8/1" or "score: 80%".
+    match = re.search(r"(-?\d+(?:\.\d+)?)\s*(/\s*1|%)?", text)
+    if not match:
+        return 0.5
+
+    number = float(match.group(1))
+    suffix = match.group(2) or ""
+    if "%" in suffix or number > 1.0:
+        number /= 100.0
+    return min(1.0, max(0.0, number))

--- a/evolution/core/lm.py
+++ b/evolution/core/lm.py
@@ -1,0 +1,27 @@
+"""Shared DSPy language-model construction helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import dspy
+
+from evolution.core.config import EvolutionConfig
+
+
+def make_lm(model: str, config: Optional[EvolutionConfig] = None, **kwargs: Any) -> dspy.LM:
+    """Construct a DSPy LM honoring configured OpenAI-compatible settings.
+
+    The self-evolution repo supports OpenAI-style providers such as OpenRouter
+    by passing ``api_base`` through to DSPy. Keeping this in one helper prevents
+    the optimizer, dataset builder, and judge from silently using different
+    providers or token caps.
+    """
+
+    params = dict(kwargs)
+    if config is not None:
+        if config.api_base and "api_base" not in params:
+            params["api_base"] = config.api_base
+        if config.lm_max_tokens and "max_tokens" not in params:
+            params["max_tokens"] = config.lm_max_tokens
+    return dspy.LM(model, **params)

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -2,35 +2,263 @@
 
 Usage:
     python -m evolution.skills.evolve_skill --skill github-code-review --iterations 10
-    python -m evolution.skills.evolve_skill --skill arxiv --eval-source golden --dataset datasets/skills/arxiv/
+    python -m evolution.skills.evolve_skill --skill arxiv --eval-source golden --dataset-path datasets/skills/arxiv/
 """
+
+from __future__ import annotations
 
 import json
 import sys
 import time
-from pathlib import Path
+from contextlib import contextmanager
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 import click
 import dspy
 from rich.console import Console
-from rich.panel import Panel
 from rich.table import Table
 
+from evolution.core.benchmark_gate import BenchmarkGate, BenchmarkResult
 from evolution.core.config import EvolutionConfig, resolve_hermes_agent_path
-from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset, GoldenDatasetLoader
+from evolution.core.constraints import ConstraintResult, ConstraintValidator
+from evolution.core.dataset_builder import EvalDataset, GoldenDatasetLoader, SyntheticDatasetBuilder
 from evolution.core.external_importers import build_dataset_from_external
-from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore
-from evolution.core.constraints import ConstraintValidator
+from evolution.core.fitness import LLMJudge, make_skill_fitness_metric
+from evolution.core.lm import make_lm
 from evolution.skills.skill_module import (
     SkillModule,
-    load_skill,
+    extract_evolved_skill_text,
     find_skill,
+    load_skill,
     reassemble_skill,
 )
 
 console = Console()
+
+
+@contextmanager
+def _temporary_file_contents(path: Path, contents: str):
+    """Temporarily write a file and always restore its original contents."""
+
+    original = path.read_text()
+    try:
+        path.write_text(contents)
+        yield
+    finally:
+        path.write_text(original)
+
+
+def _all_pass(results: list[ConstraintResult]) -> bool:
+    return all(result.passed for result in results)
+
+
+def _print_constraint_results(results: list[ConstraintResult]) -> None:
+    for c in results:
+        icon = "✓" if c.passed else "✗"
+        color = "green" if c.passed else "red"
+        console.print(f"  [{color}]{icon} {c.constraint_name}[/{color}]: {c.message}")
+        if c.details and not c.passed:
+            console.print(f"    [dim]{c.details}[/dim]")
+
+
+def _fail(message: str, exit_code: int = 1) -> None:
+    console.print(f"[red]✗ {message}[/red]")
+    raise SystemExit(exit_code)
+
+
+def _build_dataset(
+    config: EvolutionConfig,
+    skill_name: str,
+    skill_raw: str,
+    eval_source: str,
+    dataset_path: Optional[str],
+    judge_model: str,
+) -> EvalDataset:
+    console.print(f"\n[bold]Building evaluation dataset[/bold] (source: {eval_source})")
+
+    if eval_source == "golden" and dataset_path:
+        dataset = GoldenDatasetLoader.load(Path(dataset_path))
+        console.print(f"  Loaded golden dataset: {len(dataset.all_examples)} examples")
+        return dataset
+
+    if eval_source == "sessiondb":
+        save_path = Path(dataset_path) if dataset_path else Path("datasets") / "skills" / skill_name
+        dataset = build_dataset_from_external(
+            skill_name=skill_name,
+            skill_text=skill_raw,
+            sources=["claude-code", "copilot", "hermes"],
+            output_path=save_path,
+            model=judge_model,
+        )
+        if not dataset.all_examples:
+            _fail("No relevant examples found from session history")
+        console.print(f"  Mined {len(dataset.all_examples)} examples from session history")
+        return dataset
+
+    if eval_source == "synthetic":
+        builder = SyntheticDatasetBuilder(config)
+        dataset = builder.generate(artifact_text=skill_raw, artifact_type="skill")
+        save_path = Path("datasets") / "skills" / skill_name
+        dataset.save(save_path)
+        console.print(f"  Generated {len(dataset.all_examples)} synthetic examples")
+        console.print(f"  Saved to {save_path}/")
+        return dataset
+
+    if dataset_path:
+        dataset = EvalDataset.load(Path(dataset_path))
+        console.print(f"  Loaded dataset: {len(dataset.all_examples)} examples")
+        return dataset
+
+    _fail("Specify --dataset-path or use --eval-source synthetic")
+
+
+def _require_usable_dataset(dataset: EvalDataset) -> None:
+    """Phase 1 must have train/val/holdout data before claiming improvement."""
+
+    missing = []
+    if not dataset.train:
+        missing.append("train")
+    if not dataset.val:
+        missing.append("val")
+    if not dataset.holdout:
+        missing.append("holdout")
+    if missing:
+        _fail(
+            "Evaluation dataset is missing required split(s): "
+            + ", ".join(missing)
+            + ". Phase 1 must prove improvement on a held-out set."
+        )
+
+
+def _adjust_size_limit_for_baseline(config: EvolutionConfig, baseline_text: str) -> None:
+    """Avoid rejecting existing large skills while still enforcing growth limits."""
+
+    required_limit = int(len(baseline_text) * (1 + config.max_prompt_growth))
+    if required_limit > config.max_skill_size:
+        console.print(
+            "  [yellow]Increasing max_skill_size for this run from "
+            f"{config.max_skill_size:,} to {required_limit:,} chars so the baseline "
+            "skill is not rejected solely for already being large.[/yellow]"
+        )
+        config.max_skill_size = required_limit
+
+
+def _compile_with_gepa_or_fallback(
+    baseline_module: SkillModule,
+    trainset: list[dspy.Example],
+    valset: list[dspy.Example],
+    gepa_metric,
+    scalar_metric,
+    config: EvolutionConfig,
+) -> tuple[dspy.Module, str]:
+    """Run GEPA with the current DSPy 3.x API, falling back visibly if needed."""
+
+    reflection_lm = make_lm(config.optimizer_model, config)
+    try:
+        optimizer = dspy.GEPA(
+            metric=gepa_metric,
+            max_full_evals=max(1, config.iterations),
+            reflection_lm=reflection_lm,
+        )
+        return optimizer.compile(baseline_module, trainset=trainset, valset=valset), "GEPA"
+    except Exception as e:
+        console.print(
+            "[yellow]WARNING: GEPA unavailable or failed "
+            f"({type(e).__name__}: {e}); falling back to MIPROv2[/yellow]"
+        )
+
+    optimizer = dspy.MIPROv2(metric=scalar_metric, auto="light")
+    # MIPROv2.compile prompts on stdin by default (requires_permission_to_run=True),
+    # which raises EOFError / hangs in a non-interactive evolution run. The fallback
+    # must stay fully automated.
+    return (
+        optimizer.compile(
+            baseline_module,
+            trainset=trainset,
+            requires_permission_to_run=False,
+        ),
+        "MIPROv2",
+    )
+
+
+def _score_holdout(
+    module: dspy.Module,
+    examples: list[dspy.Example],
+    judge: LLMJudge,
+    fallback_skill_text: str,
+    config: EvolutionConfig,
+) -> list[float]:
+    """Score a module on holdout examples with LLM-as-judge."""
+
+    scores: list[float] = []
+    for ex in examples:
+        prediction = module(task_input=ex.task_input)
+        skill_text = getattr(prediction, "skill_text", "") or fallback_skill_text
+        score = judge.score(
+            task_input=ex.task_input,
+            expected_behavior=getattr(ex, "expected_behavior", ""),
+            agent_output=getattr(prediction, "output", "") or "",
+            skill_text=skill_text,
+            artifact_size=len(skill_text),
+            max_size=config.max_skill_size,
+        )
+        scores.append(score.composite)
+    return scores
+
+
+def _save_candidate(
+    skill_name: str,
+    timestamp: str,
+    baseline_full: str,
+    evolved_full: str,
+    metrics: dict,
+) -> Path:
+    output_dir = Path("output") / skill_name / timestamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "evolved_skill.md").write_text(evolved_full)
+    (output_dir / "baseline_skill.md").write_text(baseline_full)
+    (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+    return output_dir
+
+
+def _run_pytest_gate(
+    validator: ConstraintValidator,
+    hermes_repo: Path,
+    skill_path: Path,
+    evolved_full: str,
+) -> ConstraintResult:
+    console.print("\n[bold]Running hermes-agent test gate against temporary evolved skill[/bold]")
+    with _temporary_file_contents(skill_path, evolved_full):
+        return validator.run_test_suite(hermes_repo)
+
+
+def _run_tblite_gate(
+    config: EvolutionConfig,
+    hermes_repo: Path,
+    skill_path: Path,
+    evolved_full: str,
+) -> BenchmarkResult:
+    console.print("\n[bold]Running TBLite benchmark gate[/bold]")
+    gate = BenchmarkGate(config)
+    try:
+        if config.tblite_baseline_score is None:
+            console.print("  Measuring baseline TBLite score before writing evolved skill")
+            baseline_score = gate.run_tblite_score(hermes_repo)
+        else:
+            baseline_score = config.tblite_baseline_score
+            console.print(f"  Using configured baseline TBLite score: {baseline_score:.3f}")
+
+        with _temporary_file_contents(skill_path, evolved_full):
+            evolved_score = gate.run_tblite_score(hermes_repo)
+        return gate.compare_tblite_scores(baseline_score, evolved_score)
+    except Exception as exc:
+        return BenchmarkResult(
+            passed=False,
+            name="tblite",
+            message=f"TBLite gate failed: {exc}",
+        )
 
 
 def evolve(
@@ -40,8 +268,14 @@ def evolve(
     dataset_path: Optional[str] = None,
     optimizer_model: str = "openai/gpt-4.1",
     eval_model: str = "openai/gpt-4.1-mini",
+    judge_model: str = "openai/gpt-4.1",
     hermes_repo: Optional[str] = None,
     run_tests: bool = False,
+    run_tblite: bool = False,
+    tblite_command: Optional[str] = None,
+    tblite_baseline_score: Optional[float] = None,
+    min_skill_improvement: float = 0.10,
+    allow_heuristic_fallback: bool = False,
     dry_run: bool = False,
 ):
     """Main evolution function — orchestrates the full optimization loop."""
@@ -51,17 +285,25 @@ def evolve(
         iterations=iterations,
         optimizer_model=optimizer_model,
         eval_model=eval_model,
-        judge_model=eval_model,  # Use same model for dataset generation
+        judge_model=judge_model,
         run_pytest=run_tests,
+        run_tblite=run_tblite,
+        min_skill_improvement=min_skill_improvement,
+        allow_heuristic_fallback=allow_heuristic_fallback,
     )
+    if tblite_command is not None:
+        config.tblite_command = tblite_command
+    if tblite_baseline_score is not None:
+        config.tblite_baseline_score = tblite_baseline_score
 
-    # ── 1. Find and load the skill ──────────────────────────────────────
-    console.print(f"\n[bold cyan]🧬 Hermes Agent Self-Evolution[/bold cyan] — Evolving skill: [bold]{skill_name}[/bold]\n")
+    console.print(
+        f"\n[bold cyan]Hermes Agent Self-Evolution[/bold cyan] — "
+        f"Evolving skill: [bold]{skill_name}[/bold]\n"
+    )
 
     skill_path = find_skill(skill_name, config.hermes_agent_path)
     if not skill_path:
-        console.print(f"[red]✗ Skill '{skill_name}' not found in {config.hermes_agent_path / 'skills'}[/red]")
-        sys.exit(1)
+        _fail(f"Skill '{skill_name}' not found in {config.hermes_agent_path / 'skills'}")
 
     skill = load_skill(skill_path)
     console.print(f"  Loaded: {skill_path.relative_to(config.hermes_agent_path)}")
@@ -69,175 +311,118 @@ def evolve(
     console.print(f"  Size: {len(skill['raw']):,} chars")
     console.print(f"  Description: {skill['description'][:80]}...")
 
+    _adjust_size_limit_for_baseline(config, skill["raw"])
+
     if dry_run:
-        console.print(f"\n[bold green]DRY RUN — setup validated successfully.[/bold green]")
+        console.print("\n[bold green]DRY RUN — setup validated successfully.[/bold green]")
         console.print(f"  Would generate eval dataset (source: {eval_source})")
-        console.print(f"  Would run GEPA optimization ({iterations} iterations)")
-        console.print(f"  Would validate constraints and create PR")
+        console.print(f"  Would run GEPA optimization ({iterations} full evals)")
+        console.print("  Would validate constraints, holdout score, and configured gates")
         return
 
-    # ── 2. Build or load evaluation dataset ─────────────────────────────
-    console.print(f"\n[bold]Building evaluation dataset[/bold] (source: {eval_source})")
+    dataset = _build_dataset(config, skill_name, skill["raw"], eval_source, dataset_path, judge_model)
+    console.print(
+        f"  Split: {len(dataset.train)} train / "
+        f"{len(dataset.val)} val / {len(dataset.holdout)} holdout"
+    )
+    _require_usable_dataset(dataset)
 
-    if eval_source == "golden" and dataset_path:
-        dataset = GoldenDatasetLoader.load(Path(dataset_path))
-        console.print(f"  Loaded golden dataset: {len(dataset.all_examples)} examples")
-    elif eval_source == "sessiondb":
-        save_path = Path(dataset_path) if dataset_path else Path("datasets") / "skills" / skill_name
-        dataset = build_dataset_from_external(
-            skill_name=skill_name,
-            skill_text=skill["raw"],
-            sources=["claude-code", "copilot", "hermes"],
-            output_path=save_path,
-            model=eval_model,
-        )
-        if not dataset.all_examples:
-            console.print("[red]✗ No relevant examples found from session history[/red]")
-            sys.exit(1)
-        console.print(f"  Mined {len(dataset.all_examples)} examples from session history")
-    elif eval_source == "synthetic":
-        builder = SyntheticDatasetBuilder(config)
-        dataset = builder.generate(
-            artifact_text=skill["raw"],
-            artifact_type="skill",
-        )
-        # Save for reuse
-        save_path = Path("datasets") / "skills" / skill_name
-        dataset.save(save_path)
-        console.print(f"  Generated {len(dataset.all_examples)} synthetic examples")
-        console.print(f"  Saved to {save_path}/")
-    elif dataset_path:
-        dataset = EvalDataset.load(Path(dataset_path))
-        console.print(f"  Loaded dataset: {len(dataset.all_examples)} examples")
-    else:
-        console.print("[red]✗ Specify --dataset-path or use --eval-source synthetic[/red]")
-        sys.exit(1)
-
-    console.print(f"  Split: {len(dataset.train)} train / {len(dataset.val)} val / {len(dataset.holdout)} holdout")
-
-    # ── 3. Validate constraints on baseline ─────────────────────────────
-    console.print(f"\n[bold]Validating baseline constraints[/bold]")
+    console.print("\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
-    all_pass = True
-    for c in baseline_constraints:
-        icon = "✓" if c.passed else "✗"
-        color = "green" if c.passed else "red"
-        console.print(f"  [{color}]{icon} {c.constraint_name}[/{color}]: {c.message}")
-        if not c.passed:
-            all_pass = False
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
+    _print_constraint_results(baseline_constraints)
+    if not _all_pass(baseline_constraints):
+        _fail("Baseline skill failed constraints; refusing to optimize from an invalid baseline")
 
-    if not all_pass:
-        console.print("[yellow]⚠ Baseline skill has constraint violations — proceeding anyway[/yellow]")
-
-    # ── 4. Set up DSPy + GEPA optimizer ─────────────────────────────────
-    console.print(f"\n[bold]Configuring optimizer[/bold]")
-    console.print(f"  Optimizer: GEPA ({iterations} iterations)")
+    console.print("\n[bold]Configuring optimizer[/bold]")
+    console.print(f"  Optimizer: GEPA ({iterations} full evals; MIPROv2 fallback)")
     console.print(f"  Optimizer model: {optimizer_model}")
-    console.print(f"  Eval model: {eval_model}")
+    console.print(f"  Eval/student model: {eval_model}")
+    console.print(f"  Judge/dataset model: {judge_model}")
+    console.print(f"  Promotion threshold: ≥{min_skill_improvement:.1%} relative holdout lift")
 
-    # Configure DSPy
-    lm = dspy.LM(eval_model)
-    dspy.configure(lm=lm)
+    student_lm = make_lm(config.eval_model, config)
+    dspy.configure(lm=student_lm)
 
-    # Create the baseline skill module
     baseline_module = SkillModule(skill["body"])
-
-    # Prepare DSPy examples
     trainset = dataset.to_dspy_examples("train")
     valset = dataset.to_dspy_examples("val")
+    gepa_metric = make_skill_fitness_metric(
+        config, fallback_skill_text=skill["body"], return_feedback=True
+    )
+    scalar_metric = make_skill_fitness_metric(
+        config, fallback_skill_text=skill["body"], return_feedback=False
+    )
 
-    # ── 5. Run GEPA optimization ────────────────────────────────────────
-    console.print(f"\n[bold cyan]Running GEPA optimization ({iterations} iterations)...[/bold cyan]\n")
-
+    console.print(f"\n[bold cyan]Running optimization ({iterations} full evals)...[/bold cyan]\n")
     start_time = time.time()
-
-    try:
-        optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
-            max_steps=iterations,
-        )
-
-        optimized_module = optimizer.compile(
-            baseline_module,
-            trainset=trainset,
-            valset=valset,
-        )
-    except Exception as e:
-        # Fall back to MIPROv2 if GEPA isn't available in this DSPy version
-        console.print(f"[yellow]GEPA not available ({e}), falling back to MIPROv2[/yellow]")
-        optimizer = dspy.MIPROv2(
-            metric=skill_fitness_metric,
-            auto="light",
-        )
-        optimized_module = optimizer.compile(
-            baseline_module,
-            trainset=trainset,
-        )
-
+    optimized_module, optimizer_name = _compile_with_gepa_or_fallback(
+        baseline_module=baseline_module,
+        trainset=trainset,
+        valset=valset,
+        gepa_metric=gepa_metric,
+        scalar_metric=scalar_metric,
+        config=config,
+    )
     elapsed = time.time() - start_time
-    console.print(f"\n  Optimization completed in {elapsed:.1f}s")
+    console.print(f"\n  Optimization completed with {optimizer_name} in {elapsed:.1f}s")
 
-    # ── 6. Extract evolved skill text ───────────────────────────────────
-    # The optimized module's instructions contain the evolved skill text
-    evolved_body = optimized_module.skill_text
+    evolved_body = extract_evolved_skill_text(optimized_module, fallback=skill["body"])
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
-    # ── 7. Validate evolved skill ───────────────────────────────────────
-    console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
-    all_pass = True
-    for c in evolved_constraints:
-        icon = "✓" if c.passed else "✗"
-        color = "green" if c.passed else "red"
-        console.print(f"  [{color}]{icon} {c.constraint_name}[/{color}]: {c.message}")
-        if not c.passed:
-            all_pass = False
-
-    if not all_pass:
-        console.print("[red]✗ Evolved skill FAILED constraints — not deploying[/red]")
-        # Still save for inspection
+    console.print("\n[bold]Validating evolved skill[/bold]")
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
+    _print_constraint_results(evolved_constraints)
+    if not _all_pass(evolved_constraints):
+        console.print("[red]✗ Evolved skill FAILED constraints — not promoting[/red]")
         output_path = Path("output") / skill_name / "evolved_FAILED.md"
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(evolved_full)
         console.print(f"  Saved failed variant to {output_path}")
         return
 
-    # ── 8. Evaluate on holdout set ──────────────────────────────────────
     console.print(f"\n[bold]Evaluating on holdout set ({len(dataset.holdout)} examples)[/bold]")
-
     holdout_examples = dataset.to_dspy_examples("holdout")
+    judge = LLMJudge(config)
+    baseline_scores = _score_holdout(baseline_module, holdout_examples, judge, skill["body"], config)
+    evolved_scores = _score_holdout(optimized_module, holdout_examples, judge, evolved_body, config)
 
-    baseline_scores = []
-    evolved_scores = []
-    for ex in holdout_examples:
-        # Score baseline
-        with dspy.context(lm=lm):
-            baseline_pred = baseline_module(task_input=ex.task_input)
-            baseline_score = skill_fitness_metric(ex, baseline_pred)
-            baseline_scores.append(baseline_score)
-
-            evolved_pred = optimized_module(task_input=ex.task_input)
-            evolved_score = skill_fitness_metric(ex, evolved_pred)
-            evolved_scores.append(evolved_score)
-
-    avg_baseline = sum(baseline_scores) / max(1, len(baseline_scores))
-    avg_evolved = sum(evolved_scores) / max(1, len(evolved_scores))
+    avg_baseline = sum(baseline_scores) / len(baseline_scores)
+    avg_evolved = sum(evolved_scores) / len(evolved_scores)
     improvement = avg_evolved - avg_baseline
+    relative_improvement = improvement / max(0.001, avg_baseline)
+    promotion_passed = avg_evolved > avg_baseline and relative_improvement >= config.min_skill_improvement
 
-    # ── 9. Report results ───────────────────────────────────────────────
+    test_result: Optional[ConstraintResult] = None
+    benchmark_result: Optional[BenchmarkResult] = None
+
+    if promotion_passed and config.run_pytest:
+        test_result = _run_pytest_gate(validator, config.hermes_agent_path, skill_path, evolved_full)
+        _print_constraint_results([test_result])
+        if not test_result.passed:
+            promotion_passed = False
+            console.print("[red]✗ Evolved skill FAILED test gate — not promoting[/red]")
+
+    if promotion_passed and config.run_tblite:
+        benchmark_result = _run_tblite_gate(config, config.hermes_agent_path, skill_path, evolved_full)
+        color = "green" if benchmark_result.passed else "red"
+        icon = "✓" if benchmark_result.passed else "✗"
+        console.print(f"  [{color}]{icon} {benchmark_result.name}[/{color}]: {benchmark_result.message}")
+        if not benchmark_result.passed:
+            promotion_passed = False
+            console.print("[red]✗ Evolved skill FAILED benchmark gate — not promoting[/red]")
+
     table = Table(title="Evolution Results")
     table.add_column("Metric", style="bold")
     table.add_column("Baseline", justify="right")
     table.add_column("Evolved", justify="right")
     table.add_column("Change", justify="right")
-
     change_color = "green" if improvement > 0 else "red"
     table.add_row(
         "Holdout Score",
         f"{avg_baseline:.3f}",
         f"{avg_evolved:.3f}",
-        f"[{change_color}]{improvement:+.3f}[/{change_color}]",
+        f"[{change_color}]{improvement:+.3f} ({relative_improvement:+.1%})[/{change_color}]",
     )
     table.add_row(
         "Skill Size",
@@ -245,66 +430,99 @@ def evolve(
         f"{len(evolved_body):,} chars",
         f"{len(evolved_body) - len(skill['body']):+,} chars",
     )
+    table.add_row("Optimizer", "", optimizer_name, "")
     table.add_row("Time", "", f"{elapsed:.1f}s", "")
     table.add_row("Iterations", "", str(iterations), "")
-
+    table.add_row("Promotion Gate", "", "PASS" if promotion_passed else "FAIL", "")
     console.print()
     console.print(table)
 
-    # ── 10. Save output ─────────────────────────────────────────────────
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_dir = Path("output") / skill_name / timestamp
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    # Save evolved skill
-    (output_dir / "evolved_skill.md").write_text(evolved_full)
-
-    # Save baseline for comparison
-    (output_dir / "baseline_skill.md").write_text(skill["raw"])
-
-    # Save metrics
     metrics = {
         "skill_name": skill_name,
         "timestamp": timestamp,
         "iterations": iterations,
+        "optimizer": optimizer_name,
         "optimizer_model": optimizer_model,
         "eval_model": eval_model,
         "baseline_score": avg_baseline,
         "evolved_score": avg_evolved,
         "improvement": improvement,
+        "relative_improvement": relative_improvement,
+        "min_skill_improvement": config.min_skill_improvement,
+        "promotion_passed": promotion_passed,
         "baseline_size": len(skill["body"]),
         "evolved_size": len(evolved_body),
+        "max_skill_size_used": config.max_skill_size,
         "train_examples": len(dataset.train),
         "val_examples": len(dataset.val),
         "holdout_examples": len(dataset.holdout),
         "elapsed_seconds": elapsed,
-        "constraints_passed": all_pass,
+        "constraints_passed": _all_pass(evolved_constraints),
+        "pytest_gate_ran": test_result is not None,
+        "pytest_gate_passed": None if test_result is None else test_result.passed,
+        "tblite_gate_ran": benchmark_result is not None,
+        "tblite_gate_passed": None if benchmark_result is None else benchmark_result.passed,
+        "tblite_baseline_score": None if benchmark_result is None else benchmark_result.baseline_score,
+        "tblite_evolved_score": None if benchmark_result is None else benchmark_result.evolved_score,
     }
-    (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+    output_dir = _save_candidate(skill_name, timestamp, skill["raw"], evolved_full, metrics)
 
     console.print(f"\n  Output saved to {output_dir}/")
-
-    if improvement > 0:
-        console.print(f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement/max(0.001, avg_baseline)*100:+.1f}%)[/bold green]")
+    if promotion_passed:
+        console.print(
+            "\n[bold green]✓ Phase-1 promotion gate passed: "
+            f"{relative_improvement:+.1%} relative holdout lift[/bold green]"
+        )
         console.print(f"  Review the diff: diff {output_dir}/baseline_skill.md {output_dir}/evolved_skill.md")
     else:
-        console.print(f"\n[yellow]⚠ Evolution did not improve skill (change: {improvement:+.3f})[/yellow]")
-        console.print("  Try: more iterations, better eval dataset, or different optimizer model")
+        console.print(
+            "\n[yellow]⚠ Phase-1 promotion gate did not pass "
+            f"(requires ≥{config.min_skill_improvement:.0%} relative holdout lift and all enabled gates)[/yellow]"
+        )
+        console.print("  Candidate saved for inspection but should not be promoted.")
 
 
 @click.command()
 @click.option("--skill", required=True, help="Name of the skill to evolve")
-@click.option("--iterations", default=10, help="Number of GEPA iterations")
-@click.option("--eval-source", default="synthetic", type=click.Choice(["synthetic", "golden", "sessiondb"]),
-              help="Source for evaluation dataset")
-@click.option("--dataset-path", default=None, help="Path to existing eval dataset (JSONL)")
+@click.option("--iterations", default=10, help="Number of GEPA full evals")
+@click.option(
+    "--eval-source",
+    default="synthetic",
+    type=click.Choice(["synthetic", "golden", "sessiondb"]),
+    help="Source for evaluation dataset",
+)
+@click.option("--dataset-path", default=None, help="Path to existing eval dataset (JSONL or split dir)")
 @click.option("--optimizer-model", default="openai/gpt-4.1", help="Model for GEPA reflections")
-@click.option("--eval-model", default="openai/gpt-4.1-mini", help="Model for evaluations")
+@click.option("--eval-model", default="openai/gpt-4.1-mini", help="Student model used to execute candidate skills")
+@click.option("--judge-model", default="openai/gpt-4.1", help="Model for LLM-as-judge scoring and dataset generation")
 @click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
-@click.option("--run-tests", is_flag=True, help="Run full pytest suite as constraint gate")
+@click.option("--run-tests", is_flag=True, help="Run full pytest suite as promotion gate")
+@click.option("--run-tblite", is_flag=True, help="Run configured TBLite benchmark as promotion gate")
+@click.option("--tblite-command", default=None, help="Command that prints TBLite JSON score/pass_rate")
+@click.option("--tblite-baseline-score", default=None, type=float, help="Optional precomputed baseline TBLite score")
+@click.option("--min-skill-improvement", default=0.10, type=float, help="Required relative holdout lift")
+@click.option("--allow-heuristic-fallback", is_flag=True, help="Allow lexical metric fallback if LLM judge fails")
 @click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")
-def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run):
+def main(
+    skill,
+    iterations,
+    eval_source,
+    dataset_path,
+    optimizer_model,
+    eval_model,
+    judge_model,
+    hermes_repo,
+    run_tests,
+    run_tblite,
+    tblite_command,
+    tblite_baseline_score,
+    min_skill_improvement,
+    allow_heuristic_fallback,
+    dry_run,
+):
     """Evolve a Hermes Agent skill using DSPy + GEPA optimization."""
+
     evolve(
         skill_name=skill,
         iterations=iterations,
@@ -312,8 +530,14 @@ def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_mod
         dataset_path=dataset_path,
         optimizer_model=optimizer_model,
         eval_model=eval_model,
+        judge_model=judge_model,
         hermes_repo=hermes_repo,
         run_tests=run_tests,
+        run_tblite=run_tblite,
+        tblite_command=tblite_command,
+        tblite_baseline_score=tblite_baseline_score,
+        min_skill_improvement=min_skill_improvement,
+        allow_heuristic_fallback=allow_heuristic_fallback,
         dry_run=dry_run,
     )
 

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -1,9 +1,12 @@
 """Wraps a SKILL.md file as a DSPy module for optimization.
 
-The key abstraction: a skill file becomes a parameterized DSPy module
-where the skill text is the optimizable parameter. GEPA can then
-mutate the skill text and evaluate the results.
+The key abstraction: a skill file becomes a parameterized DSPy module where the
+skill body itself is the optimizable instruction text. GEPA can then mutate the
+actual skill procedure rather than only a wrapper prompt around an immutable
+``skill_instructions`` input.
 """
+
+from __future__ import annotations
 
 import re
 from pathlib import Path
@@ -11,39 +14,66 @@ from typing import Optional
 
 import dspy
 
+_FRONTMATTER_RE = re.compile(
+    r"\A[ \t]*---[ \t]*\r?\n(?P<frontmatter>.*?)(?:\r?\n)---[ \t]*(?:\r?\n|\Z)(?P<body>.*)\Z",
+    re.DOTALL,
+)
+
+
+def split_frontmatter(raw: str) -> tuple[str, str]:
+    """Split a SKILL.md file into ``(frontmatter, body)``.
+
+    Only a leading YAML frontmatter block is recognized. Internal markdown
+    horizontal rules are left untouched.
+    """
+
+    match = _FRONTMATTER_RE.match(raw)
+    if not match:
+        return "", raw.strip()
+    return match.group("frontmatter").strip(), match.group("body").strip()
+
+
+def strip_leading_frontmatter(text: str) -> str:
+    """Return text with one leading YAML frontmatter block removed.
+
+    Optimizers occasionally emit a full ``SKILL.md`` even though the evolution
+    pipeline only asks them to mutate the body. Deployment preserves the
+    baseline metadata, so optimizer-supplied leading metadata must be stripped
+    before reassembly. Non-leading ``---`` blocks are preserved.
+    """
+
+    _, body = split_frontmatter(text)
+    return body.strip()
+
 
 def load_skill(skill_path: Path) -> dict:
     """Load a skill file and parse its frontmatter + body.
 
     Returns:
-        {
-            "path": Path,
-            "raw": str (full file content),
-            "frontmatter": str (YAML between --- markers),
-            "body": str (markdown after frontmatter),
-            "name": str,
-            "description": str,
-        }
+    {
+        "path": Path,
+        "raw": str (full file content),
+        "frontmatter": str (YAML between --- markers),
+        "body": str (markdown after frontmatter),
+        "name": str,
+        "description": str,
+    }
     """
+
     raw = skill_path.read_text()
+    frontmatter, body = split_frontmatter(raw)
 
-    # Parse YAML frontmatter
-    frontmatter = ""
-    body = raw
-    if raw.strip().startswith("---"):
-        parts = raw.split("---", 2)
-        if len(parts) >= 3:
-            frontmatter = parts[1].strip()
-            body = parts[2].strip()
-
-    # Extract name and description from frontmatter
+    # Extract name and description from frontmatter without requiring PyYAML at
+    # import time. This mirrors the current lightweight parser while making the
+    # frontmatter boundary detection robust.
     name = ""
     description = ""
     for line in frontmatter.split("\n"):
-        if line.strip().startswith("name:"):
-            name = line.split(":", 1)[1].strip().strip("'\"")
-        elif line.strip().startswith("description:"):
-            description = line.split(":", 1)[1].strip().strip("'\"")
+        stripped = line.strip()
+        if stripped.startswith("name:"):
+            name = stripped.split(":", 1)[1].strip().strip("'\"")
+        elif stripped.startswith("description:"):
+            description = stripped.split(":", 1)[1].strip().strip("'\"")
 
     return {
         "path": skill_path,
@@ -56,15 +86,13 @@ def load_skill(skill_path: Path) -> dict:
 
 
 def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
-    """Find a skill by name in the hermes-agent skills directory.
+    """Find a skill by name in the hermes-agent skills directory."""
 
-    Searches recursively for a SKILL.md in a directory matching the skill name.
-    """
     skills_dir = hermes_agent_path / "skills"
     if not skills_dir.exists():
         return None
 
-    # Direct match: skills/<category>/<skill_name>/SKILL.md
+    # Direct match: skills/<skill_name>/SKILL.md
     for skill_md in skills_dir.rglob("SKILL.md"):
         if skill_md.parent.name == skill_name:
             return skill_md
@@ -81,43 +109,116 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
     return None
 
 
-class SkillModule(dspy.Module):
-    """A DSPy module that wraps a skill file for optimization.
-
-    The skill text (body) is the parameter that GEPA optimizes.
-    On each forward pass, the module:
-    1. Uses the skill text as instructions
-    2. Processes the task input
-    3. Returns the agent's response
-    """
+def _make_skill_signature(skill_text: str) -> type[dspy.Signature]:
+    """Create a DSPy signature whose instructions are the skill body itself."""
 
     class TaskWithSkill(dspy.Signature):
-        """Complete a task following the provided skill instructions.
+        __doc__ = skill_text
 
-        You are an AI agent following specific skill instructions to complete a task.
-        Read the skill instructions carefully and follow the procedure described.
-        """
-        skill_instructions: str = dspy.InputField(desc="The skill instructions to follow")
         task_input: str = dspy.InputField(desc="The task to complete")
         output: str = dspy.OutputField(desc="Your response following the skill instructions")
 
+    return TaskWithSkill
+
+
+def _signature_instruction_text(signature: object) -> str:
+    """Return a DSPy signature's current instruction text, if available."""
+
+    if signature is None:
+        return ""
+
+    for attr in ("instructions", "__doc__"):
+        text = getattr(signature, attr, None)
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+    return ""
+
+
+def _predictor_instruction_text(predictor: object) -> str:
+    """Probe known DSPy predictor paths for optimized signature text."""
+
+    for signature in (
+        getattr(predictor, "signature", None),
+        getattr(getattr(predictor, "predict", None), "signature", None),
+    ):
+        text = _signature_instruction_text(signature)
+        if text:
+            return text
+    return ""
+
+
+class SkillModule(dspy.Module):
+    """A DSPy module that wraps a skill file for optimization.
+
+    GEPA mutates the signature instructions. Therefore the skill body must live
+    in the signature instructions, not in a normal runtime input field; otherwise
+    optimization only improves a wrapper prompt while the deployed skill remains
+    unchanged.
+    """
+
     def __init__(self, skill_text: str):
         super().__init__()
-        self.skill_text = skill_text
-        self.predictor = dspy.ChainOfThought(self.TaskWithSkill)
+        self.skill_text = skill_text.strip()
+        self.predictor = dspy.ChainOfThought(_make_skill_signature(self.skill_text))
+
+    def current_skill_text(self) -> str:
+        """Return the current optimizable skill instructions for this module."""
+
+        return _predictor_instruction_text(self.predictor) or self.skill_text
 
     def forward(self, task_input: str) -> dspy.Prediction:
-        result = self.predictor(
-            skill_instructions=self.skill_text,
-            task_input=task_input,
+        current_skill_text = self.current_skill_text()
+        result = self.predictor(task_input=task_input)
+        return dspy.Prediction(output=result.output, skill_text=current_skill_text)
+
+
+def extract_evolved_skill_text(module: dspy.Module, fallback: str = "") -> str:
+    """Extract evolved skill text from an optimized DSPy module.
+
+    DSPy stores optimized signature instructions under slightly different
+    attribute paths across versions. We probe the known paths before falling
+    back to a ``skill_text`` attribute. The returned text is body-only and safe
+    to pass to ``reassemble_skill``.
+    """
+
+    candidates: list[object] = []
+
+    predictor = getattr(module, "predictor", None)
+    if predictor is not None:
+        predictor_text = _predictor_instruction_text(predictor)
+        if predictor_text:
+            candidates.append(predictor_text)
+        candidates.extend(
+            [
+                getattr(predictor, "signature", None),
+                getattr(getattr(predictor, "predict", None), "signature", None),
+            ]
         )
-        return dspy.Prediction(output=result.output)
+
+    candidates.extend(
+        [
+            getattr(module, "signature", None),
+            getattr(module, "skill_text", None),
+            fallback,
+        ]
+    )
+
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        text = _signature_instruction_text(candidate) if not isinstance(candidate, str) else candidate
+        if isinstance(text, str) and text.strip():
+            return strip_leading_frontmatter(text)
+
+    return ""
 
 
 def reassemble_skill(frontmatter: str, evolved_body: str) -> str:
     """Reassemble a skill file from frontmatter and evolved body.
 
-    Preserves the original YAML frontmatter (name, description, metadata)
-    and replaces only the body with the evolved version.
+    Preserves the original YAML frontmatter (name, description, metadata) and
+    replaces only the body with the evolved version.
     """
-    return f"---\n{frontmatter}\n---\n\n{evolved_body}\n"
+
+    body = strip_leading_frontmatter(evolved_body)
+    return f"---\n{frontmatter.strip()}\n---\n\n{body}\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ keywords = ["llm", "optimization", "evolution", "dspy", "gepa", "hermes", "agent
 
 dependencies = [
     "dspy>=3.0.0",
+    "optuna>=3.0",
     "openai>=1.0.0",
     "pyyaml>=6.0",
     "click>=8.0",

--- a/tests/core/test_benchmark_gate.py
+++ b/tests/core/test_benchmark_gate.py
@@ -1,0 +1,32 @@
+"""Tests for benchmark gate fail-closed behavior and score comparison."""
+
+from evolution.core.benchmark_gate import BenchmarkGate
+from evolution.core.config import EvolutionConfig
+
+
+def test_tblite_gate_fails_closed_without_baseline(tmp_path):
+    config = EvolutionConfig(run_tblite=True, tblite_command="echo {}")
+
+    result = BenchmarkGate(config).run_tblite_comparison(tmp_path)
+
+    assert not result.passed
+    assert "baseline score" in result.message
+
+
+def test_tblite_compare_allows_configured_regression_threshold():
+    config = EvolutionConfig(tblite_regression_threshold=0.02)
+
+    result = BenchmarkGate(config).compare_tblite_scores(0.90, 0.885)
+
+    assert result.passed
+    assert result.baseline_score == 0.90
+    assert result.evolved_score == 0.885
+
+
+def test_tblite_compare_rejects_regression_beyond_threshold():
+    config = EvolutionConfig(tblite_regression_threshold=0.02)
+
+    result = BenchmarkGate(config).compare_tblite_scores(0.90, 0.87)
+
+    assert not result.passed
+    assert "regressed" in result.message

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,52 @@
+"""Tests for evolution config environment handling."""
+
+from pathlib import Path
+
+import pytest
+
+from evolution.core.config import (
+    EvolutionConfig,
+    _default_lm_max_tokens,
+    _default_tblite_baseline_score,
+    resolve_hermes_agent_path,
+)
+
+
+def test_evolution_config_can_construct_without_repo(monkeypatch):
+    monkeypatch.delenv("HERMES_AGENT_REPO", raising=False)
+
+    config = EvolutionConfig()
+
+    assert config.hermes_agent_path is None or isinstance(config.hermes_agent_path, Path)
+
+
+def test_resolve_prefers_explicit_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_AGENT_REPO", str(tmp_path / "env-repo"))
+    explicit = tmp_path / "explicit-repo"
+
+    assert resolve_hermes_agent_path(str(explicit)) == explicit
+
+
+def test_api_base_reads_openrouter_env(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+
+    assert EvolutionConfig().api_base == "https://openrouter.ai/api/v1"
+
+
+def test_lm_max_tokens_validation(monkeypatch):
+    monkeypatch.setenv("HERMES_EVOLUTION_MAX_TOKENS", "4096")
+    assert _default_lm_max_tokens() == 4096
+
+    monkeypatch.setenv("HERMES_EVOLUTION_MAX_TOKENS", "nope")
+    with pytest.raises(ValueError):
+        _default_lm_max_tokens()
+
+
+def test_tblite_baseline_score_reads_env(monkeypatch):
+    monkeypatch.setenv("HERMES_TBLITE_BASELINE_SCORE", "0.91")
+
+    assert _default_tblite_baseline_score() == pytest.approx(0.91)
+
+    monkeypatch.setenv("HERMES_TBLITE_BASELINE_SCORE", "not-a-number")
+    with pytest.raises(ValueError):
+        _default_tblite_baseline_score()

--- a/tests/core/test_constraints.py
+++ b/tests/core/test_constraints.py
@@ -1,98 +1,28 @@
-"""Tests for constraint validators."""
+"""Tests for strict skill constraint validation."""
 
-import pytest
-from evolution.core.constraints import ConstraintValidator
 from evolution.core.config import EvolutionConfig
+from evolution.core.constraints import ConstraintValidator
 
 
-@pytest.fixture
-def validator():
-    config = EvolutionConfig()
-    return ConstraintValidator(config)
+def test_skill_structure_rejects_body_only_text():
+    result = ConstraintValidator(EvolutionConfig())._check_skill_structure("# Body only")
+
+    assert not result.passed
+    assert "frontmatter" in result.message
 
 
-class TestSizeConstraints:
-    def test_skill_under_limit(self, validator):
-        result = validator._check_size("x" * 1000, "skill")
-        assert result.passed
+def test_skill_structure_rejects_unclosed_frontmatter():
+    text = "---\nname: x\ndescription: y\n# Body accidentally inside yaml"
 
-    def test_skill_over_limit(self, validator):
-        result = validator._check_size("x" * 20_000, "skill")
-        assert not result.passed
-        assert "exceeded" in result.message
+    result = ConstraintValidator(EvolutionConfig())._check_skill_structure(text)
 
-    def test_tool_description_under_limit(self, validator):
-        result = validator._check_size("Search files by content", "tool_description")
-        assert result.passed
-
-    def test_tool_description_over_limit(self, validator):
-        result = validator._check_size("x" * 600, "tool_description")
-        assert not result.passed
+    assert not result.passed
+    assert "closed YAML frontmatter" in result.message
 
 
-class TestGrowthConstraints:
-    def test_acceptable_growth(self, validator):
-        baseline = "x" * 1000
-        evolved = "x" * 1100  # 10% growth
-        result = validator._check_growth(evolved, baseline, "skill")
-        assert result.passed
+def test_skill_structure_accepts_full_skill_file():
+    text = "---\nname: x\ndescription: y\n---\n\n# Body"
 
-    def test_excessive_growth(self, validator):
-        baseline = "x" * 1000
-        evolved = "x" * 1300  # 30% growth
-        result = validator._check_growth(evolved, baseline, "skill")
-        assert not result.passed
+    result = ConstraintValidator(EvolutionConfig())._check_skill_structure(text)
 
-    def test_shrinkage_is_ok(self, validator):
-        baseline = "x" * 1000
-        evolved = "x" * 800  # 20% smaller
-        result = validator._check_growth(evolved, baseline, "skill")
-        assert result.passed
-
-
-class TestNonEmpty:
-    def test_non_empty_passes(self, validator):
-        result = validator._check_non_empty("some content")
-        assert result.passed
-
-    def test_empty_fails(self, validator):
-        result = validator._check_non_empty("")
-        assert not result.passed
-
-    def test_whitespace_only_fails(self, validator):
-        result = validator._check_non_empty("   \n  ")
-        assert not result.passed
-
-
-class TestSkillStructure:
-    def test_valid_skill(self, validator):
-        skill = "---\nname: test-skill\ndescription: A test skill\n---\n\n# Test\nContent here"
-        result = validator._check_skill_structure(skill)
-        assert result.passed
-
-    def test_missing_frontmatter(self, validator):
-        skill = "# Test\nContent without frontmatter"
-        result = validator._check_skill_structure(skill)
-        assert not result.passed
-
-    def test_missing_name(self, validator):
-        skill = "---\ndescription: A test skill\n---\n\n# Test"
-        result = validator._check_skill_structure(skill)
-        assert not result.passed
-
-    def test_missing_description(self, validator):
-        skill = "---\nname: test-skill\n---\n\n# Test"
-        result = validator._check_skill_structure(skill)
-        assert not result.passed
-
-
-class TestValidateAll:
-    def test_valid_skill_passes_all(self, validator):
-        skill = "---\nname: test\ndescription: Test skill\n---\n\n# Procedure\n1. Do thing"
-        results = validator.validate_all(skill, "skill")
-        assert all(r.passed for r in results)
-
-    def test_empty_skill_fails(self, validator):
-        results = validator.validate_all("", "skill")
-        failed = [r for r in results if not r.passed]
-        assert len(failed) > 0
+    assert result.passed

--- a/tests/core/test_fitness.py
+++ b/tests/core/test_fitness.py
@@ -1,0 +1,117 @@
+"""Tests for fitness parsing, fallback scoring, and candidate-skill metric behavior."""
+
+import pytest
+
+from evolution.core.config import EvolutionConfig
+from evolution.core import fitness
+from evolution.core.fitness import FitnessScore, _parse_score, make_skill_fitness_metric, skill_fitness_metric
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (0.25, 0.25),
+        ("0.75", 0.75),
+        ("80%", 0.8),
+        ("score: 0.6/1", 0.6),
+        ("not parseable", 0.5),
+        ("150%", 1.0),
+    ],
+)
+def test_parse_score(value, expected):
+    assert _parse_score(value) == pytest.approx(expected)
+
+
+def test_composite_clamps_after_penalty():
+    score = FitnessScore(correctness=1, procedure_following=1, conciseness=1, length_penalty=2)
+
+    assert score.composite == 0.0
+
+
+def test_legacy_metric_is_keyword_based_fallback_only():
+    class Example:
+        expected_behavior = "must identify sql injection and recommend parameterized queries"
+
+    class Prediction:
+        output = "This identifies SQL injection and recommends parameterized queries."
+
+    assert skill_fitness_metric(Example(), Prediction()) > 0.7
+
+
+def test_metric_uses_candidate_skill_text_from_prediction(monkeypatch):
+    seen = {}
+
+    class FakeJudge:
+        def __init__(self, config):
+            pass
+
+        def score(self, **kwargs):
+            seen.update(kwargs)
+            return FitnessScore(correctness=1, procedure_following=1, conciseness=1)
+
+    monkeypatch.setattr(fitness, "LLMJudge", FakeJudge)
+    metric = make_skill_fitness_metric(EvolutionConfig(), fallback_skill_text="# Baseline")
+
+    class Example:
+        task_input = "task"
+        expected_behavior = "expected"
+
+    class Prediction:
+        output = "answer"
+        skill_text = "# Candidate"
+
+    assert metric(Example(), Prediction()) == 1.0
+    assert seen["skill_text"] == "# Candidate"
+
+
+def test_gepa_metric_returns_score_and_feedback_prediction(monkeypatch):
+    class FakeJudge:
+        def __init__(self, config):
+            pass
+
+        def score(self, **kwargs):
+            return FitnessScore(
+                correctness=0.8,
+                procedure_following=0.7,
+                conciseness=0.9,
+                feedback="Tighten the procedure."
+            )
+
+    monkeypatch.setattr(fitness, "LLMJudge", FakeJudge)
+    metric = make_skill_fitness_metric(
+        EvolutionConfig(), fallback_skill_text="# Baseline", return_feedback=True
+    )
+
+    class Example:
+        task_input = "task"
+        expected_behavior = "expected"
+
+    class Prediction:
+        output = "answer"
+        skill_text = "# Candidate"
+
+    result = metric(Example(), Prediction(), trace=[], pred_name="predictor", pred_trace=[])
+
+    assert result.score == pytest.approx(0.79)
+    assert result.feedback == "Tighten the procedure."
+
+
+def test_scalar_metric_accepts_gepa_extra_arguments(monkeypatch):
+    class FakeJudge:
+        def __init__(self, config):
+            pass
+
+        def score(self, **kwargs):
+            return FitnessScore(correctness=1, procedure_following=1, conciseness=1)
+
+    monkeypatch.setattr(fitness, "LLMJudge", FakeJudge)
+    metric = make_skill_fitness_metric(EvolutionConfig(), fallback_skill_text="# Baseline")
+
+    class Example:
+        task_input = "task"
+        expected_behavior = "expected"
+
+    class Prediction:
+        output = "answer"
+
+    assert metric(Example(), Prediction(), trace=[], pred_name="p", pred_trace=[]) == 1.0

--- a/tests/skills/test_skill_module.py
+++ b/tests/skills/test_skill_module.py
@@ -1,17 +1,23 @@
-"""Tests for skill module loading and parsing."""
+"""Tests for skill module loading, parsing, and evolved text extraction."""
 
-import pytest
 from pathlib import Path
-from evolution.skills.skill_module import load_skill, reassemble_skill
 
+from evolution.skills.skill_module import (
+    SkillModule,
+    extract_evolved_skill_text,
+    load_skill,
+    reassemble_skill,
+    split_frontmatter,
+    strip_leading_frontmatter,
+)
 
 SAMPLE_SKILL = """---
 name: test-skill
 description: A skill for testing things
 version: 1.0.0
 metadata:
-  hermes:
-    tags: [testing]
+  hermes: true
+  tags: [testing]
 ---
 
 # Test Skill — Testing Things
@@ -30,63 +36,153 @@ Use this when you need to test things.
 
 
 class TestLoadSkill:
-    def test_parses_frontmatter(self, tmp_path):
+    def test_parses_frontmatter(self, tmp_path: Path):
         skill_file = tmp_path / "SKILL.md"
         skill_file.write_text(SAMPLE_SKILL)
+
         skill = load_skill(skill_file)
 
         assert skill["name"] == "test-skill"
         assert skill["description"] == "A skill for testing things"
         assert "version: 1.0.0" in skill["frontmatter"]
 
-    def test_parses_body(self, tmp_path):
+    def test_parses_body(self, tmp_path: Path):
         skill_file = tmp_path / "SKILL.md"
         skill_file.write_text(SAMPLE_SKILL)
+
         skill = load_skill(skill_file)
 
         assert "# Test Skill" in skill["body"]
         assert "## Procedure" in skill["body"]
         assert "Don't forget" in skill["body"]
 
-    def test_raw_contains_everything(self, tmp_path):
+    def test_raw_contains_everything(self, tmp_path: Path):
         skill_file = tmp_path / "SKILL.md"
         skill_file.write_text(SAMPLE_SKILL)
+
         skill = load_skill(skill_file)
 
         assert skill["raw"] == SAMPLE_SKILL
 
-    def test_path_is_stored(self, tmp_path):
+    def test_path_is_stored(self, tmp_path: Path):
         skill_file = tmp_path / "SKILL.md"
         skill_file.write_text(SAMPLE_SKILL)
+
         skill = load_skill(skill_file)
 
         assert skill["path"] == skill_file
 
 
+class TestFrontmatterHandling:
+    def test_split_frontmatter_preserves_internal_horizontal_rules(self):
+        raw = """---
+name: x
+description: y
+---
+
+# Body
+
+---
+
+Not frontmatter.
+"""
+
+        frontmatter, body = split_frontmatter(raw)
+
+        assert "name: x" in frontmatter
+        assert "---\n\nNot frontmatter." in body
+
+    def test_strip_leading_frontmatter_is_noop_for_plain_body(self):
+        body = "# Body\n\nNo frontmatter here."
+
+        assert strip_leading_frontmatter(body) == body
+
+    def test_strip_leading_frontmatter_handles_crlf(self):
+        text = "---\r\nname: emitted\r\ndescription: emitted\r\n---\r\n\r\n# Body\r\nStep."
+
+        assert strip_leading_frontmatter(text) == "# Body\r\nStep."
+
+
 class TestReassembleSkill:
-    def test_roundtrip(self, tmp_path):
+    def test_roundtrip(self, tmp_path: Path):
         skill_file = tmp_path / "SKILL.md"
         skill_file.write_text(SAMPLE_SKILL)
         skill = load_skill(skill_file)
 
         reassembled = reassemble_skill(skill["frontmatter"], skill["body"])
-        assert "---" in reassembled
+
+        assert reassembled.startswith("---\n")
         assert "name: test-skill" in reassembled
         assert "# Test Skill" in reassembled
 
     def test_preserves_frontmatter(self):
         frontmatter = "name: my-skill\ndescription: Does stuff"
         body = "# My Skill\nDo the thing."
+
         result = reassemble_skill(frontmatter, body)
 
         assert result.startswith("---\n")
         assert "name: my-skill" in result
         assert "# My Skill" in result
 
-    def test_evolved_body_replaces_original(self):
-        frontmatter = "name: my-skill\ndescription: Does stuff"
-        evolved_body = "# EVOLVED\nNew and improved procedure."
+    def test_reassemble_strips_optimizer_emitted_frontmatter(self):
+        frontmatter = "name: baseline-skill\ndescription: Baseline metadata"
+        evolved_body = """---
+name: optimizer-skill
+description: Optimizer hallucinated metadata
+---
+
+# Evolved Body
+Use the better procedure.
+"""
+
         result = reassemble_skill(frontmatter, evolved_body)
 
-        assert "EVOLVED" in result
-        assert "New and improved" in result
+        assert result == (
+            "---\n"
+            "name: baseline-skill\n"
+            "description: Baseline metadata\n"
+            "---\n\n"
+            "# Evolved Body\n"
+            "Use the better procedure.\n"
+        )
+        assert "optimizer-skill" not in result
+
+
+class TestSkillModule:
+    def test_forward_attaches_current_skill_text_to_prediction(self):
+        module = SkillModule("# Baseline\nFollow the procedure.")
+
+        prediction = module(task_input="Do it")
+
+        assert prediction.skill_text == "# Baseline\nFollow the procedure."
+
+
+class TestExtractEvolvedSkillText:
+    def test_extracts_nested_dspy_signature_instructions(self):
+        class Signature:
+            instructions = "# Evolved\n\nDo the better process."
+
+        class Predict:
+            signature = Signature()
+
+        class Predictor:
+            predict = Predict()
+
+        class Module:
+            predictor = Predictor()
+            skill_text = "# Baseline"
+
+        assert extract_evolved_skill_text(Module(), fallback="# Fallback") == "# Evolved\n\nDo the better process."
+
+    def test_extract_strips_optimizer_frontmatter(self):
+        class Signature:
+            instructions = "---\nname: x\ndescription: y\n---\n\n# Body"
+
+        class Predictor:
+            signature = Signature()
+
+        class Module:
+            predictor = Predictor()
+
+        assert extract_evolved_skill_text(Module()) == "# Body"


### PR DESCRIPTION
## Why

Phase 1 is supposed to prove that skill evolution can produce a real, measurable skill improvement before later phases. Today the implementation can run but still fails key Phase 1 correctness requirements: evolved skills may never deploy, GEPA can optimize the wrapper instead of the actual skill body, the fitness signal can be lexical rather than semantic, pytest/TBLite gates are not reliably wired, and DSPy 3.x GEPA parameters can force an unintended fallback.

This PR turns Phase 1 from a demo path into a promotion-gated path.

## Summary

### 1. GEPA mutates the actual skill body
- `SkillModule` places the SKILL.md body in the DSPy signature instructions.
- `SkillModule.forward()` attaches the candidate's current skill text to the prediction so the judge evaluates each candidate against its own evolved instructions.
- Extraction helpers probe DSPy signature instruction paths across versions.

### 2. Full SKILL.md validation and safe reassembly
- Baseline validation uses the full raw skill file; evolved validation uses the reassembled full file including preserved YAML frontmatter.
- Reassembly strips optimizer-emitted leading frontmatter to prevent nested YAML blocks; frontmatter parsing recognizes only a leading block and preserves internal markdown `---` rules.

### 3. LLM-as-judge is the default optimization metric
- `make_skill_fitness_metric()` backed by `LLMJudge`, returning GEPA-compatible score + feedback when GEPA is running.
- Legacy keyword-overlap metric kept only as an explicit, opt-in fallback (`--allow-heuristic-fallback`); judge failures fail closed by default.

### 4. Promotion gate matches Phase 1
- Requires train/val/holdout splits before optimization.
- Promotion requires evolved > baseline and >= `min_skill_improvement` (default 0.10) relative holdout lift.
- Existing large baseline skills are not rejected solely for size; per-run size limit is raised to baseline + allowed growth while growth stays constrained.
- Metrics persist baseline/evolved scores, absolute/relative improvement, gate status, and benchmark/test status.

### 5. Test and benchmark gates are wired
- `--run-tests` temporarily writes the evolved skill, runs the repo test suite through the existing validator, then restores the original file.
- Fail-closed TBLite gate module; CLI flags `--judge-model`, `--run-tblite`, `--tblite-command`, `--tblite-baseline-score`.

### 6. DSPy/provider compatibility
- GEPA uses DSPy 3.x parameters `max_full_evals` + `reflection_lm`; MIPROv2 fallback is visible and explicit.
- Shared `make_lm()` helper so optimizer/student/judge/dataset generation respect the same OpenAI-compatible `api_base` and token cap.
- Added `optuna>=3.0` for the MIPROv2 fallback.
- MIPROv2 fallback runs with `requires_permission_to_run=False` so the documented fallback cannot hang / raise `EOFError` in an unattended run.

## Validation

Static + unit (DSPy stubbed in the constrained env):

```
python -m py_compile $(find evolution -name '*.py')   # clean
pytest -q tests/skills/test_skill_module.py tests/core/test_config.py \
          tests/core/test_fitness.py tests/core/test_benchmark_gate.py \
          tests/core/test_constraints.py                # 35 passed
```

Cross-module review against current `main`:
- Branches off the latest config fix (#122) and preserves its `--hermes-repo` / non-fatal `EvolutionConfig()` behavior.
- Preserves all imported exports (`EvolutionConfig`, `get_hermes_agent_path`, `resolve_hermes_agent_path`, `EvalExample`, `EvalDataset`), so the untouched `external_importers.py` and the pre-existing `test_config_repo_path.py` / `test_external_importers.py` remain satisfied.

Before merge, run the full suite + one real golden-dataset evolution in a live env:

```
pip install -e '.[dev]'
pytest -q
python -m evolution.skills.evolve_skill --skill <skill-name> --eval-source golden \
  --dataset-path datasets/skills/<skill-name> --iterations 5 --run-tests
```

## Issues addressed
- Body-only validation rejects valid evolved skills.
- Reassembly can create nested frontmatter.
- GEPA can optimize wrapper instructions instead of the actual skill body.
- Keyword-overlap fitness can fake quality improvements.
- `--run-tests` was effectively not part of promotion.
- TBLite benchmark gate fields existed but were not wired into promotion.
- DSPy 3.x GEPA no longer accepts `max_steps` and requires `reflection_lm`.
- MIPROv2 fallback requires `optuna` and must run non-interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Related issues

This overlaps several open reports: #119 (evolved skill never deploys), #38 / #141 (GEPA optimizing the wrapper instead of the skill body), and the validator false-positive family #74 / #93 / #110. Not tagging them as `Fixes` — each covers details I haven't re-verified one-by-one against this branch — but reviewing this PR alongside those issues should be useful.
