### PR TITLE
feat(constraints): class-aware, graduated skill-size cap

### DIFF
--- a/evolution/core/config.py
+++ b/evolution/core/config.py
@@ -25,11 +25,22 @@ class EvolutionConfig:
     eval_model: str = "openai/gpt-4.1-mini"  # Model for LLM-as-judge scoring
     judge_model: str = "openai/gpt-4.1"  # Model for dataset generation
 
-    # Constraints
-    max_skill_size: int = 15_000  # 15KB default
+    # Constraints — size is class-aware (see resolve_skill_soft_cap) and graduated.
+    # Rationale: a single flat cap over-penalizes persistent reference/runbook
+    # skills (which legitimately encode many endpoints, parameters and pitfalls,
+    # and are meant to survive context compression) purely for size; and the old
+    # penalty ramp (which started at 90% of the cap) even docked skills that were
+    # already *under* the cap. New policy:
+    #   - soft target: no length penalty at/below it (class-aware)
+    #   - hard ceiling: rejection above it (bounds genuine bloat)
+    #   - graduated penalty linearly between soft and ceiling (no pre-cap cliff)
+    max_skill_size: int = 15_000  # soft target for default (generative/prompt) skills
+    max_skill_size_reference: int = 22_000  # soft target for persistent reference/runbook skills
+    max_skill_hard_ceiling: int = 30_000  # absolute rejection ceiling for any skill
     max_tool_desc_size: int = 500  # chars
     max_param_desc_size: int = 200  # chars
-    max_prompt_growth: float = 0.2  # 20% max growth over baseline
+    max_prompt_growth: float = 0.2  # 20% max growth over baseline (per-mutation, default skills)
+    max_prompt_growth_reference: float = 0.6  # reference skills may restructure more aggressively
 
     # Eval dataset
     eval_dataset_size: int = 20  # Total examples to generate
@@ -45,6 +56,47 @@ class EvolutionConfig:
     # Output
     output_dir: Path = field(default_factory=lambda: Path("./output"))
     create_pr: bool = True
+
+
+# --- Class-aware size policy ----------------------------------------------
+
+# Signals (in frontmatter/body) that a skill is a persistent reference/runbook
+# rather than a generative/prompt skill. Such skills legitimately encode many
+# endpoints, parameters, and pitfalls and are meant to "survive compression",
+# so they get a larger soft target before any length penalty applies.
+_REFERENCE_TAGS = ("reference", "runbook", "workflow", "persistent", "operations", "pipeline")
+_REFERENCE_PHRASES = ("survives context compression", "persistent", "master reference", "every api endpoint")
+
+
+def is_reference_skill(skill_text: str) -> bool:
+    """Heuristically classify a skill as a persistent reference/runbook.
+
+    Looks at the frontmatter tags and the description/opening for the documented
+    markers of a reference skill. Conservative: defaults to False (the tighter
+    default cap) when no clear signal is present.
+    """
+    if not skill_text:
+        return False
+    head = skill_text[:1500].lower()
+    if any(tag in head for tag in _REFERENCE_TAGS):
+        return True
+    if any(phrase in head for phrase in _REFERENCE_PHRASES):
+        return True
+    return False
+
+
+def resolve_skill_soft_cap(skill_text: str, config: "EvolutionConfig") -> int:
+    """Return the no-penalty soft size target for this skill's class."""
+    return config.max_skill_size_reference if is_reference_skill(skill_text) else config.max_skill_size
+
+
+def length_penalty_for(size: int, soft_cap: int, hard_ceiling: int, max_penalty: float = 0.3) -> float:
+    """Graduated length penalty: 0 at/below soft_cap, ramping linearly to
+    max_penalty at hard_ceiling, then clamped. No penalty before the cap."""
+    if size <= soft_cap or hard_ceiling <= soft_cap:
+        return 0.0
+    over = (size - soft_cap) / (hard_ceiling - soft_cap)
+    return min(max_penalty, max(0.0, over) * max_penalty)
 
 
 def _discover_hermes_agent_path() -> Optional[Path]:

--- a/evolution/core/constraints.py
+++ b/evolution/core/constraints.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from dataclasses import dataclass
 from typing import Optional
 
-from evolution.core.config import EvolutionConfig
+from evolution.core.config import EvolutionConfig, resolve_skill_soft_cap
 
 
 @dataclass
@@ -95,7 +95,27 @@ class ConstraintValidator:
     def _check_size(self, text: str, artifact_type: str) -> ConstraintResult:
         size = len(text)
         if artifact_type == "skill":
-            limit = self.config.max_skill_size
+            # Class-aware: soft target is informational (graduated length penalty
+            # applies above it); only the hard ceiling is a hard rejection.
+            soft = resolve_skill_soft_cap(text, self.config)
+            hard = self.config.max_skill_hard_ceiling
+            if size > hard:
+                return ConstraintResult(
+                    passed=False,
+                    constraint_name="size_limit",
+                    message=f"Size exceeds hard ceiling: {size}/{hard} chars ({size - hard} over) — slim required",
+                )
+            if size <= soft:
+                return ConstraintResult(
+                    passed=True,
+                    constraint_name="size_limit",
+                    message=f"Size OK: {size}/{soft} (soft target)",
+                )
+            return ConstraintResult(
+                passed=True,
+                constraint_name="size_limit",
+                message=f"Over soft target — graduated penalty applies: {size} chars (soft {soft}, ceiling {hard})",
+            )
         elif artifact_type == "tool_description":
             limit = self.config.max_tool_desc_size
         elif artifact_type == "param_description":

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -8,7 +8,7 @@ import dspy
 from dataclasses import dataclass
 from typing import Optional
 
-from evolution.core.config import EvolutionConfig
+from evolution.core.config import EvolutionConfig, length_penalty_for
 
 
 @dataclass
@@ -87,13 +87,14 @@ class LLMJudge:
         procedure_following = _parse_score(result.procedure_following)
         conciseness = _parse_score(result.conciseness)
 
-        # Length penalty
+        # Length penalty — graduated: 0 at/below the soft cap (max_size), ramping
+        # linearly to 0.3 at the hard ceiling. No pre-cap cliff (the old ramp
+        # started at 90% and docked skills that were still under the cap).
         length_penalty = 0.0
         if artifact_size is not None and max_size is not None:
-            ratio = artifact_size / max_size
-            if ratio > 0.9:
-                # Penalty ramps from 0 at 90% to 0.3 at 100%+
-                length_penalty = min(0.3, (ratio - 0.9) * 3.0)
+            length_penalty = length_penalty_for(
+                artifact_size, max_size, self.config.max_skill_hard_ceiling
+            )
 
         return FitnessScore(
             correctness=correctness,

--- a/tests/core/test_constraints.py
+++ b/tests/core/test_constraints.py
@@ -2,7 +2,12 @@
 
 import pytest
 from evolution.core.constraints import ConstraintValidator
-from evolution.core.config import EvolutionConfig
+from evolution.core.config import (
+    EvolutionConfig,
+    is_reference_skill,
+    resolve_skill_soft_cap,
+    length_penalty_for,
+)
 
 
 @pytest.fixture
@@ -16,10 +21,44 @@ class TestSizeConstraints:
         result = validator._check_size("x" * 1000, "skill")
         assert result.passed
 
-    def test_skill_over_limit(self, validator):
+    def test_skill_over_soft_target_passes_with_penalty(self, validator):
+        # 20k > default soft target (15k) but < hard ceiling (30k): the class-aware
+        # policy treats this as a graduated-penalty pass, not a hard rejection.
         result = validator._check_size("x" * 20_000, "skill")
+        assert result.passed
+        assert "soft target" in result.message
+
+    def test_skill_over_hard_ceiling_fails(self, validator):
+        result = validator._check_size("x" * 35_000, "skill")
         assert not result.passed
-        assert "exceeded" in result.message
+        assert "ceiling" in result.message
+
+
+class TestClassAwareSizePolicy:
+    def test_reference_skill_detection(self):
+        ref = "---\ntags: [workflow]\ndescription: persistent master reference, survives context compression\n---\nbody"
+        gen = "---\nname: writer\ndescription: write a blog post on a topic\n---\nbody"
+        assert is_reference_skill(ref)
+        assert not is_reference_skill(gen)
+
+    def test_reference_skill_gets_larger_soft_cap(self):
+        cfg = EvolutionConfig()
+        ref = "tags: [runbook] survives context compression"
+        gen = "write a marketing post"
+        assert resolve_skill_soft_cap(ref, cfg) == cfg.max_skill_size_reference
+        assert resolve_skill_soft_cap(gen, cfg) == cfg.max_skill_size
+
+    def test_graduated_penalty_no_cliff_below_cap(self):
+        cfg = EvolutionConfig()
+        soft, hard = cfg.max_skill_size, cfg.max_skill_hard_ceiling
+        # No penalty at/below the soft cap (old ramp wrongly docked 90-100%).
+        assert length_penalty_for(soft, soft, hard) == 0.0
+        assert length_penalty_for(int(soft * 0.95), soft, hard) == 0.0
+        # Ramps up between soft and ceiling, clamped at 0.3 beyond.
+        mid = length_penalty_for((soft + hard) // 2, soft, hard)
+        assert 0.0 < mid < 0.3
+        assert length_penalty_for(hard, soft, hard) == pytest.approx(0.3)
+        assert length_penalty_for(hard * 2, soft, hard) == 0.3
 
     def test_tool_description_under_limit(self, validator):
         result = validator._check_size("Search files by content", "tool_description")


### PR DESCRIPTION
## Problem
The skill-size constraint uses a single flat cap (`max_skill_size = 15_000`) and a length penalty that ramps from 0 at 90% of the cap to 0.3 at/above it. Two issues:

1. **One flat cap for all skill types.** Persistent reference/runbook skills legitimately encode many endpoints, parameters and pitfalls (and are meant to survive context compression), so they get penalized purely for size even when their task guidance is already optimal.
2. **The ramp starts at 90% of the cap**, so a skill that is *under* the cap (e.g. ~14.4KB against a 15KB cap) still receives a non-trivial penalty (~0.18).

## Change
A class-aware, graduated policy (defaults backward-compatible for normal skills):

- **Soft target** (no penalty at/below): `15_000` default, `22_000` for reference/runbook skills, detected via `is_reference_skill()` from frontmatter signals (tags like `reference`/`runbook`/`workflow`/`persistent`, or phrases like "survives context compression").
- **Hard ceiling** `30_000`: rejection above it (still bounds genuine bloat).
- **Graduated penalty**: linear 0 → 0.3 between soft target and hard ceiling, with **no penalty below the soft target** (removes the sub-cap cliff).

New helpers in `config.py`: `is_reference_skill`, `resolve_skill_soft_cap`, `length_penalty_for`. `constraints._check_size` now fails only above the hard ceiling (soft-target overage is an informational pass; the graduated penalty in `fitness.py` handles the gradient).

## Compatibility
- Default soft target stays `15_000` for non-reference skills.
- A normal skill previously *under* the cap now incurs **less or no** penalty (the 90% cliff is gone).
- Skills between the old cap and the new hard ceiling no longer hard-fail the size constraint but do accrue a graduated penalty.

## Tests
`tests/core/test_constraints.py` updated + extended (class detection, class-aware caps, graduated-penalty boundaries). Full suite: **149 passed**.
