### PR TITLE
feat: emit a pull request for an evolved skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ python -m evolution.skills.evolve_skill \
     --eval-source sessiondb
 ```
 
+When a run produces a skill that beats the baseline and passes every constraint,
+it prepares a pull request against your hermes-agent repo: it writes the evolved
+skill in place, creates an `evolve/<skill>-<timestamp>` branch, and commits just
+that one file with a summary of the before/after scores. The branch is local by
+default so you can review the diff first. Add `--open-pr` to also push and open
+the PR with `gh`, or `--no-pr` to skip this step.
+
+```bash
+python -m evolution.skills.evolve_skill --skill github-code-review --open-pr
+```
+
 ## What It Optimizes
 
 | Phase | Target | Engine | Status |

--- a/evolution/core/pr.py
+++ b/evolution/core/pr.py
@@ -1,0 +1,288 @@
+"""Turn a validated, improved skill into a reviewable pull request.
+
+This is the last step of the pipeline that the README advertises
+("Best variant -> PR against hermes-agent") and that PLAN.md specifies
+("All commands output a PR branch + summary against hermes-agent. Human
+merges."), but which was never actually implemented: the only trace of it
+in the codebase was the ``create_pr`` config flag and a dry-run print.
+
+Until now ``evolve_skill`` stopped after writing ``output/<skill>/.../evolved_skill.md``,
+so a successful run left the operator to hand-copy the file into the
+hermes-agent repo and stitch together the git/gh commands themselves.
+
+Design notes
+------------
+* Safe by default. Preparing a pull request means writing the evolved skill
+  into the hermes-agent working tree, creating a fresh branch, and committing
+  *only that one file*. Pushing and opening the PR over the network is opt-in
+  (``open_remote=True``); the default produces a local branch plus the exact
+  commands to finish by hand. This mirrors the PLAN.md contract of emitting "a
+  PR branch + summary" that a human reviews.
+* Never destructive. We only ever ``git add`` the single skill file, never
+  ``git add -A``, so an unrelated dirty working tree is left untouched. We
+  create a new branch rather than committing onto the current one, and we
+  never force-push.
+* Never fatal. A missing git repo, a missing ``gh`` binary, or a failed push
+  degrades to a clear message plus copy-pasteable follow-up commands instead
+  of raising. A best-effort convenience must not sink a run that already
+  produced a good skill.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+from evolution.core.constraints import ConstraintResult
+
+
+# A runner is anything that behaves like subprocess.run with
+# capture_output=True, text=True. Injectable so tests need no network.
+Runner = Callable[[Sequence[str], Path], "subprocess.CompletedProcess"]
+
+
+def _subprocess_run(cmd: Sequence[str], cwd: Path) -> "subprocess.CompletedProcess":
+    return subprocess.run(list(cmd), cwd=str(cwd), capture_output=True, text=True)
+
+
+@dataclass
+class PREmissionResult:
+    """Outcome of preparing (and optionally opening) a pull request."""
+
+    prepared: bool                       # local branch + commit created
+    branch: str
+    base: str
+    skill_rel_path: str
+    commit_sha: Optional[str] = None
+    pushed: bool = False
+    pr_url: Optional[str] = None
+    follow_up_commands: list[str] = field(default_factory=list)
+    messages: list[str] = field(default_factory=list)
+
+
+def slugify(name: str) -> str:
+    """Reduce a skill name to a branch-safe slug."""
+    safe = "".join(c if (c.isalnum() or c in "-_") else "-" for c in name.lower())
+    while "--" in safe:
+        safe = safe.replace("--", "-")
+    return safe.strip("-") or "skill"
+
+
+def build_branch_name(skill_name: str, timestamp: str) -> str:
+    return f"evolve/{slugify(skill_name)}-{timestamp}"
+
+
+def build_pr_title(skill_name: str, improvement: float) -> str:
+    return f"evolve: {skill_name} skill (holdout {improvement:+.3f})"
+
+
+def _pct(delta: float, baseline: float) -> str:
+    if baseline <= 0:
+        return "n/a"
+    return f"{delta / baseline * 100:+.1f}%"
+
+
+def build_pr_body(
+    skill_name: str,
+    metrics: dict,
+    skill_rel_path: str,
+    evolved_full: str,
+    constraint_results: Optional[Sequence[ConstraintResult]] = None,
+) -> str:
+    """Render a deterministic, human-readable PR body from a run's metrics.
+
+    Deterministic so the same run always produces the same description, which
+    keeps the output reviewable and easy to diff.
+    """
+    baseline = float(metrics.get("baseline_score", 0.0))
+    evolved = float(metrics.get("evolved_score", 0.0))
+    improvement = float(metrics.get("improvement", evolved - baseline))
+    base_size = int(metrics.get("baseline_size", 0))
+    new_size = int(metrics.get("evolved_size", len(evolved_full)))
+    sha = hashlib.sha256(evolved_full.encode("utf-8")).hexdigest()
+
+    lines = [
+        f"This updates the `{skill_name}` skill with a version produced by the "
+        "self-evolution pipeline (DSPy + GEPA). It is offered for human review, "
+        "not auto-merge.",
+        "",
+        "## Results (holdout set)",
+        "",
+        "| Metric | Baseline | Evolved | Change |",
+        "| --- | ---: | ---: | ---: |",
+        f"| Holdout score | {baseline:.3f} | {evolved:.3f} | "
+        f"{improvement:+.3f} ({_pct(improvement, baseline)}) |",
+        f"| Skill size | {base_size:,} chars | {new_size:,} chars | "
+        f"{new_size - base_size:+,} chars |",
+        "",
+        "## How it was produced",
+        "",
+        f"- Optimizer: GEPA, {metrics.get('iterations', 'n/a')} iterations",
+        f"- Optimizer model: {metrics.get('optimizer_model', 'n/a')}",
+        f"- Eval model: {metrics.get('eval_model', 'n/a')}",
+        f"- Eval dataset: {metrics.get('train_examples', 0)} train / "
+        f"{metrics.get('val_examples', 0)} val / "
+        f"{metrics.get('holdout_examples', 0)} holdout "
+        f"(source: {metrics.get('eval_source', 'n/a')})",
+        f"- Evolved file SHA-256: `{sha}`",
+    ]
+
+    if constraint_results:
+        lines += ["", "## Constraints", ""]
+        for c in constraint_results:
+            box = "x" if c.passed else " "
+            lines.append(f"- [{box}] {c.constraint_name}: {c.message}")
+
+    lines += [
+        "",
+        "## Files",
+        "",
+        f"- `{skill_rel_path}`",
+        "",
+        f"Reproduce with `python -m evolution.skills.evolve_skill --skill {skill_name}`. "
+        "Please read the diff before merging.",
+    ]
+    return "\n".join(lines)
+
+
+def _is_git_repo(repo: Path, run: Runner) -> bool:
+    try:
+        res = run(["git", "rev-parse", "--is-inside-work-tree"], repo)
+    except FileNotFoundError:
+        return False
+    return res.returncode == 0 and (res.stdout or "").strip() == "true"
+
+
+def _follow_up_commands(repo: Path, branch: str, base: str, title: str) -> list[str]:
+    """The commands a human can run to push and open the PR by hand."""
+    quoted_title = shlex.quote(title)
+    return [
+        f"git -C {shlex.quote(str(repo))} push -u origin {shlex.quote(branch)}",
+        f"gh pr create --base {shlex.quote(base)} --head {shlex.quote(branch)} "
+        f"--title {quoted_title} --body-file <(...)  # from the hermes-agent repo",
+    ]
+
+
+def emit_pr(
+    hermes_repo: Path,
+    skill_rel_path: str,
+    evolved_full: str,
+    metrics: dict,
+    constraint_results: Optional[Sequence[ConstraintResult]] = None,
+    *,
+    base: str = "main",
+    open_remote: bool = False,
+    timestamp: str = "",
+    run: Runner = _subprocess_run,
+) -> PREmissionResult:
+    """Prepare a pull request for an evolved skill against the hermes-agent repo.
+
+    By default this writes the evolved skill into ``hermes_repo`` at
+    ``skill_rel_path``, creates a fresh ``evolve/<skill>-<timestamp>`` branch,
+    and commits that single file. With ``open_remote=True`` it also pushes the
+    branch and opens the PR with ``gh``. Anything that cannot be done (no git
+    repo, no ``gh``, push rejected) becomes a message plus follow-up commands;
+    this function does not raise on those conditions.
+    """
+    hermes_repo = Path(hermes_repo)
+    skill_name = str(metrics.get("skill_name", Path(skill_rel_path).parent.name))
+    improvement = float(metrics.get("improvement", 0.0))
+    branch = build_branch_name(skill_name, timestamp or "manual")
+    title = build_pr_title(skill_name, improvement)
+    body = build_pr_body(skill_name, metrics, skill_rel_path, evolved_full, constraint_results)
+
+    result = PREmissionResult(
+        prepared=False,
+        branch=branch,
+        base=base,
+        skill_rel_path=skill_rel_path,
+    )
+
+    if not _is_git_repo(hermes_repo, run):
+        result.messages.append(
+            f"{hermes_repo} is not a git repository, so no branch was created. "
+            "The evolved skill is saved in the run's output directory; commit it "
+            "into a hermes-agent checkout to open a PR."
+        )
+        result.follow_up_commands = [
+            f"cp <output>/evolved_skill.md {shlex.quote(str(hermes_repo / skill_rel_path))}",
+            *_follow_up_commands(hermes_repo, branch, base, title),
+        ]
+        return result
+
+    # Write the evolved skill into the working tree.
+    skill_file = hermes_repo / skill_rel_path
+    skill_file.parent.mkdir(parents=True, exist_ok=True)
+    skill_file.write_text(evolved_full)
+
+    co = run(["git", "checkout", "-b", branch], hermes_repo)
+    if co.returncode != 0:
+        result.messages.append(
+            f"Could not create branch {branch}: {(co.stderr or co.stdout or '').strip()}. "
+            "The evolved skill was written to the working tree; commit it manually."
+        )
+        result.follow_up_commands = _follow_up_commands(hermes_repo, branch, base, title)
+        return result
+
+    # Stage only the skill file so an unrelated dirty tree is left alone.
+    run(["git", "add", skill_rel_path], hermes_repo)
+    commit = run(["git", "commit", "-m", title, "-m", body], hermes_repo)
+    if commit.returncode != 0:
+        result.messages.append(
+            f"Branch {branch} was created but the commit failed: "
+            f"{(commit.stderr or commit.stdout or '').strip()}."
+        )
+        result.follow_up_commands = _follow_up_commands(hermes_repo, branch, base, title)
+        return result
+
+    rev = run(["git", "rev-parse", "HEAD"], hermes_repo)
+    result.prepared = True
+    result.commit_sha = (rev.stdout or "").strip() if rev.returncode == 0 else None
+    result.messages.append(f"Prepared branch {branch} with the evolved {skill_name} skill.")
+    result.follow_up_commands = _follow_up_commands(hermes_repo, branch, base, title)
+
+    if not open_remote:
+        return result
+
+    # Opt-in network mutation from here on.
+    try:
+        push = run(["git", "push", "-u", "origin", branch], hermes_repo)
+    except FileNotFoundError:
+        push = None
+    if push is None or push.returncode != 0:
+        detail = "" if push is None else (push.stderr or push.stdout or "").strip()
+        result.messages.append(
+            f"Could not push {branch} to origin{(': ' + detail) if detail else ''}. "
+            "Run the follow-up commands once the remote is reachable."
+        )
+        return result
+    result.pushed = True
+
+    try:
+        pr = run(
+            [
+                "gh", "pr", "create",
+                "--base", base,
+                "--head", branch,
+                "--title", title,
+                "--body", body,
+            ],
+            hermes_repo,
+        )
+    except FileNotFoundError:
+        pr = None
+    if pr is None or pr.returncode != 0:
+        detail = "gh not found" if pr is None else (pr.stderr or pr.stdout or "").strip()
+        result.messages.append(
+            f"Pushed {branch}, but could not open the PR automatically ({detail}). "
+            "Open it from the hermes-agent repo with gh or the web UI."
+        )
+        return result
+
+    result.pr_url = (pr.stdout or "").strip().splitlines()[-1] if pr.stdout else None
+    result.messages.append(f"Opened pull request: {result.pr_url}")
+    return result

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -23,6 +23,7 @@ from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset,
 from evolution.core.external_importers import build_dataset_from_external
 from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore
 from evolution.core.constraints import ConstraintValidator
+from evolution.core.pr import emit_pr
 from evolution.skills.skill_module import (
     SkillModule,
     load_skill,
@@ -43,6 +44,9 @@ def evolve(
     hermes_repo: Optional[str] = None,
     run_tests: bool = False,
     dry_run: bool = False,
+    no_pr: bool = False,
+    open_pr: bool = False,
+    base: str = "main",
 ):
     """Main evolution function — orchestrates the full optimization loop."""
 
@@ -73,7 +77,12 @@ def evolve(
         console.print(f"\n[bold green]DRY RUN — setup validated successfully.[/bold green]")
         console.print(f"  Would generate eval dataset (source: {eval_source})")
         console.print(f"  Would run GEPA optimization ({iterations} iterations)")
-        console.print(f"  Would validate constraints and create PR")
+        if no_pr:
+            console.print(f"  Would validate constraints (PR preparation disabled via --no-pr)")
+        elif open_pr:
+            console.print(f"  Would validate constraints, prepare a branch, and open a PR (base: {base})")
+        else:
+            console.print(f"  Would validate constraints and prepare a PR branch against base '{base}'")
         return
 
     # ── 2. Build or load evaluation dataset ─────────────────────────────
@@ -269,6 +278,7 @@ def evolve(
         "iterations": iterations,
         "optimizer_model": optimizer_model,
         "eval_model": eval_model,
+        "eval_source": eval_source,
         "baseline_score": avg_baseline,
         "evolved_score": avg_evolved,
         "improvement": improvement,
@@ -287,6 +297,34 @@ def evolve(
     if improvement > 0:
         console.print(f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement/max(0.001, avg_baseline)*100:+.1f}%)[/bold green]")
         console.print(f"  Review the diff: diff {output_dir}/baseline_skill.md {output_dir}/evolved_skill.md")
+
+        # ── 11. Prepare a pull request against hermes-agent ─────────────
+        if no_pr or not config.create_pr:
+            console.print("\n[dim]PR preparation skipped (--no-pr or create_pr disabled).[/dim]")
+        else:
+            console.print(f"\n[bold]Preparing pull request[/bold]")
+            skill_rel_path = str(skill_path.relative_to(config.hermes_agent_path))
+            pr_result = emit_pr(
+                hermes_repo=config.hermes_agent_path,
+                skill_rel_path=skill_rel_path,
+                evolved_full=evolved_full,
+                metrics=metrics,
+                constraint_results=evolved_constraints,
+                base=base,
+                open_remote=open_pr,
+                timestamp=timestamp,
+            )
+            for msg in pr_result.messages:
+                console.print(f"  {msg}")
+            if pr_result.pr_url:
+                console.print(f"\n[bold green]✓ Pull request opened: {pr_result.pr_url}[/bold green]")
+            elif pr_result.prepared:
+                console.print(f"  Commit: {pr_result.commit_sha}")
+                console.print("  Finish by running:")
+                for cmd in pr_result.follow_up_commands:
+                    console.print(f"    {cmd}")
+                if not open_pr:
+                    console.print("  Or re-run with --open-pr to push and open it automatically.")
     else:
         console.print(f"\n[yellow]⚠ Evolution did not improve skill (change: {improvement:+.3f})[/yellow]")
         console.print("  Try: more iterations, better eval dataset, or different optimizer model")
@@ -303,7 +341,10 @@ def evolve(
 @click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
 @click.option("--run-tests", is_flag=True, help="Run full pytest suite as constraint gate")
 @click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")
-def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run):
+@click.option("--no-pr", is_flag=True, help="Skip preparing the pull request branch")
+@click.option("--open-pr", is_flag=True, help="Push the branch and open the PR via gh (off by default)")
+@click.option("--base", default="main", help="Base branch for the pull request")
+def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run, no_pr, open_pr, base):
     """Evolve a Hermes Agent skill using DSPy + GEPA optimization."""
     evolve(
         skill_name=skill,
@@ -315,6 +356,9 @@ def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_mod
         hermes_repo=hermes_repo,
         run_tests=run_tests,
         dry_run=dry_run,
+        no_pr=no_pr,
+        open_pr=open_pr,
+        base=base,
     )
 
 

--- a/tests/core/test_pr.py
+++ b/tests/core/test_pr.py
@@ -1,0 +1,217 @@
+"""Tests for pull request emission (evolution/core/pr.py).
+
+Background
+----------
+The README advertises "Best variant -> PR against hermes-agent" and PLAN.md
+specifies that every command should "output a PR branch + summary against
+hermes-agent" for a human to merge. That step was never implemented: the only
+trace was the ``create_pr`` config flag and a dry-run print, so a successful
+``evolve_skill`` run stopped at writing ``output/<skill>/.../evolved_skill.md``
+and left the operator to copy the file and stitch the git/gh commands by hand.
+
+These tests lock in the new behavior at both layers: the deterministic title and
+body builders, and ``emit_pr`` itself. The local-prep paths run against a real
+temporary git repo (faithful, no network). The remote paths use an injected
+runner so push and ``gh`` are exercised without touching the network, including
+the degradation paths (no git repo, missing ``gh``).
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from evolution.core.constraints import ConstraintResult
+from evolution.core.pr import (
+    build_branch_name,
+    build_pr_body,
+    build_pr_title,
+    emit_pr,
+    slugify,
+)
+
+
+SKILL_REL = "skills/testing/demo/SKILL.md"
+EVOLVED = "---\nname: demo\ndescription: Demo skill\n---\n\n# Demo (evolved)\n\n1. Do the better thing.\n"
+
+METRICS = {
+    "skill_name": "demo",
+    "iterations": 10,
+    "optimizer_model": "openai/gpt-4.1",
+    "eval_model": "openai/gpt-4.1-mini",
+    "eval_source": "synthetic",
+    "baseline_score": 0.785,
+    "evolved_score": 0.812,
+    "improvement": 0.027,
+    "baseline_size": 14836,
+    "evolved_size": 11407,
+    "train_examples": 10,
+    "val_examples": 5,
+    "holdout_examples": 5,
+}
+
+CONSTRAINTS = [
+    ConstraintResult(passed=True, constraint_name="size", message="within limit"),
+    ConstraintResult(passed=True, constraint_name="non_empty", message="ok"),
+]
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+def _git(args, cwd):
+    return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True)
+
+
+def _make_git_repo(tmp_path) -> Path:
+    """A minimal hermes-agent-style git repo with one committed skill."""
+    repo = tmp_path / "hermes-agent"
+    skill_dir = repo / "skills" / "testing" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Demo skill\n---\n\n# Demo\n\n1. Do the thing.\n"
+    )
+    _git(["init", "-b", "main"], repo)
+    _git(["config", "user.email", "test@example.com"], repo)
+    _git(["config", "user.name", "Test"], repo)
+    _git(["add", "."], repo)
+    _git(["commit", "-m", "initial"], repo)
+    return repo
+
+
+def _committed_files(repo, sha="HEAD"):
+    out = _git(["show", "--name-only", "--pretty=format:", sha], repo).stdout
+    return [line for line in out.splitlines() if line.strip()]
+
+
+class FakeRunner:
+    """Records commands and returns canned results; no real process spawned."""
+
+    def __init__(self, missing=()):
+        self.calls = []
+        self.missing = set(missing)
+
+    def __call__(self, cmd, cwd):
+        cmd = list(cmd)
+        self.calls.append(cmd)
+        if cmd[0] in self.missing:
+            raise FileNotFoundError(cmd[0])
+        joined = " ".join(cmd)
+        if "rev-parse --is-inside-work-tree" in joined:
+            return subprocess.CompletedProcess(cmd, 0, "true\n", "")
+        if "rev-parse HEAD" in joined:
+            return subprocess.CompletedProcess(cmd, 0, "deadbeef\n", "")
+        if cmd[0] == "gh":
+            return subprocess.CompletedProcess(
+                cmd, 0, "https://github.com/NousResearch/hermes-agent/pull/999\n", ""
+            )
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+
+# ── builders ──────────────────────────────────────────────────────────────
+
+def test_slugify_makes_branch_safe_names():
+    assert slugify("github-code-review") == "github-code-review"
+    assert slugify("My Skill!!") == "my-skill"
+    assert slugify("---") == "skill"
+
+
+def test_build_branch_name_and_title():
+    assert build_branch_name("demo", "20260628-101500") == "evolve/demo-20260628-101500"
+    assert build_pr_title("demo", 0.027) == "evolve: demo skill (holdout +0.027)"
+
+
+def test_build_pr_body_is_deterministic_and_clean():
+    body_a = build_pr_body("demo", METRICS, SKILL_REL, EVOLVED, CONSTRAINTS)
+    body_b = build_pr_body("demo", METRICS, SKILL_REL, EVOLVED, CONSTRAINTS)
+    assert body_a == body_b  # deterministic
+
+    assert "demo" in body_a
+    assert "0.785" in body_a and "0.812" in body_a   # before/after
+    assert "+3.4%" in body_a                          # percentage change
+    assert SKILL_REL in body_a
+    assert "size" in body_a and "non_empty" in body_a  # constraint names
+    assert "SHA-256" in body_a
+
+    # House rules for this contribution: no em dashes, no tool branding.
+    assert "—" not in body_a
+    assert "claude" not in body_a.lower()
+
+
+# ── emit_pr: local preparation (real git) ────────────────────────────────
+
+def test_emit_pr_prepares_branch_and_commit(tmp_path):
+    repo = _make_git_repo(tmp_path)
+    result = emit_pr(repo, SKILL_REL, EVOLVED, METRICS, CONSTRAINTS, timestamp="ts1")
+
+    assert result.prepared is True
+    assert result.branch == "evolve/demo-ts1"
+    assert result.pushed is False and result.pr_url is None
+    assert result.commit_sha
+    assert result.follow_up_commands  # how to finish by hand
+
+    # Branch is checked out and the evolved content is committed.
+    assert _git(["rev-parse", "--abbrev-ref", "HEAD"], repo).stdout.strip() == "evolve/demo-ts1"
+    assert (repo / SKILL_REL).read_text() == EVOLVED
+    assert SKILL_REL in _committed_files(repo)
+
+
+def test_emit_pr_commits_only_the_skill_file(tmp_path):
+    repo = _make_git_repo(tmp_path)
+    (repo / "unrelated.txt").write_text("dirty working tree")  # untracked noise
+
+    emit_pr(repo, SKILL_REL, EVOLVED, METRICS, CONSTRAINTS, timestamp="ts2")
+
+    committed = _committed_files(repo)
+    assert committed == [SKILL_REL]
+    assert "unrelated.txt" not in committed
+
+
+# ── emit_pr: degradation paths (never fatal) ─────────────────────────────
+
+def test_emit_pr_non_git_repo_degrades(tmp_path):
+    plain = tmp_path / "not-a-repo"
+    (plain / "skills" / "testing" / "demo").mkdir(parents=True)
+
+    result = emit_pr(plain, SKILL_REL, EVOLVED, METRICS, CONSTRAINTS, timestamp="ts3")
+
+    assert result.prepared is False
+    assert any("not a git repository" in m for m in result.messages)
+    assert result.follow_up_commands  # cp + push + gh, so the user can finish
+    # Nothing was written into a non-repo, so we cannot clobber anything.
+    assert not (plain / SKILL_REL).exists()
+
+
+def test_emit_pr_open_remote_pushes_and_opens_pr(tmp_path):
+    repo = tmp_path / "hermes-agent"
+    (repo / "skills" / "testing" / "demo").mkdir(parents=True)
+    runner = FakeRunner()
+
+    result = emit_pr(
+        repo, SKILL_REL, EVOLVED, METRICS, CONSTRAINTS,
+        base="main", open_remote=True, timestamp="ts4", run=runner,
+    )
+
+    assert result.prepared is True
+    assert result.pushed is True
+    assert result.pr_url == "https://github.com/NousResearch/hermes-agent/pull/999"
+
+    gh_calls = [c for c in runner.calls if c[0] == "gh"]
+    assert gh_calls, "gh pr create should have been invoked"
+    gh = gh_calls[0]
+    assert "--head" in gh and "evolve/demo-ts4" in gh
+    assert "--base" in gh and "main" in gh
+
+
+def test_emit_pr_missing_gh_degrades_after_push(tmp_path):
+    repo = tmp_path / "hermes-agent"
+    (repo / "skills" / "testing" / "demo").mkdir(parents=True)
+    runner = FakeRunner(missing={"gh"})
+
+    result = emit_pr(
+        repo, SKILL_REL, EVOLVED, METRICS, CONSTRAINTS,
+        open_remote=True, timestamp="ts5", run=runner,
+    )
+
+    assert result.pushed is True       # push still succeeded
+    assert result.pr_url is None       # but the PR could not be opened
+    assert any("could not open the PR" in m for m in result.messages)


### PR DESCRIPTION
## What this adds

The pipeline is meant to end in a pull request. The README diagram shows `Best variant -> PR against hermes-agent`, and PLAN.md says every command should "output a PR branch + summary against hermes-agent. Human merges." In the current code that final step is missing. The only traces of it are the `create_pr` flag in `EvolutionConfig` and a dry-run line that prints `Would validate constraints and create PR`. There is no git or `gh` code anywhere in the tree.

So today a successful run optimizes the skill, validates it, writes `output/<skill>/<timestamp>/evolved_skill.md`, and stops. To actually land the improvement you have to copy the file into your hermes-agent checkout and assemble the branch, commit, push, and `gh pr create` commands yourself. This closes that gap.

## How it works

New module `evolution/core/pr.py` with `emit_pr(...)`, wired into `evolve_skill` right after a skill beats the baseline and passes every constraint (the existing `improvement > 0` success path):

- By default it writes the evolved skill into the hermes-agent working tree, creates an `evolve/<skill>-<timestamp>` branch, and commits that one file with a generated summary of the before/after scores. The branch stays local so you can read the diff before anything leaves your machine.
- `--open-pr` additionally pushes the branch and opens the PR with `gh`.
- `--no-pr` skips the step entirely.

The PR body is built deterministically from the run's metrics: before/after holdout scores and percentage change, size delta, optimizer and eval models, the dataset split and source, the evolved file's SHA-256, and the constraint results.

## Why it is shaped this way

A convenience at the very end of a run should never put the repo or the run at risk, so:

- **Safe by default.** Network mutation is opt-in. The default output is a local branch plus the exact commands to finish by hand, which matches the PLAN.md contract of emitting "a PR branch + summary" for a human to merge.
- **Small blast radius.** Only the single skill file is staged, never `git add -A`, so an unrelated dirty working tree is left alone. It creates a fresh branch rather than committing onto the current one, and never force-pushes.
- **Never fatal.** A missing git repo, a missing `gh`, or a rejected push degrades to a clear message plus copy-pasteable follow-up commands instead of raising. A good evolved skill should not be lost because the convenience step hit a snag.

## Tests

`tests/core/test_pr.py` (8 tests). The local preparation paths run against a real temporary git repo, so they prove the branch is created, the evolved content is committed, and only the skill file is staged even when an unrelated dirty file is present. The remote and degradation paths use an injected runner so push and `gh` are exercised without the network, including the no-git-repo and missing-`gh` cases. The builders are checked for determinism and for the before/after numbers landing in the body.

Full suite stays green (153 passed). The three flag combinations are also verified through `--dry-run`.

## Scope

Kept deliberately narrow. No changes to the optimizer, fitness, or constraints, and no auto-merge, proposal store, or nightly pipeline. This is just the missing final step so it can be reviewed on its own.
