### PR TITLE
Fix evolve_skill validation and assembly bugs (fixes #119)

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -185,7 +185,9 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    # evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    # Pehle: evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -119,5 +119,21 @@ def reassemble_skill(frontmatter: str, evolved_body: str) -> str:
 
     Preserves the original YAML frontmatter (name, description, metadata)
     and replaces only the body with the evolved version.
+
+    If evolved_body already contains its own frontmatter block (the
+    optimizer sometimes writes a full skill file rather than just the body),
+    that block is stripped first so the result never has nested frontmatter.
     """
-    return f"---\n{frontmatter}\n---\n\n{evolved_body}\n"
+    body = evolved_body
+    if body.strip().startswith("---"):
+        parts = body.split("---", 2)
+        if len(parts) >= 3:
+            body = parts[2].lstrip("\n")
+    return f"---\n{frontmatter}\n---\n\n{body}\n"
+# def reassemble_skill(frontmatter: str, evolved_body: str) -> str:
+#     """Reassemble a skill file from frontmatter and evolved body.
+
+#     Preserves the original YAML frontmatter (name, description, metadata)
+#     and replaces only the body with the evolved version.
+#     """
+#     return f"---\n{frontmatter}\n---\n\n{evolved_body}\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pyyaml>=6.0",
     "click>=8.0",
     "rich>=13.0",
+    "optuna>=3.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_issue_119_repro.py
+++ b/tests/test_issue_119_repro.py
@@ -1,0 +1,54 @@
+"""Repro tests for NousResearch/hermes-agent-self-evolution issue #119.
+
+Bug 1: evolve_skill.py validates `evolved_body` (which deliberately has no
+frontmatter -- it's re-added separately by reassemble_skill) against the
+`skill_structure` constraint, which requires frontmatter. This means the
+structure check always fails, even for a perfectly valid evolved skill.
+
+Bug 2: reassemble_skill() unconditionally prepends the baseline frontmatter
+onto evolved_body. If evolved_body already contains its own frontmatter
+block (which the optimizer sometimes writes), the result has two nested
+frontmatter blocks instead of one.
+"""
+
+from evolution.core.config import EvolutionConfig
+from evolution.core.constraints import ConstraintValidator
+from evolution.skills.skill_module import reassemble_skill
+
+
+def test_bug1_validating_body_alone_always_fails_structure_even_when_full_text_is_valid():
+    config = EvolutionConfig()
+    validator = ConstraintValidator(config)
+
+    frontmatter = "name: my-skill\ndescription: Does stuff"
+    evolved_body = "# My Skill\nDo the thing well."
+
+    # This is what evolve_skill.py currently does (the bug): validate the body
+    # alone, which never has frontmatter by design.
+    results_on_body_alone = validator.validate_all(evolved_body, "skill")
+    structure_on_body = next(r for r in results_on_body_alone if r.constraint_name == "skill_structure")
+    assert not structure_on_body.passed  # demonstrates the bug
+
+    # This is what it should validate instead: the reassembled full text,
+    # which does have frontmatter and is a perfectly valid skill.
+    evolved_full = reassemble_skill(frontmatter, evolved_body)
+    results_on_full = validator.validate_all(evolved_full, "skill")
+    structure_on_full = next(r for r in results_on_full if r.constraint_name == "skill_structure")
+    assert structure_on_full.passed
+
+
+def test_bug2_reassemble_nests_frontmatter_when_evolved_body_has_its_own():
+    frontmatter = "name: my-skill\ndescription: Does stuff"
+    evolved_body_with_own_frontmatter = (
+        "---\nname: my-skill\ndescription: A different description\n---\n\n"
+        "# My Skill\nDo the thing well."
+    )
+
+    result = reassemble_skill(frontmatter, evolved_body_with_own_frontmatter)
+
+    # Current (buggy) behavior produces two nested frontmatter blocks (4 "---"
+    # markers). A correct reassembly should produce exactly one block (2
+    # markers).
+    assert result.count("---") == 2, f"expected exactly one frontmatter block, got: {result!r}"
+    assert "# My Skill" in result
+    assert "Do the thing well." in result


### PR DESCRIPTION
Fixes #119

Addresses 3 of the 4 bugs reported in the issue. Bug 4's warning (`console.print(...GEPA not available...)`) already exists in current `main`, so no change was needed there.

**Bug 1 — validator called on body instead of full reassembled text (`evolve_skill.py`)**
The `skill_structure` constraint checks for YAML frontmatter (`---`). `evolved_body` never has frontmatter by design — it's added back by `reassemble_skill`. Passing the body alone to `validate_all` caused the structure check to always fail, even for a perfectly valid evolved skill, so every run produced `evolved_FAILED.md` instead of deploying.

Fix: validate `evolved_full` (the reassembled complete file) against `skill["raw"]` (the full baseline) instead.

**Bug 2 — `reassemble_skill` produces nested frontmatter blocks (`skill_module.py`)**
When the optimizer writes a full skill file (frontmatter + body) into `evolved_body`, `reassemble_skill` prepended the baseline frontmatter on top, producing two nested `---...---` blocks.

Fix: strip any leading frontmatter from `evolved_body` before reassembling.

**Bug 3 — `optuna` is a runtime requirement but not declared (`pyproject.toml`)**
MIPROv2 imports `optuna` lazily — the ImportError only surfaces when the optimizer runs, not at install time. Added `optuna>=3.0` as a hard dependency.

**Tests:** `tests/test_issue_119_repro.py` — covers both Bug 1 (body-only validation always fails structure, full-text passes) and Bug 2 (nested frontmatter is prevented). All 147 tests passing, no regressions. The one pre-existing failure (`test_resolve_expands_user_home`) is a Windows path issue unrelated to this PR.