### PR TITLE
fix: GEPA 3.2.x compatibility + symlink resolver + validator false-positive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ datasets/**/*.json
 snapshots/
 *.pkl
 
+# Evolution runs (timestamped output dirs — kept locally, not in VCS)
+output/
+
 # IDE
 .idea/
 .vscode/

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -104,11 +104,31 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+def skill_fitness_metric(
+    example: dspy.Example,
+    prediction: dspy.Prediction,
+    trace=None,
+    pred_name: str = None,
+    pred_trace=None,
+) -> float:
     """DSPy-compatible metric function for skill optimization.
 
-    This is what gets passed to dspy.GEPA(metric=...).
+    This is what gets passed to dspy.GEPA(metric=...) and dspy.MIPROv2.
     Returns a float 0-1 score.
+
+    NOTE: GEPA's adapter calls this with the signature
+        (gold, pred, trace, pred_name, pred_trace)
+    where the first two are positional ``example`` and ``prediction``. To
+    stay backward-compatible with the simpler
+        (example, prediction, trace=None)
+    shape used by MIPROv2 and other DSPy optimizers, we declare the extra
+    GEPA-specific parameters as keyword-only with defaults — they just get
+    ignored. Don't drop the defaults: removing them turns any MIPROv2
+    invocation into a TypeError.
+
+    Why not just *args/**kwargs? Because GEPA inspects the signature to
+    figure out where ``trace`` ends and the GEPA-specific args begin.
+    Positional-or-keyword with defaults is the cleanest compatible shape.
     """
     # The prediction should have an 'output' field with the agent's response
     agent_output = getattr(prediction, "output", "") or ""

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -3,9 +3,29 @@
 Usage:
     python -m evolution.skills.evolve_skill --skill github-code-review --iterations 10
     python -m evolution.skills.evolve_skill --skill arxiv --eval-source golden --dataset datasets/skills/arxiv/
+
+Provider selection:
+    The --provider flag chooses the LLM backend. Three values are supported:
+
+    - "openai" (default): use OPENAI_API_KEY / OPENAI_BASE_URL env vars, model
+      names prefixed with "openai/". Works against any OpenAI-compatible
+      endpoint.
+    - "minimax": use MINIMAX_API_KEY from env (falls back to OPENAI_API_KEY),
+      set the base URL to https://api.minimax.io/v1, and pass through
+      MiniMax-flavored model names like "MiniMax-M2.7-highspeed". This is the
+      provider wired into the project owner's setup.
+    - Anything else: used verbatim as the dspy.LM model string (e.g.
+      "anthropic/claude-sonnet-4"), assuming the user has configured the
+      relevant litellm provider keys.
+
+    The MiniMax branch exists because MiniMax's v1 endpoint is
+    OpenAI-compatible but ships only its own model names, not generic ones —
+    so we can't just rename MINIMAX_API_KEY to OPENAI_API_KEY and call it a
+    day. We also have to translate model strings.
 """
 
 import json
+import os
 import sys
 import time
 from pathlib import Path
@@ -33,6 +53,70 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+# Mapping from generic "openai/<name>" strings (as used in
+# EvolutionConfig defaults) to MiniMax's actual model IDs. We need this
+# because the v1 endpoint only accepts MiniMax's own model names — passing
+# "openai/gpt-4.1" returns a 404 even though the wire format is OpenAI-
+# compatible.
+_OPENAI_TO_MINIMAX_MODEL = {
+    "openai/gpt-4.1": "openai/MiniMax-M3",
+    "openai/gpt-4.1-mini": "openai/MiniMax-M2.7-highspeed",
+    "openai/gpt-4.1-nano": "openai/MiniMax-M2.5",
+}
+
+
+def _resolve_model_string(model: str, provider: str) -> str:
+    """Translate an EvolutionConfig-style model string for the chosen provider.
+
+    For provider="minimax", rewrite the OpenAI default names to MiniMax
+    equivalents. Pass through anything else verbatim so users can still
+    pin an exact MiniMax model if they want (e.g. "MiniMax-M3" or
+    "MiniMax-Text-01" — but note the latter is only chat, not reasoning).
+    """
+    if provider != "minimax":
+        return model
+    if model in _OPENAI_TO_MINIMAX_MODEL:
+        return _OPENAI_TO_MINIMAX_MODEL[model]
+    # If the caller already wrote "openai/MiniMax-M2.7" or "MiniMax-M2.7",
+    # pass through — we just need to make sure the base URL is set.
+    return model
+
+
+def _configure_provider_env(provider: str) -> None:
+    """Set OPENAI_API_KEY / OPENAI_BASE_URL for the chosen provider.
+
+    DSPy + litellm read these env vars when constructing the LM client.
+    Setting them here (not in the caller) keeps the evolver's surface
+    simple — callers just pick --provider and the env wiring follows.
+
+    For MiniMax we read MINIMAX_API_KEY and override the base URL to the
+    v1 endpoint (which is OpenAI-compatible; the anthropic endpoint at
+    /anthropic is NOT compatible with dspy.LM's OpenAI-format adapter).
+    """
+    if provider == "minimax":
+        key = os.getenv("MINIMAX_API_KEY") or os.getenv("OPENAI_API_KEY")
+        if not key:
+            console.print(
+                "[red]✗ provider=minimax requires MINIMAX_API_KEY (or "
+                "OPENAI_API_KEY) in env[/red]"
+            )
+            sys.exit(2)
+        os.environ["OPENAI_API_KEY"] = key
+        # /v1 is the OpenAI-compatible surface; /anthropic is anthropic-format.
+        os.environ["OPENAI_BASE_URL"] = os.getenv(
+            "MINIMAX_BASE_URL", "https://api.minimax.io/v1"
+        )
+    # For provider="openai" (default) we assume the caller already set
+    # OPENAI_API_KEY / OPENAI_BASE_URL — no override needed.
+    elif provider == "openai":
+        if not os.getenv("OPENAI_API_KEY"):
+            console.print(
+                "[red]✗ provider=openai requires OPENAI_API_KEY in env[/red]"
+            )
+            sys.exit(2)
+    # Custom string providers: trust the caller.
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -43,20 +127,48 @@ def evolve(
     hermes_repo: Optional[str] = None,
     run_tests: bool = False,
     dry_run: bool = False,
+    provider: str = "openai",
 ):
-    """Main evolution function — orchestrates the full optimization loop."""
+    """Main evolution function — orchestrates the full optimization loop.
+
+    The ``provider`` argument selects the LLM backend. See module docstring
+    for the three supported values. We translate the EvolutionConfig's
+    OpenAI-flavored default model strings into provider-appropriate names
+    here, so callers can keep using the natural ``--optimizer-model`` /
+    ``--eval-model`` flags without having to know which provider is wired
+    up.
+    """
+
+    # Configure provider env FIRST, before constructing EvolutionConfig, so
+    # any LM objects created downstream pick up the right base URL / key.
+    _configure_provider_env(provider)
+
+    # Translate model strings for the chosen provider (e.g. gpt-4.1 →
+    # MiniMax-M3 when provider=minimax). We resolve against the user's
+    # explicit --optimizer-model / --eval-model args first so they can
+    # still pin a specific MiniMax model.
+    resolved_optimizer = _resolve_model_string(optimizer_model, provider)
+    resolved_eval = _resolve_model_string(eval_model, provider)
+
+    if resolved_optimizer != optimizer_model or resolved_eval != eval_model:
+        console.print(
+            f"  [dim]Provider '{provider}': rewrote model strings[/dim]\n"
+            f"    optimizer: {optimizer_model} → {resolved_optimizer}\n"
+            f"    eval:      {eval_model} → {resolved_eval}"
+        )
 
     config = EvolutionConfig(
         hermes_agent_path=resolve_hermes_agent_path(hermes_repo),
         iterations=iterations,
-        optimizer_model=optimizer_model,
-        eval_model=eval_model,
-        judge_model=eval_model,  # Use same model for dataset generation
+        optimizer_model=resolved_optimizer,
+        eval_model=resolved_eval,
+        judge_model=resolved_eval,  # Use same model for dataset generation
         run_pytest=run_tests,
     )
 
     # ── 1. Find and load the skill ──────────────────────────────────────
     console.print(f"\n[bold cyan]🧬 Hermes Agent Self-Evolution[/bold cyan] — Evolving skill: [bold]{skill_name}[/bold]\n")
+    console.print(f"  Provider: {provider} (base URL: {os.getenv('OPENAI_BASE_URL', '<default>')})")
 
     skill_path = find_skill(skill_name, config.hermes_agent_path)
     if not skill_path:
@@ -118,7 +230,11 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    # Validate the full raw skill (frontmatter + body), not just the body.
+    # _check_skill_structure looks for the YAML frontmatter at the top of
+    # the text; passing only the body always fails the frontmatter check
+    # even when the baseline itself is structurally correct.
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -133,11 +249,14 @@ def evolve(
     # ── 4. Set up DSPy + GEPA optimizer ─────────────────────────────────
     console.print(f"\n[bold]Configuring optimizer[/bold]")
     console.print(f"  Optimizer: GEPA ({iterations} iterations)")
-    console.print(f"  Optimizer model: {optimizer_model}")
-    console.print(f"  Eval model: {eval_model}")
+    console.print(f"  Optimizer model: {config.optimizer_model}")
+    console.print(f"  Eval model: {config.eval_model}")
 
-    # Configure DSPy
-    lm = dspy.LM(eval_model)
+    # Configure DSPy with the eval model as the global default. Any
+    # unconfigured LM downstream (e.g. MIPROv2's data-aware proposer) will
+    # pick this up rather than falling back to a hardcoded "gpt-4.1-mini"
+    # that doesn't exist on MiniMax.
+    lm = dspy.LM(config.eval_model)
     dspy.configure(lm=lm)
 
     # Create the baseline skill module
@@ -153,9 +272,27 @@ def evolve(
     start_time = time.time()
 
     try:
+        # Pass a reflection_lm to GEPA so it uses our chosen model for
+        # the reflective mutation prompts. Without this, GEPA falls back
+        # to dspy.settings.lm (already configured) but also defaults to
+        # "gpt-4.1-mini" for some internal calls — which 404s on MiniMax.
+        # Constructing an explicit reflection_lm makes the wiring obvious
+        # and provider-portable.
+        #
+        # GEPA's budget arg is `max_full_evals` (not `max_steps` — that was
+        # the older GEPA API). Each "full eval" runs the metric across the
+        # whole valset, which gives a real budget ≈ `iterations * valset_size`
+        # LM calls. We also cap with `max_metric_calls` as a hard ceiling
+        # so the run can't run away even if valset is large.
+        reflection_lm = dspy.LM(config.optimizer_model)
+        # GEPA accepts exactly one of {max_full_evals, max_metric_calls, auto}.
+        # Pass max_full_evals so a tiny iterations budget (e.g. 3) doesn't
+        # blow up into thousands of metric calls. Drop max_metric_calls
+        # entirely — it causes GEPA to refuse to start with a config error.
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
-            max_steps=iterations,
+            max_full_evals=iterations,
+            reflection_lm=reflection_lm,
         )
 
         optimized_module = optimizer.compile(
@@ -185,7 +322,14 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    # Use the reassembled full skill (frontmatter + body) for validation —
+    # _check_skill_structure looks for the YAML frontmatter block at the
+    # top of the text, and that lives in frontmatter, not body. Without
+    # this the check always reports the frontmatter as "missing" and
+    # gates every deploy, even when the artifact is structurally fine.
+    evolved_constraints = validator.validate_all(
+        evolved_full, "skill", baseline_text=skill["raw"]
+    )
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"
@@ -303,7 +447,10 @@ def evolve(
 @click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
 @click.option("--run-tests", is_flag=True, help="Run full pytest suite as constraint gate")
 @click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")
-def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run):
+@click.option("--provider", default="openai", type=click.Choice(["openai", "minimax"], case_sensitive=False),
+              help="LLM backend. 'openai' uses OPENAI_API_KEY/OPENAI_BASE_URL env vars; "
+                   "'minimax' uses MINIMAX_API_KEY and rewrites model strings to MiniMax equivalents.")
+def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run, provider):
     """Evolve a Hermes Agent skill using DSPy + GEPA optimization."""
     evolve(
         skill_name=skill,
@@ -315,6 +462,7 @@ def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_mod
         hermes_repo=hermes_repo,
         run_tests=run_tests,
         dry_run=dry_run,
+        provider=provider,
     )
 
 

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -5,11 +5,28 @@ where the skill text is the optimizable parameter. GEPA can then
 mutate the skill text and evaluate the results.
 """
 
+import os
 import re
 from pathlib import Path
 from typing import Optional
 
 import dspy
+
+
+def _iter_skill_files(skills_dir: Path):
+    """Recursively yield every SKILL.md under skills_dir, following symlinks.
+
+    ``Path.rglob`` in Python <3.12 doesn't accept ``follow_symlinks``, and
+    even on 3.12+ the default is False — which silently skips user-installed
+    skills that are symlinked into the framework's ``skills/`` tree. We use
+    ``os.walk(..., followlinks=True)`` (stdlib kwarg is ``followlinks``, not
+    ``follow_symlinks`` — that one's pathlib) so the evolver can find any
+    skill the runtime can find, regardless of how it's wired up.
+    """
+    for root, _dirs, files in os.walk(skills_dir, followlinks=True):
+        for name in files:
+            if name == "SKILL.md":
+                yield Path(root) / name
 
 
 def load_skill(skill_path: Path) -> dict:
@@ -65,12 +82,12 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
         return None
 
     # Direct match: skills/<category>/<skill_name>/SKILL.md
-    for skill_md in skills_dir.rglob("SKILL.md"):
+    for skill_md in _iter_skill_files(skills_dir):
         if skill_md.parent.name == skill_name:
             return skill_md
 
     # Fuzzy match: check the name field in frontmatter
-    for skill_md in skills_dir.rglob("SKILL.md"):
+    for skill_md in _iter_skill_files(skills_dir):
         try:
             content = skill_md.read_text()[:500]
             if f"name: {skill_name}" in content or f'name: "{skill_name}"' in content:


### PR DESCRIPTION
## Summary

Six fixes needed to run the GEPA skill-evolution pipeline end-to-end on a real Hermes Agent install with a non-OpenAI provider. Five are general-purpose bugs; one is provider-specific.

## General fixes (affect all users)

### 1. GEPA requires explicit `reflection_lm`
**File:** `evolution/skills/evolve_skill.py`

`dspy.GEPA` defaults its internal reflection LM to `gpt-4.1-mini`. On any non-OpenAI endpoint (OpenRouter, Anthropic, MiniMax, local models), this silently 404s. Fix: construct `reflection_lm` from the user's configured optimizer model and pass it explicitly.

```python
reflection_lm = dspy.LM(config.optimizer_model)
optimizer = dspy.GEPA(metric=..., max_full_evals=iterations, reflection_lm=reflection_lm)
```

### 2. `max_full_evals` + `max_metric_calls` are mutually exclusive in dspy.GEPA 3.2.x
**File:** `evolution/skills/evolve_skill.py`

Newer `dspy.GEPA` requires exactly one of `{max_full_evals, max_metric_calls, auto}`. Passing both is a config error and GEPA refuses to start. The evolver was written against an older DSPy API. Fix: pass only `max_full_evals`.

### 3. `skill_fitness_metric` needs 5-arg signature for GEPA compatibility
**File:** `evolution/core/fitness.py`

GEPA's adapter calls metrics as `(gold, pred, trace, pred_name, pred_trace)`. Without the two extra keyword-only params with defaults, GEPA refuses to start. Same upstream DSPy API drift as #2.

```python
def skill_fitness_metric(example, prediction, trace=None, pred_name=None, pred_trace=None) -> float:
```

### 4. `find_skill` silently misses symlinked skill directories
**File:** `evolution/skills/skill_module.py`

`Path.rglob("SKILL.md")` on Python <3.12 silently skips symlinked subtrees. The standard Hermes skill layout symlinks user-installed skills into the framework tree — so any real install hits this. The resolver reports "skill not found" with no error. Fix: use `os.walk(..., followlinks=True)`.

### 5. `validate_all()` receives `skill['body']` instead of `skill['raw']`
**File:** `evolution/skills/evolve_skill.py`

`_check_skill_structure` does `text.strip().startswith("---")` to detect YAML frontmatter, but both call sites pass `skill["body"]` (frontmatter stripped). Result: every baseline AND every evolved variant is flagged as "missing YAML frontmatter" and gated from deploy. Evolved candidates always suffix `_FAILED.md`. Fix: pass `skill["raw"]` (full text) to `validate_all()`.

## Provider-specific (held for follow-up)

### 6. `--provider` flag for non-OpenAI backends

Adds `--provider {openai|minimax}` flag that reads provider-specific env vars, sets the correct base URL, and translates hardcoded OpenAI model strings. Currently MiniMax-specific. Worth generalizing to a provider registry pattern before upstreaming.

## Empirical validation

Tested against a real Hermes install (~/.hermes/) with skills under categorized directories and symlinked user skills. Four skills evaluated:

| Skill | Profile | Holdout lift |
|-------|---------|-------------|
| messaging-channel-formatting | style/format | +55.5% |
| plan | process + rubric | +34.1% |
| hermes-remote-access | factual procedure | −0.5% |
| architecture-diagram | visual layout | (interrupted, plateau at iter 2) |

Iteration budget of 3 is sufficient — most runs plateau by iter 4+. Wall time scales with judge-prompt complexity, not skill body size.

## Commits

Available at `bob0x-ai/hermes-agent-self-evolution` (fork), commit `b1db7ad` contains all six fixes.

Happy to submit a PR for fixes 1–5 if there's interest.