### PR TITLE
fix(importers): read Hermes session history from state.db (SQLite), not dead JSON path

### DIFF
--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -332,22 +332,60 @@ def _parse_copilot_events(
 
 
 class HermesSessionImporter:
-    """Import conversations from Hermes Agent session files.
+    """Import conversations from Hermes Agent session history.
 
-    Hermes stores session transcripts as JSON files in ~/.hermes/sessions/.
-    Each file contains an OpenAI-format message list with user, assistant,
-    and tool messages — providing richer signal than Claude Code (user-only)
-    or Copilot (user+assistant without tool context).
+    Modern Hermes stores all session transcripts in a SQLite database
+    (``state.db``) with a ``messages`` table (role/content/session_id/timestamp)
+    — NOT as per-session JSON files. Older/alternate installs may still expose
+    JSON files under ``<hermes_home>/sessions/*.json``. This importer reads the
+    SQLite store first (the current, canonical location) and falls back to the
+    legacy JSON layout so both work.
 
-    This mines user messages paired with the assistant's final response,
-    giving the LLM judge both the task and how it was actually handled.
+    It mines user messages paired with the assistant's next response (skipping
+    intervening tool messages), giving the LLM judge both the task and how it
+    was actually handled — richer signal than Claude Code (user-only) or
+    Copilot (user+assistant, no tool context).
     """
 
+    # Legacy JSON layout (kept for back-compat / non-standard installs).
     SESSION_DIR = Path.home() / ".hermes" / "sessions"
 
     @staticmethod
+    def _resolve_state_db() -> Optional[Path]:
+        """Locate the Hermes SQLite state store across platforms.
+
+        Priority:
+          1. ``HERMES_STATE_DB`` env var (explicit override)
+          2. ``HERMES_HOME``/state.db if HERMES_HOME is set
+          3. Windows: ``%LOCALAPPDATA%/hermes/state.db`` (and the common
+             ``~/AppData/Local/hermes/state.db``)
+          4. ``~/.hermes/state.db`` (Linux/macOS standard install)
+        """
+        import os
+
+        candidates = []
+        env_db = os.getenv("HERMES_STATE_DB")
+        if env_db:
+            candidates.append(Path(env_db).expanduser())
+        env_home = os.getenv("HERMES_HOME")
+        if env_home:
+            candidates.append(Path(env_home).expanduser() / "state.db")
+        local_appdata = os.getenv("LOCALAPPDATA")
+        if local_appdata:
+            candidates.append(Path(local_appdata) / "hermes" / "state.db")
+        candidates.append(Path.home() / "AppData" / "Local" / "hermes" / "state.db")
+        candidates.append(Path.home() / ".hermes" / "state.db")
+
+        for db_path in candidates:
+            if db_path.exists():
+                return db_path
+        return None
+
+    @staticmethod
     def extract_messages(limit: int = 0) -> list[dict]:
-        """Read user/assistant pairs from Hermes session files.
+        """Read user/assistant pairs from the Hermes state store.
+
+        Tries the SQLite ``state.db`` first, then the legacy JSON layout.
 
         Args:
             limit: Maximum messages to return (0 = no limit).
@@ -356,6 +394,71 @@ class HermesSessionImporter:
             List of dicts with keys: source, task_input, assistant_response,
             session_id.
         """
+        db_path = HermesSessionImporter._resolve_state_db()
+        if db_path is not None:
+            msgs = HermesSessionImporter._extract_from_sqlite(db_path, limit)
+            if msgs:
+                return msgs
+        # Fall back to the legacy per-session JSON layout.
+        return HermesSessionImporter._extract_from_json(limit)
+
+    @staticmethod
+    def _extract_from_sqlite(db_path: Path, limit: int = 0) -> list[dict]:
+        """Mine user→assistant pairs from the messages table of state.db.
+
+        Walks each session's messages in order, pairing every user message
+        with the next assistant response (skipping tool/system messages). Uses
+        a read-only connection so a live Hermes process holding the DB is never
+        disturbed.
+        """
+        import sqlite3
+
+        messages: list[dict] = []
+        try:
+            # Read-only, immutable-friendly connection; never writes or locks.
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        except sqlite3.Error:
+            return []
+
+        try:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            # Order by session, then message id (chronological within session).
+            cur.execute(
+                "SELECT session_id, role, content FROM messages "
+                "WHERE role IN ('user','assistant') AND content IS NOT NULL "
+                "ORDER BY session_id, id"
+            )
+            pending_user: Optional[str] = None
+            for row in cur:
+                role = row["role"]
+                content = row["content"] or ""
+                if role == "user":
+                    # A new user turn; the previous unpaired user msg is dropped.
+                    text = content.strip()
+                    pending_user = text if len(text) >= 10 and not _contains_secret(text) else None
+                elif role == "assistant" and pending_user is not None:
+                    resp = content.strip()
+                    if resp and not _contains_secret(resp):
+                        messages.append({
+                            "source": "hermes",
+                            "task_input": pending_user,
+                            "assistant_response": resp,
+                            "session_id": row["session_id"],
+                        })
+                        if limit and len(messages) >= limit:
+                            break
+                    pending_user = None
+        except sqlite3.Error:
+            return messages
+        finally:
+            conn.close()
+
+        return messages
+
+    @staticmethod
+    def _extract_from_json(limit: int = 0) -> list[dict]:
+        """Legacy path: read user/assistant pairs from <hermes>/sessions/*.json."""
         if not HermesSessionImporter.SESSION_DIR.exists():
             return []
 

--- a/tests/core/test_external_importers.py
+++ b/tests/core/test_external_importers.py
@@ -468,6 +468,16 @@ class TestCopilotHelpers:
 
 
 class TestHermesSessionImporter:
+    """Legacy JSON-layout path. state.db resolver is neutralized so these
+    exercise the fallback (_extract_from_json) in isolation."""
+
+    @pytest.fixture(autouse=True)
+    def _no_state_db(self, monkeypatch):
+        # Force the SQLite resolver to find nothing so the JSON fallback runs.
+        monkeypatch.setattr(
+            HermesSessionImporter, "_resolve_state_db", staticmethod(lambda: None)
+        )
+
     def test_parses_session_json(self, tmp_path):
         session = {
             "session_id": "test-session",
@@ -508,7 +518,7 @@ class TestHermesSessionImporter:
     def test_filters_secrets(self, tmp_path):
         session = {
             "messages": [
-                {"role": "user", "content": "Set ANTHROPIC_API_KEY=sk-ant-api03-xyz in the env"},
+                {"role": "user", "content": "Set ANTHROPIC_API_KEY=«redacted:sk-…» in the env"},
                 {"role": "assistant", "content": "Done."},
             ],
         }
@@ -554,6 +564,110 @@ class TestHermesSessionImporter:
         with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
             msgs = HermesSessionImporter.extract_messages(limit=3)
         assert len(msgs) == 3
+
+
+class TestHermesSessionImporterSQLite:
+    """SQLite state.db path — the modern, canonical Hermes session store."""
+
+    @staticmethod
+    def _make_db(path, rows):
+        """rows: list of (session_id, role, content) in insertion order."""
+        import sqlite3
+        conn = sqlite3.connect(str(path))
+        conn.execute(
+            "CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "session_id TEXT, role TEXT, content TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO messages (session_id, role, content) VALUES (?,?,?)", rows
+        )
+        conn.commit()
+        conn.close()
+
+    def test_pairs_user_assistant_skipping_tools(self, tmp_path, monkeypatch):
+        db = tmp_path / "state.db"
+        self._make_db(db, [
+            ("s1", "user", "Fix the bug in auth.py"),
+            ("s1", "assistant", None),          # tool-call turn (no content)
+            ("s1", "tool", "file contents"),
+            ("s1", "assistant", "I found the issue and fixed it."),
+            ("s1", "user", "Now run the tests"),
+            ("s1", "assistant", "All 42 tests passed."),
+        ])
+        monkeypatch.setattr(HermesSessionImporter, "_resolve_state_db", staticmethod(lambda: db))
+        msgs = HermesSessionImporter.extract_messages()
+        assert len(msgs) == 2
+        assert msgs[0]["task_input"] == "Fix the bug in auth.py"
+        assert msgs[0]["assistant_response"] == "I found the issue and fixed it."
+        assert msgs[0]["source"] == "hermes"
+        assert msgs[0]["session_id"] == "s1"
+        assert msgs[1]["task_input"] == "Now run the tests"
+
+    def test_skips_short_user_messages(self, tmp_path, monkeypatch):
+        db = tmp_path / "state.db"
+        self._make_db(db, [
+            ("s1", "user", "hi"),
+            ("s1", "assistant", "Hello!"),
+        ])
+        monkeypatch.setattr(HermesSessionImporter, "_resolve_state_db", staticmethod(lambda: db))
+        assert HermesSessionImporter.extract_messages() == []
+
+    def test_filters_secrets(self, tmp_path, monkeypatch):
+        db = tmp_path / "state.db"
+        self._make_db(db, [
+            ("s1", "user", "Set ANTHROPIC_API_KEY=«redacted» please here now"),
+            ("s1", "assistant", "Done."),
+        ])
+        monkeypatch.setattr(HermesSessionImporter, "_resolve_state_db", staticmethod(lambda: db))
+        # env var name ANTHROPIC_API_KEY triggers secret filter → dropped
+        assert HermesSessionImporter.extract_messages() == []
+
+    def test_respects_limit(self, tmp_path, monkeypatch):
+        db = tmp_path / "state.db"
+        rows = []
+        for i in range(10):
+            rows.append(("s1", "user", f"Message number {i} with enough text here"))
+            rows.append(("s1", "assistant", f"Reply number {i}"))
+        self._make_db(db, rows)
+        monkeypatch.setattr(HermesSessionImporter, "_resolve_state_db", staticmethod(lambda: db))
+        assert len(HermesSessionImporter.extract_messages(limit=3)) == 3
+
+    def test_unpaired_user_dropped(self, tmp_path, monkeypatch):
+        db = tmp_path / "state.db"
+        self._make_db(db, [
+            ("s1", "user", "A question with no assistant reply following it"),
+            ("s1", "user", "Another question that does get answered here"),
+            ("s1", "assistant", "Here is the answer."),
+        ])
+        monkeypatch.setattr(HermesSessionImporter, "_resolve_state_db", staticmethod(lambda: db))
+        msgs = HermesSessionImporter.extract_messages()
+        assert len(msgs) == 1
+        assert msgs[0]["task_input"] == "Another question that does get answered here"
+
+    def test_sqlite_preferred_over_json(self, tmp_path, monkeypatch):
+        """When state.db yields results, the JSON fallback is not used."""
+        db = tmp_path / "state.db"
+        self._make_db(db, [
+            ("s1", "user", "A real question from the SQLite store"),
+            ("s1", "assistant", "A real answer."),
+        ])
+        # A JSON dir that would yield different data — must be ignored.
+        json_dir = tmp_path / "sessions"
+        json_dir.mkdir()
+        (json_dir / "s.json").write_text(json.dumps(
+            {"messages": [{"role": "user", "content": "JSON path should not run"},
+                          {"role": "assistant", "content": "nope"}]}))
+        monkeypatch.setattr(HermesSessionImporter, "_resolve_state_db", staticmethod(lambda: db))
+        with patch.object(HermesSessionImporter, "SESSION_DIR", json_dir):
+            msgs = HermesSessionImporter.extract_messages()
+        assert len(msgs) == 1
+        assert msgs[0]["task_input"] == "A real question from the SQLite store"
+
+    def test_resolver_finds_nothing_returns_empty(self, tmp_path, monkeypatch):
+        """No state.db and no JSON dir → empty, no crash."""
+        monkeypatch.setattr(HermesSessionImporter, "_resolve_state_db", staticmethod(lambda: None))
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path / "nonexistent"):
+            assert HermesSessionImporter.extract_messages() == []
 
 
 # ── Skill Name Matching ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`HermesSessionImporter` (used by `--eval-source sessiondb`) reads session
transcripts from `~/.hermes/sessions/*.json`. **Modern Hermes doesn't store
sessions there** — it keeps everything in a SQLite database (`state.db`) with a
`messages` table. As a result, on any current Hermes install the importer
finds **zero** Hermes messages and silently contributes nothing to the eval
dataset. The code path exists but has never worked against a real, current
Hermes install (the docstring even asserts the wrong location).

Verified on a current install: the old path returned 0 messages; the fix
returns 600 real user→assistant pairs from the same machine.

## Fix

`HermesSessionImporter.extract_messages()` now reads the SQLite `state.db`
first, and falls back to the legacy `sessions/*.json` layout when no DB is
found. Fully backward compatible — installs still on the JSON layout keep
working unchanged.

- **`_resolve_state_db()`** — cross-platform DB discovery, in priority order:
  1. `HERMES_STATE_DB` env override
  2. `HERMES_HOME/state.db`
  3. Windows `%LOCALAPPDATA%/hermes/state.db` (and `~/AppData/Local/hermes/state.db`)
  4. `~/.hermes/state.db` (Linux/macOS)
- **`_extract_from_sqlite()`** — opens the DB **read-only** (`mode=ro`, never
  writes or locks a live Hermes process), walks each session's messages in
  order, and pairs each user message with the next assistant response
  (skipping tool/system turns). Same secret-filtering and min-length rules as
  the other importers.
- **`_extract_from_json()`** — the original logic, preserved verbatim as the
  fallback.

## Tests

- Existing JSON-layout tests retained; a small autouse fixture neutralizes the
  new SQLite resolver so they still exercise the fallback in isolation.
- New `TestHermesSessionImporterSQLite` covers: user→assistant pairing across
  tool turns, short-message skipping, secret filtering, `limit`, unpaired-user
  drop, SQLite-preferred-over-JSON precedence, and the empty/no-store case.
- Full suite green (the one unrelated pre-existing failure is a Unix-only
  hardcoded-path test, untouched here).

## Privacy note

No session content is included anywhere in this change. Secret-bearing messages
are filtered out before they can enter a dataset, and the DB is only ever
opened read-only.
