### PR TITLE
Fix DSPy compatibility and report material skill diffs honestly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ datasets/**/*.json
 
 # Evolution snapshots
 snapshots/
+output/
 *.pkl
 
 # IDE

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -104,11 +104,13 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None, pred_name=None, pred_trace=None):
     """DSPy-compatible metric function for skill optimization.
 
-    This is what gets passed to dspy.GEPA(metric=...).
-    Returns a float 0-1 score.
+    Supports both classic DSPy metrics (example, prediction, trace) and the
+    current GEPA feedback-metric shape
+    (gold, pred, trace, pred_name, pred_trace). For GEPA, return structured
+    feedback so reflection has something useful to optimize against.
     """
     # The prediction should have an 'output' field with the agent's response
     agent_output = getattr(prediction, "output", "") or ""
@@ -116,24 +118,34 @@ def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, tra
     task = getattr(example, "task_input", "") or ""
 
     if not agent_output.strip():
-        return 0.0
+        score = 0.0
+    else:
+        # Quick heuristic scoring (for speed during optimization)
+        # Full LLM-as-judge scoring is expensive — use it selectively
+        score = 0.5  # Base score for non-empty output
 
-    # Quick heuristic scoring (for speed during optimization)
-    # Full LLM-as-judge scoring is expensive — use it selectively
-    score = 0.5  # Base score for non-empty output
+        # Check if key phrases from expected behavior appear
+        expected_lower = expected.lower()
+        output_lower = agent_output.lower()
 
-    # Check if key phrases from expected behavior appear
-    expected_lower = expected.lower()
-    output_lower = agent_output.lower()
+        # Simple keyword overlap as a fast proxy
+        expected_words = set(expected_lower.split())
+        output_words = set(output_lower.split())
+        if expected_words:
+            overlap = len(expected_words & output_words) / len(expected_words)
+            score = 0.3 + (0.7 * overlap)
 
-    # Simple keyword overlap as a fast proxy
-    expected_words = set(expected_lower.split())
-    output_words = set(output_lower.split())
-    if expected_words:
-        overlap = len(expected_words & output_words) / len(expected_words)
-        score = 0.3 + (0.7 * overlap)
+        score = min(1.0, max(0.0, score))
 
-    return min(1.0, max(0.0, score))
+    if pred_name is not None or pred_trace is not None:
+        feedback = (
+            f"Score {score:.3f} for task: {task[:300]}\n"
+            f"Expected behavior: {expected[:600]}\n"
+            f"Observed output: {agent_output[:600]}"
+        )
+        return score, feedback
+
+    return score
 
 
 def _parse_score(value) -> float:

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -227,6 +227,8 @@ def evolve(
     improvement = avg_evolved - avg_baseline
 
     # ── 9. Report results ───────────────────────────────────────────────
+    material_diff = evolved_full != skill["raw"]
+
     table = Table(title="Evolution Results")
     table.add_column("Metric", style="bold")
     table.add_column("Baseline", justify="right")
@@ -248,6 +250,7 @@ def evolve(
     )
     table.add_row("Time", "", f"{elapsed:.1f}s", "")
     table.add_row("Iterations", "", str(iterations), "")
+    table.add_row("Material Diff", "", "yes" if material_diff else "no", "")
 
     console.print()
     console.print(table)
@@ -280,14 +283,18 @@ def evolve(
         "holdout_examples": len(dataset.holdout),
         "elapsed_seconds": elapsed,
         "constraints_passed": all_pass,
+        "material_diff": material_diff,
     }
     (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
 
     console.print(f"\n  Output saved to {output_dir}/")
 
-    if improvement > 0:
+    if improvement > 0 and material_diff:
         console.print(f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement/max(0.001, avg_baseline)*100:+.1f}%)[/bold green]")
         console.print(f"  Review the diff: diff {output_dir}/baseline_skill.md {output_dir}/evolved_skill.md")
+    elif improvement > 0 and not material_diff:
+        console.print(f"\n[yellow]⚠ Eval score improved by {improvement:+.3f}, but the saved skill text is identical to baseline.[/yellow]")
+        console.print("  Treat this as optimizer-instruction improvement only; do not deploy as a skill change.")
     else:
         console.print(f"\n[yellow]⚠ Evolution did not improve skill (change: {improvement:+.3f})[/yellow]")
         console.print("  Try: more iterations, better eval dataset, or different optimizer model")

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -155,7 +155,8 @@ def evolve(
     try:
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
-            max_steps=iterations,
+            max_metric_calls=iterations,
+            reflection_lm=dspy.LM(optimizer_model),
         )
 
         optimized_module = optimizer.compile(

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -33,6 +33,16 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+def has_material_diff(baseline_full: str, evolved_full: str) -> bool:
+    """Return whether the saved SKILL.md candidate differs from baseline.
+
+    Scores can improve because optimizer state changed without producing a
+    deployable skill-file diff. Treat that as non-material so callers do not
+    advertise a deployable improvement when the written artifact is identical.
+    """
+    return evolved_full != baseline_full
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -118,7 +128,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -186,7 +196,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"
@@ -227,7 +237,7 @@ def evolve(
     improvement = avg_evolved - avg_baseline
 
     # ── 9. Report results ───────────────────────────────────────────────
-    material_diff = evolved_full != skill["raw"]
+    material_diff = has_material_diff(skill["raw"], evolved_full)
 
     table = Table(title="Evolution Results")
     table.add_column("Metric", style="bold")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
+    "optuna>=3.0",
 ]
 darwinian = [
     "darwinian-evolver",

--- a/tests/core/test_fitness_metric.py
+++ b/tests/core/test_fitness_metric.py
@@ -1,0 +1,41 @@
+"""Tests for DSPy-compatible fitness metric behavior."""
+
+import dspy
+
+from evolution.core.fitness import skill_fitness_metric
+
+
+def test_skill_fitness_metric_classic_shape_returns_float():
+    example = dspy.Example(
+        task_input="Debug a failing test",
+        expected_behavior="Read the error, reproduce, and verify the fix.",
+    ).with_inputs("task_input")
+    prediction = dspy.Prediction(output="Read the error, reproduce the failure, then verify the fix.")
+
+    score = skill_fitness_metric(example, prediction)
+
+    assert isinstance(score, float)
+    assert 0.0 <= score <= 1.0
+
+
+def test_skill_fitness_metric_gepa_feedback_shape_returns_score_and_feedback():
+    example = dspy.Example(
+        task_input="Debug a failing test",
+        expected_behavior="Read the error, reproduce, and verify the fix.",
+    ).with_inputs("task_input")
+    prediction = dspy.Prediction(output="Read the error, reproduce the failure, then verify the fix.")
+
+    result = skill_fitness_metric(
+        example,
+        prediction,
+        trace=None,
+        pred_name="predict",
+        pred_trace=None,
+    )
+
+    assert isinstance(result, tuple)
+    score, feedback = result
+    assert isinstance(score, float)
+    assert 0.0 <= score <= 1.0
+    assert "Score" in feedback
+    assert "Expected behavior" in feedback

--- a/tests/skills/test_evolve_skill.py
+++ b/tests/skills/test_evolve_skill.py
@@ -1,0 +1,14 @@
+"""Tests for skill evolution reporting helpers."""
+
+from evolution.skills.evolve_skill import has_material_diff
+
+
+def test_has_material_diff_false_for_identical_saved_skill():
+    baseline = "---\nname: test\ndescription: test\n---\n\n# Body\nDo thing."
+    assert has_material_diff(baseline, baseline) is False
+
+
+def test_has_material_diff_true_for_changed_saved_skill():
+    baseline = "---\nname: test\ndescription: test\n---\n\n# Body\nDo thing."
+    evolved = "---\nname: test\ndescription: test\n---\n\n# Body\nDo safer thing."
+    assert has_material_diff(baseline, evolved) is True


### PR DESCRIPTION
# Fix DSPy compatibility and report material skill diffs honestly

## Summary

- Update GEPA optimizer construction for the current DSPy API by using `max_metric_calls` and a dedicated `reflection_lm` instead of the removed `max_steps` argument.
- Add `optuna` to dev dependencies so the MIPROv2 fallback path has its required dependency available.
- Make `skill_fitness_metric` compatible with both classic DSPy metric calls and the current GEPA feedback-metric shape that passes `pred_name` / `pred_trace`.
- Track `material_diff` separately from score improvement so runs do not claim a deployable skill improvement when the saved `SKILL.md` artifact is identical to baseline.
- Validate the full saved skill file, including frontmatter, rather than validating only the Markdown body.
- Ignore generated local `output/` artifacts.

## Why

Current DSPy releases changed the GEPA interface. The existing code path can fail before optimization starts, and even when an optimizer improves internal predictor instructions, the saved `evolved_skill.md` can remain byte-identical to the baseline. In that case, reporting a deployable skill improvement is misleading.

This PR keeps the existing workflow intact while making the result reporting more honest: score changes and material file diffs are reported separately, and the success message only appears when both improve.

## Testing

```bash
python -m pytest tests -q
```

Result:

```text
149 passed, 11 warnings in 3.78s
```

## Notes

This PR intentionally does not add the later safety-gate, review-report, distillation, or golden-rubric work. Those are better as follow-up PRs after this compatibility/reporting foundation lands.
