### PR TITLE
feat(fitness): objective ground-truth verifier for skill evolution (reference: arxiv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ python -m evolution.skills.evolve_skill \
 | **Phase 4** | Tool implementation code | Darwinian Evolver | 🔲 Planned |
 | **Phase 5** | Continuous improvement loop | Automated pipeline | 🔲 Planned |
 
+## Fitness Signals
+
+Evolution is only as trustworthy as the score it optimizes. The pipeline picks the strongest signal available for the target skill:
+
+| Signal | How it scores | Trust |
+|--------|--------------|-------|
+| **Objective verifier** | Checks output against verifiable ground truth (IDs, titles, authors, dates); pure Python, zero API cost per grade | Highest: cannot be gamed by echoing rubric vocabulary |
+| **Keyword overlap** | Lexical overlap between output and rubric text | Fallback only |
+
+Skills with a registered verifier (currently: `arxiv`) evolve against real facts by default. Verifier feedback explains exactly what was wrong ("expected ID 1706.03762, response said 1706.03799"), which is the reflection signal GEPA mutates on.
+
+```bash
+# Objective fitness is picked automatically when a verifier exists
+python -m evolution.skills.evolve_skill --skill arxiv --iterations 10
+
+# Cross-check the verifier's embedded ground truth against the live arXiv API
+python -m evolution.verifiers.arxiv_verifier --validate
+
+# See how the grader scores correct, wrong, and evasive answers
+python -m evolution.verifiers.arxiv_verifier --demo
+```
+
+To add a verifier for another skill, subclass `Verifier` in `evolution/verifiers/`, decorate it with `@register_verifier`, and implement `build_dataset()` plus `score()`.
+
 ## Engines
 
 | Engine | What It Does | License |

--- a/evolution/core/admission.py
+++ b/evolution/core/admission.py
@@ -1,0 +1,239 @@
+"""The admission rule: when is an evolved artifact actually better?
+
+Comparing two mean scores and deploying whenever the second is larger treats
+every difference as real. On the eval sets this pipeline can afford, most are
+not. A six-example holdout is the case that makes this concrete: the best
+possible one-sided paired result short of a clean sweep, four losses out of
+four, lands at p = 0.0625, and five aligned losses are needed to reach 0.05 at
+p = 0.03125. Nothing weaker than a near-unanimous flip can clear the bar, so a
+rule that admits on ``mean_after > mean_before`` is not measuring evidence, it
+is measuring noise with a sign.
+
+So admission is declared, and it is paired throughout:
+
+  1. The deployable artifact actually changed, where the caller checks that.
+  2. The paired test finds a significant improvement at *alpha*.
+  3. The paired test does not find a significant regression at *alpha*.
+
+Point 1 is optional because not every caller can answer it. ``material_diff``
+defaults to ``None``, meaning the question was not asked, and the verdict then
+records ``None`` rather than claiming an unchecked ``True``. A caller that does
+compare the artifacts passes the answer and gets it enforced.
+
+**Point 2 replaces "the mean went up".** That is the whole change. A positive
+delta with p = 0.5 is not an improvement, and this module will not call it one.
+
+**Power is reported, never assumed.** :func:`min_detectable_paired_shift` gives
+the smallest shift the sample size could possibly have called significant. It
+does not gate: a result that reached significance did so on evidence, and
+refusing it because some *smaller* effect would have been invisible would be
+backwards. What the power number does is qualify the non-regression claim in
+point 3. On six examples nothing under an 83.3% collapse could ever have been
+detected, so "no significant regression" there means "no regression large
+enough to be visible", which is a much weaker statement than it reads as, and
+the verdict says so rather than leaving the operator to infer it.
+
+**Binary when there is ground truth, continuous otherwise.** An objective
+verifier knows whether each answer was actually right, so the outcomes are
+binary and McNemar's exact test applies: it conditions on the examples the two
+versions disagreed about, which are the only ones carrying information about
+which is better. Without ground truth there is no defensible threshold to
+binarize a judge score at, so the continuous path uses the signed-rank test and
+a paired bootstrap instead. Both paths come from :mod:`evolution.core.stats`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from evolution.core.stats import (
+    PairedBinary,
+    PairedContinuous,
+    compare_paired_binary,
+    compare_paired_continuous,
+    mcnemar_exact,
+    min_detectable_paired_shift,
+)
+
+__all__ = [
+    "DEFAULT_ALPHA",
+    "DEFAULT_TOLERANCE",
+    "AdmissionVerdict",
+    "evaluate_admission",
+]
+
+#: Significance level for both the improvement and the regression test.
+DEFAULT_ALPHA = 0.05
+
+#: The regression size the operator wants the gate to be able to catch. Used
+#: only to decide whether the holdout was ever large enough to catch it, which
+#: is reported alongside the verdict rather than silently assumed.
+DEFAULT_TOLERANCE = 0.05
+
+
+@dataclass(frozen=True)
+class AdmissionVerdict:
+    """Whether a candidate may be deployed, and the evidence for that."""
+
+    admitted: bool
+    reason: str
+    n: int
+    delta: float
+    p_improvement: float
+    p_regression: float
+    significant_improvement: bool
+    significant_regression: bool
+    min_detectable_shift: float
+    underpowered: bool
+    #: True/False when the caller compared the artifacts, None when it did not
+    #: ask. None never blocks admission, and is reported as "not assessed"
+    #: rather than as a passing check.
+    material_diff: bool | None
+    alpha: float = DEFAULT_ALPHA
+    tolerance: float = DEFAULT_TOLERANCE
+    test: str = ""
+    binary: PairedBinary | None = None
+    continuous: PairedContinuous | None = None
+
+    @property
+    def power_note(self) -> str:
+        """How much of a shift this holdout could ever have resolved."""
+        if not self.underpowered:
+            return (
+                f"{self.n} examples can resolve a shift of "
+                f"{self.min_detectable_shift:.1%}, within the {self.tolerance:.1%} tolerance."
+            )
+        return (
+            f"Underpowered: {self.n} examples cannot resolve anything smaller "
+            f"than {self.min_detectable_shift:.1%}, so a {self.tolerance:.1%} "
+            "tolerance is not being enforced by evidence."
+        )
+
+    def describe(self) -> str:
+        """One line carrying the verdict, the test used, and the evidence."""
+        comparison = self.binary or self.continuous
+        detail = comparison.describe() if comparison is not None else f"n={self.n}"
+        icon = "✓" if self.admitted else "✗"
+        return f"{icon} {self.reason} [{self.test}] {detail}"
+
+    def to_dict(self) -> dict:
+        """Serialise the verdict for a run's metrics file."""
+        payload = {
+            "admitted": self.admitted,
+            "reason": self.reason,
+            "test": self.test,
+            "n": self.n,
+            "delta": round(self.delta, 6),
+            "alpha": self.alpha,
+            "tolerance": self.tolerance,
+            "p_improvement": round(self.p_improvement, 6),
+            "p_regression": round(self.p_regression, 6),
+            "significant_improvement": self.significant_improvement,
+            "significant_regression": self.significant_regression,
+            "min_detectable_shift": round(self.min_detectable_shift, 6),
+            "underpowered": self.underpowered,
+            "material_diff": self.material_diff,
+        }
+        if self.binary is not None:
+            payload["paired_binary"] = self.binary.to_dict()
+        if self.continuous is not None:
+            payload["paired_continuous"] = self.continuous.to_dict()
+        return payload
+
+
+def evaluate_admission(
+    baseline_scores: Sequence[float],
+    candidate_scores: Sequence[float],
+    *,
+    material_diff: bool | None = None,
+    baseline_correct: Sequence[bool] | None = None,
+    candidate_correct: Sequence[bool] | None = None,
+    alpha: float = DEFAULT_ALPHA,
+    tolerance: float = DEFAULT_TOLERANCE,
+) -> AdmissionVerdict:
+    """Decide whether a candidate is admissible on paired holdout results.
+
+    ``baseline_scores`` and ``candidate_scores`` must be aligned: index i is
+    the same holdout example in both, or the pairing is meaningless.
+
+    Pass ``baseline_correct``/``candidate_correct`` when objective ground truth
+    is available. The verdict is then decided by McNemar's exact test on those
+    outcomes, and the continuous comparison is still computed and attached for
+    the report. Without them the signed-rank test on the scores decides.
+    """
+    if len(baseline_scores) != len(candidate_scores):
+        raise ValueError(
+            f"paired admission needs equal lengths, got "
+            f"{len(baseline_scores)} and {len(candidate_scores)}"
+        )
+
+    n = len(baseline_scores)
+    continuous = compare_paired_continuous(
+        baseline_scores, candidate_scores, alpha=alpha
+    )
+
+    binary: PairedBinary | None = None
+    if baseline_correct is not None and candidate_correct is not None:
+        binary = compare_paired_binary(
+            baseline_correct, candidate_correct, alpha=alpha
+        )
+
+    if binary is not None:
+        test = "McNemar exact (paired binary)"
+        delta = binary.delta
+        improved = binary.significant_improvement
+        regressed = binary.significant_regression
+        # One-sided in each direction: the mirror of ``p_worse``.
+        p_improvement = mcnemar_exact(
+            binary.baseline_only, binary.candidate_only, "better"
+        )
+        p_regression = binary.p_worse
+    else:
+        test = "Wilcoxon signed-rank (paired continuous)"
+        delta = continuous.delta
+        improved = continuous.significant_improvement
+        regressed = continuous.significant_regression
+        # The signed-rank p is two-sided; direction comes from the properties
+        # above, so the same p describes both claims.
+        p_improvement = continuous.wilcoxon_p
+        p_regression = continuous.wilcoxon_p
+
+    shift = min_detectable_paired_shift(n, alpha) if n > 0 else 1.0
+    underpowered = shift > abs(tolerance)
+
+    if n == 0:
+        admitted, reason = False, "No holdout examples, so nothing was measured"
+    elif material_diff is False:
+        admitted, reason = False, "The deployable artifact did not change"
+    elif regressed:
+        admitted, reason = False, "The candidate significantly regressed"
+    elif not improved:
+        admitted, reason = False, (
+            f"No significant improvement (delta {delta:+.3f}, p={p_improvement:.3f} "
+            f"at alpha {alpha})"
+        )
+    else:
+        admitted, reason = True, (
+            f"Significant improvement (delta {delta:+.3f}, p={p_improvement:.3f} "
+            f"at alpha {alpha})"
+        )
+
+    return AdmissionVerdict(
+        admitted=admitted,
+        reason=reason,
+        n=n,
+        delta=delta,
+        p_improvement=p_improvement,
+        p_regression=p_regression,
+        significant_improvement=improved,
+        significant_regression=regressed,
+        min_detectable_shift=shift,
+        underpowered=underpowered,
+        material_diff=material_diff,
+        alpha=alpha,
+        tolerance=tolerance,
+        test=test,
+        binary=binary,
+        continuous=continuous,
+    )

--- a/evolution/core/stats.py
+++ b/evolution/core/stats.py
@@ -236,7 +236,17 @@ def wilson_interval(successes: int, n: int, confidence: float = 0.95) -> Interva
     denom = 1.0 + z * z / n
     centre = (p + z * z / (2 * n)) / denom
     half = (z / denom) * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))
-    return Interval(p, max(0.0, centre - half), min(1.0, centre + half), confidence)
+    # At the boundaries the answer is known exactly: with no successes the rate
+    # could be zero, and with no failures it could be one. Leaving that to
+    # ``centre -/+ half`` only lands on it when the arithmetic happens to
+    # cancel. It often does not: at n = 10 the lower bound comes back as
+    # 2.8e-17, so ``contains(0.0)`` is False for a sample of ten misses, and 43
+    # of the first 200 sample sizes miss zero this way while 60 miss one. The
+    # clamps below cannot fire on a non-boundary count, where centre -/+ half
+    # is strictly inside (0, 1).
+    low = 0.0 if successes <= 0 else max(0.0, centre - half)
+    high = 1.0 if successes >= n else min(1.0, centre + half)
+    return Interval(p, low, high, confidence)
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/evolution/core/stats.py
+++ b/evolution/core/stats.py
@@ -1,0 +1,1090 @@
+"""Statistics for deciding whether an evolved variant is actually better.
+
+Every comparison this pipeline makes is **paired**: the baseline and the
+candidate are evaluated on the identical example set, so each example yields a
+matched pair of outcomes. That structure is the single most useful fact
+available, and discarding it is expensive in both directions.
+
+* Comparing two independent rates when the data are paired throws away the
+  pairing and loses power. The variance of a paired difference depends only on
+  the examples where the two versions *disagreed*; examples both got right, or
+  both got wrong, carry no information about which is better.
+* Comparing point estimates against a fixed tolerance models no noise at all.
+  With 10 examples, a selection rate of 0.8 has a standard error of 0.126, so a
+  swing of 12 points is one standard error of nothing happening.
+
+So the tests here are paired throughout: McNemar's exact test for binary
+outcomes, Wilcoxon signed-rank and a seeded paired bootstrap for continuous
+scores, and ordinary least squares with a real t-test on the slope for trends.
+
+**Power is reported, not assumed.** :func:`min_detectable_paired_shift` answers
+the question a small eval set makes unavoidable: given this many examples, what
+is the smallest regression that could possibly have reached significance? When
+that number is larger than the tolerance being enforced, the gate cannot do its
+job, and saying so is more useful than returning a confident pass.
+
+**Why an intersection-union test, and why no multiplicity correction.**
+PLAN.md's requirement for Phase 2 is that *no individual tool's selection rate
+regresses*. Accepting a candidate therefore means accepting a conjunction of
+per-tool claims. Under the intersection-union principle, a conjunction of
+claims each tested at level alpha is itself valid at level alpha, so no
+Bonferroni or Benjamini-Hochberg adjustment is applied or needed. Correcting
+here would make the gate more permissive as the tool count grows, which is
+exactly backwards for a safety gate.
+
+Standard library only: no numpy, no scipy. The incomplete beta function is
+implemented directly because a Student-t tail is needed and stdlib has none.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from statistics import NormalDist
+from typing import Optional, Sequence
+
+__all__ = [
+    "Interval",
+    "wilson_interval",
+    "mcnemar_exact",
+    "PairedBinary",
+    "compare_paired_binary",
+    "min_detectable_paired_shift",
+    "paired_bootstrap_ci",
+    "wilcoxon_signed_rank",
+    "signed_rank_direction",
+    "PairedContinuous",
+    "compare_paired_continuous",
+    "OLSTrend",
+    "ols_trend",
+    "cohens_h",
+    "cohens_d",
+    "chance_accuracy",
+    "holm_adjust",
+    "mann_kendall",
+    "student_t_sf",
+    "binomial_sf",
+    "binomial_cdf",
+]
+
+_NORM = NormalDist()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Distribution primitives
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _z_for(confidence: float) -> float:
+    """Two-sided critical value for a normal at *confidence* (e.g. 0.95)."""
+    confidence = min(max(confidence, 1e-6), 1 - 1e-9)
+    return _NORM.inv_cdf(1 - (1 - confidence) / 2)
+
+
+def binomial_cdf(k: int, n: int, p: float = 0.5) -> float:
+    """Exact P(X <= k) for X ~ Binomial(n, p). Exact, not approximated.
+
+    Used for McNemar's conditional test, where p is always 0.5 and the counts
+    are small enough that exactness matters more than speed.
+    """
+    if n <= 0:
+        return 1.0
+    if k < 0:
+        return 0.0
+    if k >= n:
+        return 1.0
+    return sum(math.comb(n, i) * p**i * (1 - p) ** (n - i) for i in range(k + 1))
+
+
+def binomial_sf(k: int, n: int, p: float = 0.5) -> float:
+    """Exact P(X >= k) for X ~ Binomial(n, p)."""
+    if n <= 0:
+        return 1.0
+    if k <= 0:
+        return 1.0
+    if k > n:
+        return 0.0
+    return sum(math.comb(n, i) * p**i * (1 - p) ** (n - i) for i in range(k, n + 1))
+
+
+def _betacf(a: float, b: float, x: float, iterations: int = 300) -> float:
+    """Continued fraction for the incomplete beta function (Lentz's method)."""
+    tiny = 1e-30
+    qab, qap, qam = a + b, a + 1.0, a - 1.0
+    c = 1.0
+    d = 1.0 - qab * x / qap
+    if abs(d) < tiny:
+        d = tiny
+    d = 1.0 / d
+    h = d
+    for m in range(1, iterations + 1):
+        m2 = 2 * m
+        aa = m * (b - m) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if abs(d) < tiny:
+            d = tiny
+        c = 1.0 + aa / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        h *= d * c
+        aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if abs(d) < tiny:
+            d = tiny
+        c = 1.0 + aa / c
+        if abs(c) < tiny:
+            c = tiny
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < 3e-16:
+            break
+    return h
+
+
+def _betainc(a: float, b: float, x: float) -> float:
+    """Regularized incomplete beta I_x(a, b)."""
+    if x <= 0.0:
+        return 0.0
+    if x >= 1.0:
+        return 1.0
+    front = math.exp(
+        math.lgamma(a + b) - math.lgamma(a) - math.lgamma(b)
+        + a * math.log(x) + b * math.log1p(-x)
+    )
+    if x < (a + 1.0) / (a + b + 2.0):
+        return front * _betacf(a, b, x) / a
+    return 1.0 - math.exp(
+        math.lgamma(a + b) - math.lgamma(a) - math.lgamma(b)
+        + b * math.log1p(-x) + a * math.log(x)
+    ) * _betacf(b, a, 1.0 - x) / b
+
+
+def student_t_sf(t: float, df: float) -> float:
+    """Upper tail P(T > t) for Student's t with *df* degrees of freedom."""
+    if df <= 0:
+        return float("nan")
+    if math.isinf(t):
+        return 0.0 if t > 0 else 1.0
+    two_sided = _betainc(df / 2.0, 0.5, df / (df + t * t))
+    return two_sided / 2.0 if t > 0 else 1.0 - two_sided / 2.0
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Intervals
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Interval:
+    """A confidence interval on a point estimate.
+
+    ``estimable`` is False when the sample cannot support an interval at all -
+    for example a bootstrap over differences that are all identical, which has
+    no spread to resample. A zero-width interval is then a statement about the
+    sample, not a claim of certainty, and callers must not print it as one.
+    """
+
+    point: float
+    low: float
+    high: float
+    confidence: float = 0.95
+    estimable: bool = True
+
+    @property
+    def width(self) -> float:
+        """Distance from the low bound to the high bound."""
+        return self.high - self.low
+
+    def contains(self, value: float) -> bool:
+        """True when *value* falls inside the interval, endpoints included."""
+        return self.low <= value <= self.high
+
+    def describe(self, as_percent: bool = True) -> str:
+        """The point estimate with its interval, or a note when no interval is estimable."""
+        if not self.estimable:
+            body = f"{self.point:.1%}" if as_percent else f"{self.point:.3f}"
+            return f"{body} [interval not estimable from this sample]"
+        if as_percent:
+            return f"{self.point:.1%} [{self.low:.1%}, {self.high:.1%}]"
+        return f"{self.point:.3f} [{self.low:.3f}, {self.high:.3f}]"
+
+    def to_dict(self) -> dict:
+        """Serialise the interval for the run artifacts."""
+        return {
+            "point": round(self.point, 6),
+            "low": round(self.low, 6),
+            "high": round(self.high, 6),
+            "confidence": self.confidence,
+            "estimable": self.estimable,
+        }
+
+
+def wilson_interval(successes: int, n: int, confidence: float = 0.95) -> Interval:
+    """Wilson score interval for a binomial proportion.
+
+    Preferred over the Wald interval because eval sets here are small and rates
+    sit near the boundaries, exactly where Wald misbehaves: at 10/10 successes
+    Wald reports the absurd [1.0, 1.0], while Wilson reports [0.72, 1.0].
+    """
+    if n <= 0:
+        return Interval(0.0, 0.0, 1.0, confidence)
+    z = _z_for(confidence)
+    p = successes / n
+    denom = 1.0 + z * z / n
+    centre = (p + z * z / (2 * n)) / denom
+    half = (z / denom) * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))
+    return Interval(p, max(0.0, centre - half), min(1.0, centre + half), confidence)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Paired binary outcomes (McNemar)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def mcnemar_exact(b: int, c: int, alternative: str = "two-sided") -> float:
+    """Exact McNemar test p-value on discordant counts.
+
+    *b* is the number of examples the baseline got right and the candidate got
+    wrong; *c* is the reverse. Concordant examples are uninformative and are
+    correctly excluded: under the null the b + c discordant pairs split like
+    fair coin flips, so the test is an exact binomial on that conditional.
+
+    ``alternative="worse"`` is the one-sided test for the candidate having
+    regressed, which is the direction a safety gate cares about.
+    """
+    n = b + c
+    if n == 0:
+        return 1.0
+    if alternative == "worse":
+        # P(at least b losses) under a fair split.
+        return binomial_sf(b, n, 0.5)
+    if alternative == "better":
+        return binomial_sf(c, n, 0.5)
+    # Two-sided exact: double the smaller tail, clamped at 1.
+    return min(1.0, 2.0 * binomial_cdf(min(b, c), n, 0.5))
+
+
+def min_detectable_paired_shift(n: int, alpha: float = 0.05) -> float:
+    """Smallest regression an exact paired test could ever call significant.
+
+    The best case for detection is every disagreement pointing the same way. If
+    k of n examples flip against the candidate and none flip for it, the
+    one-sided exact p-value is 0.5**k, so significance needs
+    ``k >= -log2(alpha)``. The answer is that k over n.
+
+    This is the number that makes a small eval set honest. At n = 10 and
+    alpha = 0.05 it is 0.5: nothing short of a fifty point collapse could reach
+    significance, so a 5% tolerance is not being enforced by evidence.
+    """
+    if n <= 0:
+        return 1.0
+    if not 0 < alpha < 1:
+        raise ValueError("alpha must be in (0, 1)")
+    k = math.ceil(-math.log2(alpha))
+    return min(1.0, k / n)
+
+
+@dataclass
+class PairedBinary:
+    """Baseline vs candidate over paired binary outcomes on one population."""
+
+    n: int
+    both_correct: int
+    baseline_only: int  # b: baseline right, candidate wrong
+    candidate_only: int  # c: baseline wrong, candidate right
+    both_wrong: int
+    alpha: float = 0.05
+    confidence: float = 0.95
+
+    @property
+    def baseline_correct(self) -> int:
+        """Examples the baseline got right."""
+        return self.both_correct + self.baseline_only
+
+    @property
+    def candidate_correct(self) -> int:
+        """Examples the candidate got right."""
+        return self.both_correct + self.candidate_only
+
+    @property
+    def baseline_rate(self) -> float:
+        """Baseline accuracy over the paired examples."""
+        return self.baseline_correct / self.n if self.n else 0.0
+
+    @property
+    def candidate_rate(self) -> float:
+        """Candidate accuracy over the paired examples."""
+        return self.candidate_correct / self.n if self.n else 0.0
+
+    @property
+    def delta(self) -> float:
+        """Candidate rate minus baseline rate."""
+        return self.candidate_rate - self.baseline_rate
+
+    @property
+    def discordant(self) -> int:
+        """Examples where exactly one of the two was right.
+
+        These are the only ones McNemar's test uses: agreements carry no
+        information about which is better.
+        """
+        return self.baseline_only + self.candidate_only
+
+    @property
+    def p_worse(self) -> float:
+        """One-sided p for 'the candidate regressed'."""
+        return mcnemar_exact(self.baseline_only, self.candidate_only, "worse")
+
+    @property
+    def p_two_sided(self) -> float:
+        """Two-sided p-value from McNemar's exact conditional test."""
+        return mcnemar_exact(self.baseline_only, self.candidate_only, "two-sided")
+
+    @property
+    def significant_regression(self) -> bool:
+        """True when the candidate is worse at alpha."""
+        return self.p_worse < self.alpha
+
+    @property
+    def significant_improvement(self) -> bool:
+        """True when the candidate is better at alpha."""
+        return mcnemar_exact(self.baseline_only, self.candidate_only, "better") < self.alpha
+
+    def delta_interval(self) -> Interval:
+        """Confidence interval on the paired difference in rates.
+
+        Built conditionally on the discordant pairs rather than from the Wald
+        variance. The Wald form ``(b + c - (c-b)**2/n) / n**2`` collapses to
+        exactly zero whenever every disagreement points the same way, so a
+        candidate that flipped ten out of ten examples in its favour reported a
+        zero-width 95% interval around +100%. That is the same degeneracy this
+        module rejects Wald for in :func:`wilson_interval`, and it is worse
+        here because it appears precisely on the strongest results.
+
+        Conditioning fixes it. With ``m = b + c`` disagreements, the count that
+        went the candidate's way is Binomial(m, pi). A Wilson interval on
+        ``c / m`` maps back to the rate scale through ``(2*pi - 1) * m / n``,
+        which is never zero-width for m > 0. With no disagreements at all there
+        is nothing to condition on, so the discordant *rate* is bounded by a
+        Wilson interval on ``0 / n`` and the difference is bounded symmetrically
+        by it.
+        """
+        if self.n <= 0:
+            return Interval(0.0, 0.0, 0.0, self.confidence, estimable=False)
+
+        b, c, n = self.baseline_only, self.candidate_only, self.n
+        m = b + c
+        d = self.delta
+
+        if m == 0:
+            # No example changed. The rate of disagreement is not zero, it is
+            # merely unobserved, so bound it and let the difference inherit it.
+            bound = wilson_interval(0, n, self.confidence).high
+            return Interval(d, max(-1.0, -bound), min(1.0, bound), self.confidence)
+
+        pi = wilson_interval(c, m, self.confidence)
+        scale = m / n
+        low = (2 * pi.low - 1) * scale
+        high = (2 * pi.high - 1) * scale
+        return Interval(d, max(-1.0, low), min(1.0, high), self.confidence)
+
+    def min_detectable_shift(self) -> float:
+        """The smallest paired shift this sample size could have detected."""
+        return min_detectable_paired_shift(self.n, self.alpha)
+
+    def underpowered_for(self, tolerance: float) -> bool:
+        """True when no result on this many examples could detect *tolerance*."""
+        return self.min_detectable_shift() > abs(tolerance)
+
+    def describe(self) -> str:
+        """Rates, delta, interval, sample size, discordant pairs and p-value."""
+        ci = self.delta_interval()
+        return (
+            f"{self.baseline_rate:.1%} -> {self.candidate_rate:.1%} "
+            f"({self.delta:+.1%}, 95% CI [{ci.low:+.1%}, {ci.high:+.1%}], "
+            f"n={self.n}, discordant={self.discordant}, p={self.p_two_sided:.3f})"
+        )
+
+    def to_dict(self) -> dict:
+        """Serialise the paired binary comparison."""
+        return {
+            "n": self.n,
+            "baseline_rate": round(self.baseline_rate, 6),
+            "candidate_rate": round(self.candidate_rate, 6),
+            "delta": round(self.delta, 6),
+            "delta_ci": self.delta_interval().to_dict(),
+            "baseline_only": self.baseline_only,
+            "candidate_only": self.candidate_only,
+            "discordant": self.discordant,
+            "p_worse": round(self.p_worse, 6),
+            "p_two_sided": round(self.p_two_sided, 6),
+            "significant_regression": self.significant_regression,
+            "min_detectable_shift": round(self.min_detectable_shift(), 6),
+        }
+
+
+def compare_paired_binary(
+    baseline: Sequence[bool],
+    candidate: Sequence[bool],
+    alpha: float = 0.05,
+    confidence: float = 0.95,
+) -> PairedBinary:
+    """Build a :class:`PairedBinary` from two aligned outcome sequences.
+
+    The sequences must be the same length and in the same example order: index
+    i in both must be the same example, or the pairing is meaningless.
+    """
+    if len(baseline) != len(candidate):
+        raise ValueError(
+            f"paired comparison needs equal lengths, got {len(baseline)} and {len(candidate)}"
+        )
+    both = only_b = only_c = neither = 0
+    for base, cand in zip(baseline, candidate):
+        if base and cand:
+            both += 1
+        elif base and not cand:
+            only_b += 1
+        elif cand and not base:
+            only_c += 1
+        else:
+            neither += 1
+    return PairedBinary(
+        n=len(baseline),
+        both_correct=both,
+        baseline_only=only_b,
+        candidate_only=only_c,
+        both_wrong=neither,
+        alpha=alpha,
+        confidence=confidence,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Paired continuous outcomes
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def paired_bootstrap_ci(
+    baseline: Sequence[float],
+    candidate: Sequence[float],
+    confidence: float = 0.95,
+    iterations: int = 10_000,
+    seed: int = 20260731,
+) -> Interval:
+    """Percentile bootstrap CI on the mean paired difference.
+
+    Resamples *pairs*, not individual observations, which is what preserves the
+    pairing. Distribution-free, which matters because LLM-judge scores are
+    bounded, lumpy, and nowhere near normal.
+
+    The seed is fixed and explicit so a gate decision is reproducible: the same
+    inputs must always produce the same verdict, or a rerun could flip a
+    borderline result and nobody could audit it.
+    """
+    if len(baseline) != len(candidate):
+        raise ValueError("paired bootstrap needs equal lengths")
+    n = len(baseline)
+    if n == 0:
+        return Interval(0.0, 0.0, 0.0, confidence, estimable=False)
+
+    diffs = [c - b for b, c in zip(baseline, candidate)]
+    point = sum(diffs) / n
+    # A single pair, or differences with no spread, gives every bootstrap
+    # resample the same sample. The zero-width interval that comes back is a
+    # statement about the data, not a claim of certainty, which is exactly the
+    # case Interval documents ``estimable=False`` for. Marked here rather than
+    # left to the reader, because [+1.000, +1.000] off a single observation
+    # otherwise reads as the most confident result in the file.
+    #
+    # Compared with a tolerance, not ==: differences that are identical in
+    # intent routinely differ in the last bit or two (0.3 - 0.1 against
+    # 0.4 - 0.2), and resampling that noise produces a e-17 wide interval that
+    # is no more estimable than an exactly-zero-width one.
+    if n == 1 or math.isclose(max(diffs), min(diffs), rel_tol=1e-12, abs_tol=1e-12):
+        return Interval(point, point, point, confidence, estimable=False)
+
+    rng = random.Random(seed)
+    means = []
+    for _ in range(iterations):
+        total = 0.0
+        for _ in range(n):
+            total += diffs[rng.randrange(n)]
+        means.append(total / n)
+    means.sort()
+    lo_index = int((1 - confidence) / 2 * iterations)
+    hi_index = min(iterations - 1, int((1 + confidence) / 2 * iterations))
+    return Interval(point, means[lo_index], means[hi_index], confidence)
+
+
+# Above this many non-zero differences the exact null is not worth enumerating
+# and the normal approximation is accurate anyway.
+_EXACT_WILCOXON_MAX_N = 50
+
+
+def _exact_signed_rank_p(ranks: Sequence[float], w_plus: float) -> float:
+    """Two-sided exact p for the signed-rank null, conditional on the ranks.
+
+    Under the null each difference is equally likely to carry a plus or a minus,
+    so the null distribution of W+ is the distribution of subset sums of the
+    observed ranks over all 2**n sign assignments. Counting those subset sums by
+    dynamic programming is exact and cheap, where enumerating the assignments
+    would not be. Ranks are doubled first so that the half-integer average ranks
+    produced by ties stay on an integer lattice.
+    """
+    doubled = [int(round(r * 2)) for r in ranks]
+    total = sum(doubled)
+    counts = [0] * (total + 1)
+    counts[0] = 1
+    for value in doubled:
+        for s in range(total, value - 1, -1):
+            if counts[s - value]:
+                counts[s] += counts[s - value]
+
+    assignments = 2 ** len(doubled)
+    target = int(round(w_plus * 2))
+    at_or_below = sum(counts[: target + 1]) if target >= 0 else 0
+    at_or_above = sum(counts[target:]) if target <= total else 0
+    return min(1.0, 2.0 * min(at_or_below, at_or_above) / assignments)
+
+
+def wilcoxon_signed_rank(
+    baseline: Sequence[float], candidate: Sequence[float]
+) -> tuple[float, float]:
+    """Wilcoxon signed-rank test on paired differences.
+
+    Returns ``(statistic, two_sided_p)``, where the statistic is
+    ``min(W+, W-)``. Zero differences are dropped and ties receive average
+    ranks, both standard.
+
+    The p-value is **exact** for up to :data:`_EXACT_WILCOXON_MAX_N` non-zero
+    differences and uses the tie-corrected normal approximation above that. The
+    approximation is badly anti-conservative in the small-sample regime these
+    eval sets live in: with four pairs all moving the same way it reports
+    p = 0.046 where the exact answer is 0.125, which is the difference between
+    deploying a system prompt and correctly refusing to.
+
+    Use :func:`signed_rank_direction` to find which way the ranks point. The
+    statistic alone is directionless by construction.
+    """
+    w_plus, w_minus, statistic, p = _signed_rank_parts(baseline, candidate)
+    return statistic, p
+
+
+def _signed_rank_parts(
+    baseline: Sequence[float], candidate: Sequence[float]
+) -> tuple[float, float, float, float]:
+    """Return ``(w_plus, w_minus, statistic, two_sided_p)``."""
+    if len(baseline) != len(candidate):
+        raise ValueError("wilcoxon needs equal lengths")
+    diffs = [c - b for b, c in zip(baseline, candidate) if c != b]
+    n = len(diffs)
+    if n == 0:
+        return 0.0, 0.0, 0.0, 1.0
+
+    ordered = sorted(range(n), key=lambda i: abs(diffs[i]))
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and abs(diffs[ordered[j + 1]]) == abs(diffs[ordered[i]]):
+            j += 1
+        average = (i + j + 2) / 2.0  # ranks are 1-based
+        for k in range(i, j + 1):
+            ranks[ordered[k]] = average
+        i = j + 1
+
+    w_plus = sum(r for d, r in zip(diffs, ranks) if d > 0)
+    w_minus = sum(r for d, r in zip(diffs, ranks) if d < 0)
+    statistic = min(w_plus, w_minus)
+
+    if n <= _EXACT_WILCOXON_MAX_N:
+        return w_plus, w_minus, statistic, _exact_signed_rank_p(ranks, w_plus)
+
+    mean = n * (n + 1) / 4.0
+    tie_groups: dict[float, int] = {}
+    for d in diffs:
+        tie_groups[abs(d)] = tie_groups.get(abs(d), 0) + 1
+    tie_term = sum(t**3 - t for t in tie_groups.values())
+    variance = (n * (n + 1) * (2 * n + 1) - tie_term / 2.0) / 24.0
+    if variance <= 0:
+        return w_plus, w_minus, statistic, 1.0
+    z = (statistic - mean) / math.sqrt(variance)
+    return w_plus, w_minus, statistic, min(1.0, 2.0 * _NORM.cdf(-abs(z)))
+
+
+def signed_rank_direction(
+    baseline: Sequence[float], candidate: Sequence[float]
+) -> int:
+    """Which way the signed ranks point: +1 better, -1 worse, 0 no signal.
+
+    The rank test and the mean answer different questions and can disagree. One
+    scenario collapsing from 1.0 to 0.0 while eleven others each improve pulls
+    the mean negative even though the ranks clearly favour the candidate. Taking
+    the p-value from the ranks and the direction from the mean then labels that
+    a significant *regression*, which is the opposite of what happened.
+    """
+    w_plus, w_minus, _, _ = _signed_rank_parts(baseline, candidate)
+    if w_plus > w_minus:
+        return 1
+    if w_minus > w_plus:
+        return -1
+    return 0
+
+
+@dataclass
+class PairedContinuous:
+    """Baseline vs candidate over paired continuous scores."""
+
+    n: int
+    baseline_mean: float
+    candidate_mean: float
+    delta: float
+    delta_ci: Interval
+    wilcoxon_p: float
+    effect_size: float
+    alpha: float = 0.05
+    rank_direction: int = 0  # +1 ranks favour candidate, -1 baseline, 0 tied
+
+    @property
+    def direction_conflict(self) -> bool:
+        """True when the mean and the ranks disagree about which way it moved.
+
+        A single collapsed observation can drag the mean one way while every
+        other pair moves the other. When that happens neither direction is
+        claimed: the honest reading is that the result depends on an outlier,
+        and a gate should look at the data rather than take a verdict.
+        """
+        if self.rank_direction == 0 or self.delta == 0:
+            return False
+        return (self.rank_direction > 0) != (self.delta > 0)
+
+    @property
+    def significant_improvement(self) -> bool:
+        """True when the signed-rank test and the mean agree the candidate is better."""
+        return (
+            self.wilcoxon_p < self.alpha
+            and self.delta > 0
+            and self.rank_direction >= 0
+            and not self.direction_conflict
+        )
+
+    @property
+    def significant_regression(self) -> bool:
+        """True when the signed-rank test and the mean agree the candidate is worse."""
+        return (
+            self.wilcoxon_p < self.alpha
+            and self.delta < 0
+            and self.rank_direction <= 0
+            and not self.direction_conflict
+        )
+
+    @property
+    def inconclusive(self) -> bool:
+        """True when there is no evidence either way.
+
+        Reading ``contains(0.0)`` alone was wrong when the interval is not
+        estimable: a single pair produces a zero-width interval sitting off
+        zero, which does not contain zero and so reported the least informative
+        sample available as a conclusive result.
+
+        Deferring wholesale to ``estimable`` would be wrong in the other
+        direction, and by more. Differences with no spread are not an absence
+        of evidence, they are perfect consistency: eight pairs that every one
+        move +0.20 give a signed-rank p of 0.008, which is the cleanest signal
+        this comparison can produce, and calling it inconclusive would throw
+        away the best result in the set alongside the worst.
+
+        So a non-estimable interval simply contributes nothing, and the verdict
+        falls to the signed-rank test, which stays valid either way. One pair
+        gives p = 1.0 and settles nothing; eight identical pairs give p = 0.008
+        and settle it.
+        """
+        if self.direction_conflict:
+            return True
+        if not self.delta_ci.estimable:
+            return not (self.significant_improvement or self.significant_regression)
+        return self.delta_ci.contains(0.0)
+
+    def describe(self) -> str:
+        """Means, delta, interval, sample size, p-value and effect size."""
+        return (
+            f"{self.baseline_mean:.3f} -> {self.candidate_mean:.3f} "
+            f"({self.delta:+.3f}, 95% CI [{self.delta_ci.low:+.3f}, "
+            f"{self.delta_ci.high:+.3f}], n={self.n}, p={self.wilcoxon_p:.3f}, "
+            f"d={self.effect_size:+.2f})"
+        )
+
+    def to_dict(self) -> dict:
+        """Serialise the paired continuous comparison."""
+        return {
+            "n": self.n,
+            "baseline_mean": round(self.baseline_mean, 6),
+            "candidate_mean": round(self.candidate_mean, 6),
+            "delta": round(self.delta, 6),
+            "delta_ci": self.delta_ci.to_dict(),
+            "wilcoxon_p": round(self.wilcoxon_p, 6),
+            "effect_size": round(self.effect_size, 6),
+            "significant_improvement": self.significant_improvement,
+            "significant_regression": self.significant_regression,
+            "inconclusive": self.inconclusive,
+        }
+
+
+def compare_paired_continuous(
+    baseline: Sequence[float],
+    candidate: Sequence[float],
+    alpha: float = 0.05,
+    confidence: float = 0.95,
+    bootstrap_iterations: int = 10_000,
+    seed: int = 20260731,
+) -> PairedContinuous:
+    """Full paired comparison for continuous scores: CI, test, and effect size."""
+    if len(baseline) != len(candidate):
+        raise ValueError("paired comparison needs equal lengths")
+    n = len(baseline)
+    if n == 0:
+        return PairedContinuous(
+            0,
+            0.0,
+            0.0,
+            0.0,
+            Interval(0.0, 0.0, 0.0, confidence, estimable=False),
+            1.0,
+            0.0,
+            alpha,
+        )
+    base_mean = sum(baseline) / n
+    cand_mean = sum(candidate) / n
+    w_plus, w_minus, _, p = _signed_rank_parts(baseline, candidate)
+    direction = 1 if w_plus > w_minus else (-1 if w_minus > w_plus else 0)
+    return PairedContinuous(
+        n=n,
+        baseline_mean=base_mean,
+        candidate_mean=cand_mean,
+        delta=cand_mean - base_mean,
+        delta_ci=paired_bootstrap_ci(
+            baseline, candidate, confidence, bootstrap_iterations, seed
+        ),
+        wilcoxon_p=p,
+        effect_size=cohens_d(baseline, candidate),
+        alpha=alpha,
+        rank_direction=direction,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Trends
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def mann_kendall(ys: Sequence[float]) -> tuple[int, float]:
+    """Distribution-free monotonic trend test. Returns ``(S, two_sided_p)``.
+
+    ``S`` counts concordant minus discordant pairs. The test asks only whether
+    the ordering is monotonic, so it needs no residual variance and stays valid
+    exactly where the least-squares t-test breaks down: a perfectly straight
+    line has nothing left to estimate sigma from, but it is still either an
+    unlikely ordering or a common one.
+
+    Exact for up to 20 points with no repeated values, by counting permutations
+    with each inversion number (the Mahonian distribution). Above that, or with
+    ties, the tie-corrected normal approximation is used.
+
+    The exact answers are the reason this is worth doing: a perfectly monotone
+    run of three points is one ordering in six, p = 0.33, and should convince
+    nobody. The same run over six points is one in 720, p = 0.003.
+    """
+    n = len(ys)
+    if n < 3:
+        return 0, 1.0
+
+    s = 0
+    for i in range(n - 1):
+        for j in range(i + 1, n):
+            if ys[j] > ys[i]:
+                s += 1
+            elif ys[j] < ys[i]:
+                s -= 1
+
+    total_pairs = n * (n - 1) // 2
+    has_ties = len(set(ys)) < n
+
+    if not has_ties and n <= 20:
+        counts = [0] * (total_pairs + 1)
+        counts[0] = 1
+        for m in range(2, n + 1):
+            running = 0
+            updated = [0] * (total_pairs + 1)
+            for k in range(total_pairs + 1):
+                running += counts[k]
+                if k >= m:
+                    running -= counts[k - m]
+                updated[k] = running
+            counts = updated
+        total = math.factorial(n)
+        discordant = (total_pairs - s) // 2
+        at_or_below = sum(counts[: discordant + 1])
+        at_or_above = sum(counts[discordant:])
+        return s, min(1.0, 2.0 * min(at_or_below, at_or_above) / total)
+
+    tie_groups: dict[float, int] = {}
+    for y in ys:
+        tie_groups[y] = tie_groups.get(y, 0) + 1
+    tie_term = sum(t * (t - 1) * (2 * t + 5) for t in tie_groups.values())
+    variance = (n * (n - 1) * (2 * n + 5) - tie_term) / 18.0
+    if variance <= 0:
+        return s, 1.0
+    if s > 0:
+        z = (s - 1) / math.sqrt(variance)
+    elif s < 0:
+        z = (s + 1) / math.sqrt(variance)
+    else:
+        z = 0.0
+    return s, min(1.0, 2.0 * _NORM.cdf(-abs(z)))
+
+
+@dataclass
+class OLSTrend:
+    """Least-squares fit of value against time, with the uncertainty attached."""
+
+    n: int
+    slope: float
+    intercept: float
+    stderr: float
+    t_statistic: float
+    p_value: float
+    r_squared: float
+    span: float
+    change: float
+    slope_ci: Interval
+    alpha: float = 0.05
+    degenerate: bool = False
+    method: str = "ols"
+
+    @property
+    def significant(self) -> bool:
+        """True when the slope differs from zero beyond chance.
+
+        This is a real test, not a magnitude threshold. A steep slope through
+        three scattered points is not significant, and a shallow one through
+        forty tight points is. A degenerate fit - no residual scatter, so no
+        estimate of the error term - is never significant, because there was
+        nothing to test the slope against.
+        """
+        return self.n >= 3 and self.p_value < self.alpha
+
+    def describe(self) -> str:
+        """Slope per day with its interval, total change, fit quality and p-value."""
+        return (
+            f"slope {self.slope:+.4f}/day (95% CI [{self.slope_ci.low:+.4f}, "
+            f"{self.slope_ci.high:+.4f}]), change {self.change:+.3f} over "
+            f"{self.span:.1f}d, n={self.n}, R²={self.r_squared:.2f}, "
+            f"p={self.p_value:.3f}"
+        )
+
+    def to_dict(self) -> dict:
+        """Serialise the trend fit."""
+        return {
+            "n": self.n,
+            "slope": round(self.slope, 8),
+            "intercept": round(self.intercept, 8),
+            "stderr": round(self.stderr, 8),
+            "t_statistic": round(self.t_statistic, 6),
+            "p_value": round(self.p_value, 6),
+            "r_squared": round(self.r_squared, 6),
+            "span": round(self.span, 6),
+            "change": round(self.change, 6),
+            "slope_ci": self.slope_ci.to_dict(),
+            "significant": self.significant,
+            "degenerate": self.degenerate,
+            "method": self.method,
+        }
+
+
+def ols_trend(
+    xs: Sequence[float],
+    ys: Sequence[float],
+    alpha: float = 0.05,
+    confidence: float = 0.95,
+) -> OLSTrend:
+    """Fit ``y = a + b*x`` and test whether the slope is distinguishable from zero.
+
+    Needs at least three points: with two, the line passes through both exactly,
+    the residual variance is zero, and there is no error term left to test
+    against. Returning a confident answer from two points is how noise gets
+    promoted to a trend.
+    """
+    n = len(xs)
+    if n != len(ys):
+        raise ValueError("ols_trend needs equal lengths")
+
+    empty = Interval(0.0, 0.0, 0.0, confidence)
+    if n < 3:
+        return OLSTrend(n, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, empty, alpha)
+
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    sxx = sum((x - mean_x) ** 2 for x in xs)
+    if sxx <= 0:
+        # All observations share a timestamp: no slope is identifiable.
+        return OLSTrend(n, 0.0, mean_y, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, empty, alpha)
+
+    sxy = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    slope = sxy / sxx
+    intercept = mean_y - slope * mean_x
+
+    residuals = [y - (intercept + slope * x) for x, y in zip(xs, ys)]
+    sse = sum(r * r for r in residuals)
+    sst = sum((y - mean_y) ** 2 for y in ys)
+    r_squared = 1.0 - sse / sst if sst > 0 else 1.0
+
+    df = n - 2
+    # "No residual scatter" has to be judged relative to the data, not against
+    # exact zero. Three readings on a straight line leave residuals of order
+    # 1e-16 rather than 0.0, which is enough for stderr to underflow toward zero
+    # and t to explode, manufacturing p = 0.000 from rounding error. Anything
+    # this far below the total sum of squares is a perfect fit in every sense
+    # that matters; genuine data sits many orders of magnitude above it (a
+    # convincing real decline runs around sse/sst = 5e-3).
+    degenerate_fit = sse <= sst * 1e-12
+    if df <= 0 or degenerate_fit:
+        # A fit with no residual scatter leaves nothing to estimate sigma from,
+        # so the t-test is undefined. It previously reported p = 0.000 with a
+        # zero-width slope interval and called the trend certain, which fires on
+        # any exactly collinear reading - and success rates measured over two
+        # sessions are quantized to {0, 0.5, 1.0}, where 1.0/0.5/0.0 is exactly
+        # collinear.
+        #
+        # The t-test being undefined does not make the question unanswerable.
+        # Mann-Kendall tests the ordering instead of the residuals, so it stays
+        # valid precisely here, and it gets the intuition right in both
+        # directions: a perfectly straight six-point decline is one ordering in
+        # 720 and is significant, while the same shape over three points is one
+        # in six and is not.
+        span = max(xs) - min(xs)
+        _, mk_p = mann_kendall(list(ys))
+        return OLSTrend(
+            n=n,
+            slope=slope,
+            intercept=intercept,
+            stderr=0.0,
+            t_statistic=0.0,
+            p_value=mk_p,
+            r_squared=r_squared,
+            span=span,
+            change=slope * span,
+            slope_ci=Interval(slope, slope, slope, confidence, estimable=False),
+            alpha=alpha,
+            degenerate=True,
+            method="mann-kendall",
+        )
+
+    stderr = math.sqrt(sse / df / sxx)
+    t_stat = slope / stderr if stderr > 0 else 0.0
+    p_value = 2.0 * student_t_sf(abs(t_stat), df)
+
+    # Critical t via the inverse of the survival function, bisected. Avoids
+    # pulling in a full inverse-CDF implementation for one use.
+    target = (1 - confidence) / 2
+    lo, hi = 0.0, 1000.0
+    for _ in range(200):
+        mid = (lo + hi) / 2
+        if student_t_sf(mid, df) > target:
+            lo = mid
+        else:
+            hi = mid
+    t_crit = (lo + hi) / 2
+
+    span = max(xs) - min(xs)
+    return OLSTrend(
+        n=n,
+        slope=slope,
+        intercept=intercept,
+        stderr=stderr,
+        t_statistic=t_stat,
+        p_value=min(1.0, p_value),
+        r_squared=r_squared,
+        span=span,
+        change=slope * span,
+        slope_ci=Interval(
+            slope, slope - t_crit * stderr, slope + t_crit * stderr, confidence
+        ),
+        alpha=alpha,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Effect sizes and baselines
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def cohens_h(p1: float, p2: float) -> float:
+    """Effect size for a difference between two proportions.
+
+    The arcsine transform keeps the scale meaningful near 0 and 1, where a raw
+    difference badly understates the change: 0.95 to 0.99 is a far larger
+    practical move than 0.50 to 0.54, despite both being four points.
+    """
+    p1 = min(max(p1, 0.0), 1.0)
+    p2 = min(max(p2, 0.0), 1.0)
+    return 2 * math.asin(math.sqrt(p1)) - 2 * math.asin(math.sqrt(p2))
+
+
+def cohens_d(baseline: Sequence[float], candidate: Sequence[float]) -> float:
+    """Paired Cohen's d: mean difference over the standard deviation of differences."""
+    if len(baseline) != len(candidate) or not baseline:
+        return 0.0
+    diffs = [c - b for b, c in zip(baseline, candidate)]
+    n = len(diffs)
+    mean = sum(diffs) / n
+    if n < 2:
+        return 0.0
+    variance = sum((d - mean) ** 2 for d in diffs) / (n - 1)
+    sd = math.sqrt(variance)
+    if sd == 0:
+        return 0.0 if mean == 0 else math.copysign(math.inf, mean)
+    return mean / sd
+
+
+def holm_adjust(p_values: Sequence[float]) -> list[float]:
+    """Holm-Bonferroni step-down adjustment. Returns adjusted p-values in order.
+
+    Use this for a **disjunction**: several candidates tested against one
+    baseline where any that clears alpha gets deployed. Selecting the best of k
+    inflates the family-wise error rate, and four independent sections tested at
+    0.05 give ``1 - 0.95**4`` = 18.5%, not 5%.
+
+    Do not use it for the per-tool and per-category conjunctions elsewhere in
+    this codebase. Those are intersection-union tests, where accepting means
+    *every* claim holds; a conjunction of alpha-level claims is already valid at
+    alpha, and adjusting would make the gate looser as the catalogue grows. The
+    distinction is which way the quantifier runs: "any of these succeeded" needs
+    correcting, "all of these held" does not.
+
+    Holm rather than plain Bonferroni because it is uniformly more powerful and
+    just as valid without assuming independence.
+    """
+    n = len(p_values)
+    if n == 0:
+        return []
+    order = sorted(range(n), key=lambda i: p_values[i])
+    adjusted = [0.0] * n
+    running = 0.0
+    for rank, index in enumerate(order):
+        scaled = min(1.0, (n - rank) * p_values[index])
+        running = max(running, scaled)  # enforce monotonicity down the ladder
+        adjusted[index] = running
+    return adjusted
+
+
+def chance_accuracy(num_options: int) -> float:
+    """Accuracy a coin-flipping selector would reach across *num_options*.
+
+    Reported alongside tool-selection accuracy because raw accuracy is not
+    interpretable without it. 40% looks poor until you know there were twelve
+    tools to choose between, where chance is 8%.
+    """
+    return 1.0 / num_options if num_options > 0 else 0.0

--- a/evolution/core/verifier.py
+++ b/evolution/core/verifier.py
@@ -98,9 +98,13 @@ def verifier_metric(verifier: Verifier) -> Callable:
         task_input = getattr(gold, "task_input", "") or ""
         output = getattr(pred, "output", "") or ""
         fitness = verifier.score(task_input, output)
+        # Objective verification is an admission boundary: presentation and
+        # procedure feedback may guide reflection, but they cannot compensate
+        # for a factually wrong answer.
+        score = fitness.composite if fitness.correctness > 0 else 0.0
         if pred_name is not None:
-            return dspy.Prediction(score=fitness.composite, feedback=fitness.feedback)
-        return fitness.composite
+            return dspy.Prediction(score=score, feedback=fitness.feedback)
+        return score
 
     metric.__name__ = f"{verifier.skill_name}_verifier_metric"
     return metric

--- a/evolution/core/verifier.py
+++ b/evolution/core/verifier.py
@@ -1,0 +1,106 @@
+"""Objective fitness verifiers for skill evolution.
+
+A verifier grades agent output against checkable ground truth instead of
+keyword overlap or LLM judgment. That makes the fitness signal:
+
+  - non-circular: no LLM grades another LLM's paraphrase
+  - non-gameable: echoing rubric vocabulary scores nothing
+  - reproducible: the same output always gets the same score
+  - free: grading is pure Python, no API calls
+
+Each verifier owns both halves of the evaluation contract: it builds the
+eval dataset (tasks whose answers are verifiable facts) and it scores
+outputs against those facts. The two must travel together, because the
+grader can only score tasks it knows the ground truth for.
+
+Verifiers register themselves with @register_verifier and are looked up
+by skill name via get_verifier(). verifier_metric() adapts a verifier to
+the DSPy metric protocol, including GEPA's feedback-aware form.
+"""
+
+import abc
+from typing import Callable, Optional
+
+import dspy
+
+from evolution.core.dataset_builder import EvalDataset
+from evolution.core.fitness import FitnessScore
+
+
+class Verifier(abc.ABC):
+    """Grades agent outputs for one skill against objective ground truth."""
+
+    #: Skill name this verifier applies to (the SKILL.md directory name).
+    skill_name: str = ""
+
+    @abc.abstractmethod
+    def build_dataset(self, num_cases: int = 24, seed: int = 13) -> EvalDataset:
+        """Build a deterministic eval dataset of verifiable tasks.
+
+        The returned examples carry human-readable rubrics in
+        expected_behavior (so they stay compatible with judge and keyword
+        scoring), but the authoritative answers live inside the verifier.
+        """
+
+    @abc.abstractmethod
+    def score(self, task_input: str, output: str) -> FitnessScore:
+        """Score an agent output for a task from this verifier's dataset.
+
+        Returns a FitnessScore whose feedback explains exactly what was
+        right or wrong. The feedback doubles as GEPA's reflection signal.
+        """
+
+
+_REGISTRY: dict[str, type[Verifier]] = {}
+
+
+def register_verifier(cls: type[Verifier]) -> type[Verifier]:
+    """Class decorator that registers a Verifier by its skill_name."""
+    if not cls.skill_name:
+        raise ValueError(f"{cls.__name__} must set a non-empty skill_name")
+    _REGISTRY[cls.skill_name] = cls
+    return cls
+
+
+def get_verifier(skill_name: str) -> Optional[Verifier]:
+    """Return a verifier instance for a skill, or None if none exists."""
+    from evolution.verifiers import load_builtins
+
+    load_builtins()
+    cls = _REGISTRY.get(skill_name)
+    return cls() if cls else None
+
+
+def registered_skills() -> list[str]:
+    """Names of skills that have a registered verifier."""
+    from evolution.verifiers import load_builtins
+
+    load_builtins()
+    return sorted(_REGISTRY)
+
+
+def verifier_metric(verifier: Verifier) -> Callable:
+    """Adapt a Verifier to the DSPy metric protocol.
+
+    Handles all three calling conventions used across the pipeline:
+
+      - metric(gold, pred)                        holdout comparison
+      - metric(gold, pred, trace)                 MIPROv2 / classic DSPy
+      - metric(gold, pred, trace, pred_name, pred_trace)   GEPA
+
+    Returns a plain float normally. When GEPA asks for feedback on a
+    specific predictor (pred_name is set), returns a dspy.Prediction with
+    score and feedback so GEPA's reflection sees why the output scored
+    the way it did.
+    """
+
+    def metric(gold, pred, trace=None, pred_name=None, pred_trace=None):
+        task_input = getattr(gold, "task_input", "") or ""
+        output = getattr(pred, "output", "") or ""
+        fitness = verifier.score(task_input, output)
+        if pred_name is not None:
+            return dspy.Prediction(score=fitness.composite, feedback=fitness.feedback)
+        return fitness.composite
+
+    metric.__name__ = f"{verifier.skill_name}_verifier_metric"
+    return metric

--- a/evolution/core/verifier.py
+++ b/evolution/core/verifier.py
@@ -19,7 +19,7 @@ the DSPy metric protocol, including GEPA's feedback-aware form.
 """
 
 import abc
-from typing import Callable, Optional
+from collections.abc import Callable
 
 import dspy
 
@@ -62,7 +62,7 @@ def register_verifier(cls: type[Verifier]) -> type[Verifier]:
     return cls
 
 
-def get_verifier(skill_name: str) -> Optional[Verifier]:
+def get_verifier(skill_name: str) -> Verifier | None:
     """Return a verifier instance for a skill, or None if none exists."""
     from evolution.verifiers import load_builtins
 

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -23,6 +23,7 @@ from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset,
 from evolution.core.external_importers import build_dataset_from_external
 from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore
 from evolution.core.constraints import ConstraintValidator
+from evolution.core.verifier import get_verifier, verifier_metric
 from evolution.skills.skill_module import (
     SkillModule,
     load_skill,
@@ -43,6 +44,7 @@ def evolve(
     hermes_repo: Optional[str] = None,
     run_tests: bool = False,
     dry_run: bool = False,
+    fitness: str = "auto",
 ):
     """Main evolution function — orchestrates the full optimization loop."""
 
@@ -69,17 +71,36 @@ def evolve(
     console.print(f"  Size: {len(skill['raw']):,} chars")
     console.print(f"  Description: {skill['description'][:80]}...")
 
+    # Resolve the fitness signal. An objective verifier grades outputs
+    # against checkable ground truth; keyword overlap is the fallback.
+    verifier = None
+    if fitness in ("auto", "verifier"):
+        verifier = get_verifier(skill_name) or get_verifier(skill["name"])
+        if fitness == "verifier" and verifier is None:
+            console.print(f"[red]✗ No verifier registered for skill '{skill_name}'[/red]")
+            sys.exit(1)
+    metric_fn = verifier_metric(verifier) if verifier else skill_fitness_metric
+    fitness_label = "objective verifier" if verifier else "keyword overlap"
+
     if dry_run:
         console.print(f"\n[bold green]DRY RUN — setup validated successfully.[/bold green]")
-        console.print(f"  Would generate eval dataset (source: {eval_source})")
-        console.print(f"  Would run GEPA optimization ({iterations} iterations)")
+        console.print(f"  Would generate eval dataset (source: {'verifier' if verifier else eval_source})")
+        console.print(f"  Would run GEPA optimization ({iterations} iterations, fitness: {fitness_label})")
         console.print(f"  Would validate constraints and create PR")
         return
 
     # ── 2. Build or load evaluation dataset ─────────────────────────────
-    console.print(f"\n[bold]Building evaluation dataset[/bold] (source: {eval_source})")
+    console.print(f"\n[bold]Building evaluation dataset[/bold] (source: {'verifier' if verifier else eval_source})")
 
-    if eval_source == "golden" and dataset_path:
+    if verifier is not None:
+        # Verifier tasks carry their own ground truth, so the dataset and
+        # the fitness function must come from the same place.
+        dataset = verifier.build_dataset()
+        save_path = Path("datasets") / "skills" / f"{skill_name}-verifier"
+        dataset.save(save_path)
+        console.print(f"  Built {len(dataset.all_examples)} verified examples (objective ground truth)")
+        console.print(f"  Saved to {save_path}/")
+    elif eval_source == "golden" and dataset_path:
         dataset = GoldenDatasetLoader.load(Path(dataset_path))
         console.print(f"  Loaded golden dataset: {len(dataset.all_examples)} examples")
     elif eval_source == "sessiondb":
@@ -135,6 +156,7 @@ def evolve(
     console.print(f"  Optimizer: GEPA ({iterations} iterations)")
     console.print(f"  Optimizer model: {optimizer_model}")
     console.print(f"  Eval model: {eval_model}")
+    console.print(f"  Fitness: {fitness_label}")
 
     # Configure DSPy
     lm = dspy.LM(eval_model)
@@ -154,7 +176,7 @@ def evolve(
 
     try:
         optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
+            metric=metric_fn,
             max_steps=iterations,
         )
 
@@ -167,7 +189,7 @@ def evolve(
         # Fall back to MIPROv2 if GEPA isn't available in this DSPy version
         console.print(f"[yellow]GEPA not available ({e}), falling back to MIPROv2[/yellow]")
         optimizer = dspy.MIPROv2(
-            metric=skill_fitness_metric,
+            metric=metric_fn,
             auto="light",
         )
         optimized_module = optimizer.compile(
@@ -214,11 +236,11 @@ def evolve(
         # Score baseline
         with dspy.context(lm=lm):
             baseline_pred = baseline_module(task_input=ex.task_input)
-            baseline_score = skill_fitness_metric(ex, baseline_pred)
+            baseline_score = metric_fn(ex, baseline_pred)
             baseline_scores.append(baseline_score)
 
             evolved_pred = optimized_module(task_input=ex.task_input)
-            evolved_score = skill_fitness_metric(ex, evolved_pred)
+            evolved_score = metric_fn(ex, evolved_pred)
             evolved_scores.append(evolved_score)
 
     avg_baseline = sum(baseline_scores) / max(1, len(baseline_scores))
@@ -279,6 +301,7 @@ def evolve(
         "holdout_examples": len(dataset.holdout),
         "elapsed_seconds": elapsed,
         "constraints_passed": all_pass,
+        "fitness": fitness_label,
     }
     (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
 
@@ -303,7 +326,10 @@ def evolve(
 @click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
 @click.option("--run-tests", is_flag=True, help="Run full pytest suite as constraint gate")
 @click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")
-def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run):
+@click.option("--fitness", default="auto", type=click.Choice(["auto", "verifier", "keyword"]),
+              help="Fitness signal: auto uses an objective verifier when one is registered "
+                   "for the skill, verifier requires one, keyword forces the overlap heuristic")
+def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run, fitness):
     """Evolve a Hermes Agent skill using DSPy + GEPA optimization."""
     evolve(
         skill_name=skill,
@@ -315,6 +341,7 @@ def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_mod
         hermes_repo=hermes_repo,
         run_tests=run_tests,
         dry_run=dry_run,
+        fitness=fitness,
     )
 
 

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -95,6 +95,12 @@ def evolve(
     if verifier is not None:
         # Verifier tasks carry their own ground truth, so the dataset and
         # the fitness function must come from the same place.
+        if dataset_path or eval_source != "synthetic":
+            console.print(
+                "[yellow]  Note: the objective verifier supplies its own dataset; "
+                "--eval-source/--dataset-path are ignored. "
+                "Use --fitness keyword to evolve against a custom dataset.[/yellow]"
+            )
         dataset = verifier.build_dataset()
         save_path = Path("datasets") / "skills" / f"{skill_name}-verifier"
         dataset.save(save_path)

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from evolution.core.admission import AdmissionVerdict, evaluate_admission
 from evolution.core.config import EvolutionConfig, resolve_hermes_agent_path
 from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset, GoldenDatasetLoader
 from evolution.core.external_importers import build_dataset_from_external
@@ -32,6 +33,42 @@ from evolution.skills.skill_module import (
 )
 
 console = Console()
+
+
+def _is_correct(verifier, example, prediction) -> bool:
+    """Whether the objective verifier judged this answer fully correct.
+
+    The declared threshold is full correctness. Partial credit exists for
+    hedging across candidates and for paraphrased titles, and it is the right
+    signal for reflection, but an admission gate on ground truth should count
+    an example as solved only when the fact was actually right.
+    """
+    fitness = verifier.score(
+        getattr(example, "task_input", "") or "",
+        getattr(prediction, "output", "") or "",
+    )
+    return fitness.correctness >= 1.0
+
+
+def _admission_verdict(
+    baseline_scores,
+    evolved_scores,
+    *,
+    baseline_correct=None,
+    candidate_correct=None,
+) -> AdmissionVerdict:
+    """Apply the declared paired admission rule to a holdout comparison.
+
+    A single decision point, so the run reports the rule it actually used.
+    Whether the deployable artifact changed is a separate gate that this
+    command does not yet check, so it is left unasserted rather than assumed.
+    """
+    return evaluate_admission(
+        baseline_scores,
+        evolved_scores,
+        baseline_correct=baseline_correct,
+        candidate_correct=candidate_correct,
+    )
 
 
 def evolve(
@@ -238,6 +275,11 @@ def evolve(
 
     baseline_scores = []
     evolved_scores = []
+    # Objective correctness per example, kept alongside the scores so the
+    # admission gate can use McNemar's exact test rather than a threshold
+    # invented for the occasion. Only a verifier can supply it.
+    baseline_correct = [] if verifier is not None else None
+    evolved_correct = [] if verifier is not None else None
     for ex in holdout_examples:
         # Score baseline
         with dspy.context(lm=lm):
@@ -249,9 +291,20 @@ def evolve(
             evolved_score = metric_fn(ex, evolved_pred)
             evolved_scores.append(evolved_score)
 
+        if verifier is not None:
+            baseline_correct.append(_is_correct(verifier, ex, baseline_pred))
+            evolved_correct.append(_is_correct(verifier, ex, evolved_pred))
+
     avg_baseline = sum(baseline_scores) / max(1, len(baseline_scores))
     avg_evolved = sum(evolved_scores) / max(1, len(evolved_scores))
     improvement = avg_evolved - avg_baseline
+
+    verdict = _admission_verdict(
+        baseline_scores,
+        evolved_scores,
+        baseline_correct=baseline_correct,
+        candidate_correct=evolved_correct,
+    )
 
     # ── 9. Report results ───────────────────────────────────────────────
     table = Table(title="Evolution Results")
@@ -273,11 +326,24 @@ def evolve(
         f"{len(evolved_body):,} chars",
         f"{len(evolved_body) - len(skill['body']):+,} chars",
     )
+    table.add_row(
+        "Admission",
+        "",
+        "admitted" if verdict.admitted else "refused",
+        f"p={verdict.p_improvement:.3f} at alpha {verdict.alpha}",
+    )
     table.add_row("Time", "", f"{elapsed:.1f}s", "")
     table.add_row("Iterations", "", str(iterations), "")
 
     console.print()
     console.print(table)
+
+    # The mean delta above is descriptive; this is the decision, and the power
+    # line says what this many examples could ever have resolved.
+    console.print(f"\n  {verdict.describe()}")
+    console.print(
+        f"  [{'yellow' if verdict.underpowered else 'dim'}]{verdict.power_note}[/]"
+    )
 
     # ── 10. Save output ─────────────────────────────────────────────────
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -300,6 +366,10 @@ def evolve(
         "baseline_score": avg_baseline,
         "evolved_score": avg_evolved,
         "improvement": improvement,
+        # `improvement` is the descriptive mean delta. `admitted` is the
+        # decision, and it requires paired evidence rather than a sign.
+        "admitted": verdict.admitted,
+        "admission": verdict.to_dict(),
         "baseline_size": len(skill["body"]),
         "evolved_size": len(evolved_body),
         "train_examples": len(dataset.train),
@@ -313,9 +383,17 @@ def evolve(
 
     console.print(f"\n  Output saved to {output_dir}/")
 
-    if improvement > 0:
+    if verdict.admitted:
         console.print(f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement/max(0.001, avg_baseline)*100:+.1f}%)[/bold green]")
+        console.print(f"  {verdict.reason}")
         console.print(f"  Review the diff: diff {output_dir}/baseline_skill.md {output_dir}/evolved_skill.md")
+    elif improvement > 0:
+        # The mean moved the right way but the paired test cannot separate it
+        # from noise. Reporting "did not improve" would misstate that, so name
+        # the real reason and the sample size behind it.
+        console.print(f"\n[yellow]⚠ Not admitted: {verdict.reason}[/yellow]")
+        console.print(f"  {verdict.power_note}")
+        console.print("  Try: a larger holdout, more iterations, or a different optimizer model")
     else:
         console.print(f"\n[yellow]⚠ Evolution did not improve skill (change: {improvement:+.3f})[/yellow]")
         console.print("  Try: more iterations, better eval dataset, or different optimizer model")

--- a/evolution/verifiers/__init__.py
+++ b/evolution/verifiers/__init__.py
@@ -1,0 +1,20 @@
+"""Built-in objective verifiers.
+
+Each module here self-registers its verifier (via @register_verifier)
+when imported. load_builtins() imports them all; the registry in
+evolution.core.verifier calls it lazily so that running a verifier
+module directly (python -m evolution.verifiers.arxiv_verifier) does not
+import the module twice.
+"""
+
+import importlib
+
+_BUILTIN_MODULES = (
+    "evolution.verifiers.arxiv_verifier",
+)
+
+
+def load_builtins() -> None:
+    """Import every built-in verifier module, registering its verifier."""
+    for module_name in _BUILTIN_MODULES:
+        importlib.import_module(module_name)

--- a/evolution/verifiers/arxiv_verifier.py
+++ b/evolution/verifiers/arxiv_verifier.py
@@ -187,7 +187,13 @@ def grade_arxiv_id(expected: str, output: str) -> tuple[float, float, str]:
 def grade_title(expected: str, output: str) -> tuple[float, float, str]:
     norm_expected = _normalize(expected)
     norm_output = _normalize(output)
-    if norm_expected and norm_expected in norm_output:
+    # The spaceless comparison accepts fused spelling variants such as
+    # "Pretraining" for "Pre-training" while still requiring the exact
+    # letter sequence of the full title.
+    contains = norm_expected in norm_output or (
+        norm_expected.replace(" ", "") in norm_output.replace(" ", "")
+    )
+    if norm_expected and contains:
         return 1.0, 1.0, f"Correct title: {expected!r}."
     tokens = [t for t in norm_expected.split() if len(t) > 2]
     if tokens:

--- a/evolution/verifiers/arxiv_verifier.py
+++ b/evolution/verifiers/arxiv_verifier.py
@@ -1,0 +1,468 @@
+"""Objective verifier for the arxiv skill.
+
+Grades outputs against verifiable bibliographic facts: arXiv IDs, exact
+titles, first authors, and submission years for a fixed set of landmark
+papers. Grading is pure Python (regex + normalization), so a fitness
+evaluation costs nothing and two runs of the same output always agree.
+
+The embedded facts are historical constants (published papers do not
+change), and every one of them can be re-checked against the live arXiv
+API at any time:
+
+    python -m evolution.verifiers.arxiv_verifier --validate
+
+Other useful entry points:
+
+    python -m evolution.verifiers.arxiv_verifier --demo
+    python -m evolution.verifiers.arxiv_verifier --build --num-cases 24
+
+Task design notes:
+
+  - ID and title lookups test factual recall the skill should route
+    through the arXiv API rather than memory.
+  - Year lookups are solvable from the arXiv ID alone (the YYMM prefix),
+    so they directly measure whether the skill teaches the ID format.
+    A skill edit can flip these from wrong to right, which is exactly
+    the signal evolution needs.
+  - Wrong answers and missing answers get different feedback, steering
+    GEPA toward "verify with the API, do not guess".
+"""
+
+import json
+import random
+import re
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from evolution.core.dataset_builder import EvalDataset, EvalExample
+from evolution.core.fitness import FitnessScore
+from evolution.core.verifier import Verifier, register_verifier
+
+console = Console()
+
+ARXIV_API = "https://export.arxiv.org/api/query"
+ATOM_NS = {"atom": "http://www.w3.org/2005/Atom"}
+
+ARXIV_ID_RE = re.compile(r"\b(\d{4}\.\d{4,5})(?:v\d+)?\b")
+YEAR_RE = re.compile(r"\b(?:19|20)\d{2}\b")
+
+# Ground-truth kinds (also used as EvalExample.category).
+KIND_ID = "arxiv-id"
+KIND_TITLE = "title"
+KIND_AUTHOR = "first-author"
+KIND_YEAR = "year"
+
+
+@dataclass(frozen=True)
+class Paper:
+    """One seed paper with its verifiable facts."""
+
+    arxiv_id: str
+    title: str
+    first_author: str
+
+    @property
+    def year(self) -> int:
+        """Submission year, derived from the ID's YYMM prefix."""
+        return 2000 + int(self.arxiv_id[:2])
+
+
+# Landmark ML papers. Facts are stable (published papers do not change);
+# run this module with --validate to cross-check them against the live
+# arXiv API before trusting a new environment.
+SEED_PAPERS: tuple[Paper, ...] = (
+    Paper("1301.3781", "Efficient Estimation of Word Representations in Vector Space", "Tomas Mikolov"),
+    Paper("1406.2661", "Generative Adversarial Networks", "Ian J. Goodfellow"),
+    Paper("1412.6980", "Adam: A Method for Stochastic Optimization", "Diederik P. Kingma"),
+    Paper("1503.02531", "Distilling the Knowledge in a Neural Network", "Geoffrey Hinton"),
+    Paper("1512.03385", "Deep Residual Learning for Image Recognition", "Kaiming He"),
+    Paper("1706.03762", "Attention Is All You Need", "Ashish Vaswani"),
+    Paper("1810.04805", "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding", "Jacob Devlin"),
+    Paper("2005.14165", "Language Models are Few-Shot Learners", "Tom B. Brown"),
+    Paper("2006.11239", "Denoising Diffusion Probabilistic Models", "Jonathan Ho"),
+    Paper("2010.11929", "An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale", "Alexey Dosovitskiy"),
+    Paper("2103.00020", "Learning Transferable Visual Models From Natural Language Supervision", "Alec Radford"),
+    Paper("2106.09685", "LoRA: Low-Rank Adaptation of Large Language Models", "Edward J. Hu"),
+    Paper("2201.11903", "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models", "Jason Wei"),
+    Paper("2203.02155", "Training language models to follow instructions with human feedback", "Long Ouyang"),
+    Paper("2310.03714", "DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines", "Omar Khattab"),
+    Paper("2402.03300", "DeepSeekMath: Pushing the Limits of Mathematical Reasoning in Open Language Models", "Zhihong Shao"),
+    Paper("2507.19457", "GEPA: Reflective Prompt Evolution Can Outperform Reinforcement Learning", "Lakshya A Agrawal"),
+)
+
+PAPER_BY_ID: dict[str, Paper] = {p.arxiv_id: p for p in SEED_PAPERS}
+
+
+@dataclass(frozen=True)
+class GroundTruth:
+    """The authoritative answer for one task."""
+
+    kind: str
+    value: str
+
+
+def task_input_for(paper: Paper, kind: str) -> str:
+    """Build the exact task text for a paper and ground-truth kind.
+
+    Module-level so tests (and other tooling) can reconstruct any task
+    the verifier knows how to grade.
+    """
+    if kind == KIND_ID:
+        return f'Find the arXiv ID of the paper titled "{paper.title}".'
+    if kind == KIND_TITLE:
+        return f"What is the exact title of arXiv paper {paper.arxiv_id}?"
+    if kind == KIND_AUTHOR:
+        return f'Who is the first author of the paper "{paper.title}" (arXiv {paper.arxiv_id})?'
+    if kind == KIND_YEAR:
+        return f"In which year was arXiv paper {paper.arxiv_id} first submitted?"
+    raise ValueError(f"Unknown task kind: {kind}")
+
+
+def _rubric_for(paper: Paper, kind: str) -> str:
+    """Human-readable expected_behavior, kept compatible with judge and
+    keyword scoring modes."""
+    if kind == KIND_ID:
+        return f"The response states the correct arXiv ID: {paper.arxiv_id}."
+    if kind == KIND_TITLE:
+        return f"The response states the paper's exact title: {paper.title}."
+    if kind == KIND_AUTHOR:
+        return f"The response names the first author: {paper.first_author}."
+    return (
+        f"The response states the submission year {paper.year}. The year is "
+        f"derivable from the arXiv ID prefix {paper.arxiv_id[:4]} (YYMM format)."
+    )
+
+
+_DIFFICULTY = {
+    KIND_ID: "hard",
+    KIND_TITLE: "medium",
+    KIND_AUTHOR: "medium",
+    KIND_YEAR: "easy",
+}
+
+
+# ── Graders ───────────────────────────────────────────────────────────────
+# Each returns (correctness, well_formed, feedback). correctness is the
+# truth of the answer; well_formed is whether an answer of the expected
+# shape was present at all.
+
+
+def _normalize(text: str) -> str:
+    """Lowercase, strip punctuation, collapse whitespace."""
+    return " ".join(re.sub(r"[^a-z0-9\s]", " ", text.lower()).split())
+
+
+def grade_arxiv_id(expected: str, output: str) -> tuple[float, float, str]:
+    unique = sorted(set(ARXIV_ID_RE.findall(output)))
+    if not unique:
+        return 0.0, 0.0, (
+            f"No arXiv ID found in the response; expected {expected}. The skill "
+            "should make the agent state the ID explicitly and confirm it with an "
+            "arXiv API query (export.arxiv.org/api/query) instead of guessing."
+        )
+    if expected in unique:
+        if len(unique) == 1:
+            return 1.0, 1.0, f"Correct arXiv ID {expected}."
+        # Half credit: hedging across several IDs is not a usable answer,
+        # and full credit here would reward shotgunning candidates.
+        return 0.5, 1.0, (
+            f"The correct ID {expected} appears, but alongside other IDs "
+            f"{unique}. The skill should make the agent commit to a single "
+            "ID verified against the arXiv API."
+        )
+    return 0.0, 1.0, (
+        f"Wrong arXiv ID: the response contained {unique} but the correct ID is "
+        f"{expected}. The skill should instruct verifying candidate IDs against "
+        "the arXiv API (export.arxiv.org/api/query) before answering."
+    )
+
+
+def grade_title(expected: str, output: str) -> tuple[float, float, str]:
+    norm_expected = _normalize(expected)
+    norm_output = _normalize(output)
+    if norm_expected and norm_expected in norm_output:
+        return 1.0, 1.0, f"Correct title: {expected!r}."
+    tokens = [t for t in norm_expected.split() if len(t) > 2]
+    if tokens:
+        output_words = set(norm_output.split())
+        recall = sum(t in output_words for t in tokens) / len(tokens)
+        if recall >= 0.5:
+            return round(recall, 3), 1.0, (
+                f"Partial title match (token recall {recall:.0%}); the exact title "
+                f"is {expected!r}. The skill should have the agent quote the title "
+                "verbatim from the arXiv API's metadata rather than paraphrasing."
+            )
+    return 0.0, 0.0, (
+        f"Title not found in the response; expected {expected!r}. The skill should "
+        "route title lookups through the arXiv API (id_list query) and quote the "
+        "returned title verbatim."
+    )
+
+
+def grade_first_author(expected: str, output: str) -> tuple[float, float, str]:
+    last_name = expected.split()[-1]
+    if re.search(rf"\b{re.escape(last_name)}\b", output, re.IGNORECASE):
+        return 1.0, 1.0, f"Correct first author: {expected}."
+    return 0.0, 0.0, (
+        f"First author not named; expected {expected}. The skill should have the "
+        "agent read the author list from the paper's arXiv metadata, where the "
+        "first listed author is the first author."
+    )
+
+
+def grade_year(expected: str, output: str) -> tuple[float, float, str]:
+    # Remove arXiv-ID-shaped substrings first so an ID like 2005.14165
+    # does not have its YYMM prefix misread as the year 2005.
+    cleaned = ARXIV_ID_RE.sub(" ", output)
+    unique = sorted(set(YEAR_RE.findall(cleaned)))
+    if not unique:
+        return 0.0, 0.0, (
+            f"No year found in the response; expected {expected}. arXiv IDs encode "
+            "the submission year and month in their first four digits (YYMM), so "
+            "the skill should teach reading the year straight from the ID."
+        )
+    if expected in unique:
+        if len(unique) == 1:
+            return 1.0, 1.0, f"Correct year {expected}."
+        # Half credit for hedging across several years, same as for IDs.
+        return 0.5, 1.0, (
+            f"The correct year {expected} appears, but alongside other years "
+            f"{unique}. The skill should make the agent commit to one year, "
+            "which the arXiv ID's YYMM prefix determines exactly."
+        )
+    return 0.0, 1.0, (
+        f"Wrong year: the response said {unique} but the correct year is "
+        f"{expected}. The first four digits of an arXiv ID are YYMM, so the ID "
+        "alone determines the submission year."
+    )
+
+
+_GRADERS = {
+    KIND_ID: grade_arxiv_id,
+    KIND_TITLE: grade_title,
+    KIND_AUTHOR: grade_first_author,
+    KIND_YEAR: grade_year,
+}
+
+
+def _conciseness(output: str) -> float:
+    """1.0 up to 800 chars, linear decay to 0.0 at 4000 chars."""
+    n = len(output)
+    if n <= 800:
+        return 1.0
+    if n >= 4000:
+        return 0.0
+    return 1.0 - (n - 800) / 3200
+
+
+# ── Verifier ──────────────────────────────────────────────────────────────
+
+
+@register_verifier
+class ArxivVerifier(Verifier):
+    """Objective verifier for the arxiv skill."""
+
+    skill_name = "arxiv"
+
+    def __init__(self):
+        self._answers: dict[str, GroundTruth] = {}
+        self._tasks: list[EvalExample] = []
+        self._generate_tasks()
+
+    def _generate_tasks(self) -> None:
+        """Register every (task, ground truth) pair for the seed papers.
+
+        All tasks are registered regardless of dataset sampling, so any
+        subset (including one reloaded from disk) can be graded.
+        """
+        for paper in SEED_PAPERS:
+            for kind in (KIND_ID, KIND_TITLE, KIND_AUTHOR, KIND_YEAR):
+                task = task_input_for(paper, kind)
+                if kind == KIND_ID:
+                    value = paper.arxiv_id
+                elif kind == KIND_TITLE:
+                    value = paper.title
+                elif kind == KIND_AUTHOR:
+                    value = paper.first_author
+                else:
+                    value = str(paper.year)
+                self._answers[task] = GroundTruth(kind=kind, value=value)
+                self._tasks.append(EvalExample(
+                    task_input=task,
+                    expected_behavior=_rubric_for(paper, kind),
+                    difficulty=_DIFFICULTY[kind],
+                    category=kind,
+                    source="verifier",
+                ))
+
+    def ground_truth_for(self, task_input: str) -> Optional[GroundTruth]:
+        """The authoritative answer for a task, or None if unknown."""
+        return self._answers.get(task_input.strip())
+
+    def build_dataset(self, num_cases: int = 24, seed: int = 13) -> EvalDataset:
+        """Deterministic sample of verifiable tasks, split 50/25/25."""
+        tasks = list(self._tasks)
+        random.Random(seed).shuffle(tasks)
+        tasks = tasks[:num_cases]
+
+        n_train = max(1, int(len(tasks) * 0.5))
+        n_val = max(1, int(len(tasks) * 0.25))
+        return EvalDataset(
+            train=tasks[:n_train],
+            val=tasks[n_train:n_train + n_val],
+            holdout=tasks[n_train + n_val:],
+        )
+
+    def score(self, task_input: str, output: str) -> FitnessScore:
+        truth = self.ground_truth_for(task_input)
+        if truth is None:
+            return FitnessScore(feedback=(
+                "No ground truth registered for this task. ArxivVerifier can only "
+                "grade tasks from its own dataset (see build_dataset)."
+            ))
+        if not output.strip():
+            return FitnessScore(feedback="Empty response.")
+
+        correctness, well_formed, feedback = _GRADERS[truth.kind](truth.value, output)
+        # Conciseness only counts when an answer is actually present;
+        # a brief evasion must not outscore a verbose correct answer.
+        answered = correctness > 0 or well_formed > 0
+        return FitnessScore(
+            correctness=correctness,
+            procedure_following=well_formed,
+            conciseness=_conciseness(output) if answered else 0.0,
+            feedback=feedback,
+        )
+
+
+# ── Live cross-check against the arXiv API ────────────────────────────────
+
+
+def fetch_arxiv_metadata(arxiv_ids: list[str], timeout: int = 30) -> dict[str, dict]:
+    """Fetch title, first author, and submission year for a batch of IDs."""
+    url = f"{ARXIV_API}?id_list={','.join(arxiv_ids)}&max_results={len(arxiv_ids)}"
+    with urllib.request.urlopen(url, timeout=timeout) as resp:
+        root = ET.fromstring(resp.read())
+
+    metadata: dict[str, dict] = {}
+    for entry in root.findall("atom:entry", ATOM_NS):
+        raw_id = entry.findtext("atom:id", "", ATOM_NS)
+        match = ARXIV_ID_RE.search(raw_id)
+        if not match:
+            continue
+        authors = [
+            a.findtext("atom:name", "", ATOM_NS)
+            for a in entry.findall("atom:author", ATOM_NS)
+        ]
+        published = entry.findtext("atom:published", "", ATOM_NS)
+        metadata[match.group(1)] = {
+            "title": " ".join(entry.findtext("atom:title", "", ATOM_NS).split()),
+            "first_author": authors[0] if authors else "",
+            "year": int(published[:4]) if published[:4].isdigit() else 0,
+        }
+    return metadata
+
+
+def validate_seed_papers() -> bool:
+    """Cross-check every embedded fact against the live arXiv API."""
+    ids = [p.arxiv_id for p in SEED_PAPERS]
+    console.print(f"Fetching metadata for {len(ids)} papers from export.arxiv.org ...")
+    live = fetch_arxiv_metadata(ids)
+
+    table = Table(title="Embedded facts vs live arXiv API")
+    table.add_column("arXiv ID")
+    table.add_column("Title")
+    table.add_column("First author")
+    table.add_column("Year")
+
+    all_ok = True
+    for paper in SEED_PAPERS:
+        entry = live.get(paper.arxiv_id)
+        if entry is None:
+            table.add_row(paper.arxiv_id, "[red]NOT FOUND[/red]", "", "")
+            all_ok = False
+            continue
+        title_ok = _normalize(entry["title"]) == _normalize(paper.title)
+        author_ok = _normalize(entry["first_author"]) == _normalize(paper.first_author)
+        year_ok = entry["year"] == paper.year
+        ok = lambda flag, live_val: "[green]✓[/green]" if flag else f"[red]✗ live: {live_val}[/red]"
+        table.add_row(
+            paper.arxiv_id,
+            ok(title_ok, entry["title"]),
+            ok(author_ok, entry["first_author"]),
+            ok(year_ok, entry["year"]),
+        )
+        all_ok = all_ok and title_ok and author_ok and year_ok
+
+    console.print(table)
+    if all_ok:
+        console.print(f"[bold green]All {len(SEED_PAPERS)} papers verified against the live arXiv API.[/bold green]")
+    else:
+        console.print("[bold red]Mismatches found. Fix SEED_PAPERS before trusting this verifier.[/bold red]")
+    return all_ok
+
+
+def run_demo() -> None:
+    """Grade three canned outputs so the scoring behavior is visible."""
+    verifier = ArxivVerifier()
+    paper = PAPER_BY_ID["1706.03762"]
+    task = task_input_for(paper, KIND_ID)
+    console.print(f"\nTask: {task}\n")
+
+    samples = [
+        ("Correct and concise", "The paper is arXiv 1706.03762."),
+        ("Confidently wrong", "That paper is arXiv 1706.03799."),
+        ("No answer given", "That is a very famous transformer paper from Google Brain."),
+    ]
+    table = Table(title="ArxivVerifier demo")
+    table.add_column("Output")
+    table.add_column("Composite", justify="right")
+    table.add_column("Feedback")
+    for label, output in samples:
+        fs = verifier.score(task, output)
+        table.add_row(label, f"{fs.composite:.3f}", fs.feedback[:90] + "...")
+    console.print(table)
+
+
+@click.command()
+@click.option("--validate", "do_validate", is_flag=True,
+              help="Cross-check embedded facts against the live arXiv API")
+@click.option("--demo", "do_demo", is_flag=True,
+              help="Grade sample outputs to show the scoring behavior")
+@click.option("--build", "do_build", is_flag=True,
+              help="Build and save a verified eval dataset")
+@click.option("--num-cases", default=24, help="Dataset size for --build")
+@click.option("--output", default=None, help="Output directory for --build")
+def main(do_validate, do_demo, do_build, num_cases, output):
+    """Inspect, validate, or build datasets for the arxiv verifier."""
+    if not any([do_validate, do_demo, do_build]):
+        console.print("Nothing to do. Pass --validate, --demo, or --build.")
+        return
+
+    if do_validate:
+        if not validate_seed_papers():
+            raise SystemExit(1)
+
+    if do_demo:
+        run_demo()
+
+    if do_build:
+        verifier = ArxivVerifier()
+        dataset = verifier.build_dataset(num_cases=num_cases)
+        out_dir = Path(output) if output else Path("datasets") / "skills" / "arxiv-verifier"
+        dataset.save(out_dir)
+        console.print(
+            f"Saved {len(dataset.all_examples)} verified examples to {out_dir}/ "
+            f"(train {len(dataset.train)} / val {len(dataset.val)} / holdout {len(dataset.holdout)})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/evolution/verifiers/arxiv_verifier.py
+++ b/evolution/verifiers/arxiv_verifier.py
@@ -106,6 +106,7 @@ class GroundTruth:
 
     kind: str
     value: str
+    paper_id: str
 
 
 def task_input_for(paper: Paper, kind: str) -> str:
@@ -280,6 +281,7 @@ class ArxivVerifier(Verifier):
     def __init__(self):
         self._answers: dict[str, GroundTruth] = {}
         self._tasks: list[EvalExample] = []
+        self._tasks_by_paper: dict[str, list[EvalExample]] = {}
         self._generate_tasks()
 
     def _generate_tasks(self) -> None:
@@ -299,31 +301,80 @@ class ArxivVerifier(Verifier):
                     value = paper.first_author
                 else:
                     value = str(paper.year)
-                self._answers[task] = GroundTruth(kind=kind, value=value)
-                self._tasks.append(EvalExample(
+                self._answers[task] = GroundTruth(
+                    kind=kind,
+                    value=value,
+                    paper_id=paper.arxiv_id,
+                )
+                example = EvalExample(
                     task_input=task,
                     expected_behavior=_rubric_for(paper, kind),
                     difficulty=_DIFFICULTY[kind],
                     category=kind,
                     source="verifier",
-                ))
+                )
+                self._tasks.append(example)
+                self._tasks_by_paper.setdefault(paper.arxiv_id, []).append(example)
 
     def ground_truth_for(self, task_input: str) -> Optional[GroundTruth]:
         """The authoritative answer for a task, or None if unknown."""
         return self._answers.get(task_input.strip())
 
     def build_dataset(self, num_cases: int = 24, seed: int = 13) -> EvalDataset:
-        """Deterministic sample of verifiable tasks, split 50/25/25."""
-        tasks = list(self._tasks)
-        random.Random(seed).shuffle(tasks)
-        tasks = tasks[:num_cases]
+        """Build a deterministic 50/25/25 split without paper leakage.
 
-        n_train = max(1, int(len(tasks) * 0.5))
-        n_val = max(1, int(len(tasks) * 0.25))
+        Each paper is assigned to exactly one split before task kinds are
+        sampled. Otherwise an ID lookup for a paper can train the optimizer
+        while a title or author lookup for the same paper appears to be an
+        independent validation or holdout example.
+        """
+        if num_cases < 3:
+            raise ValueError("num_cases must be at least 3 for train/val/holdout")
+
+        rng = random.Random(seed)
+        paper_ids = list(self._tasks_by_paper)
+        rng.shuffle(paper_ids)
+
+        n_papers = len(paper_ids)
+        n_train_papers = max(1, int(n_papers * 0.5))
+        n_val_papers = max(1, int(n_papers * 0.25))
+        grouped_ids = (
+            paper_ids[:n_train_papers],
+            paper_ids[n_train_papers:n_train_papers + n_val_papers],
+            paper_ids[n_train_papers + n_val_papers:],
+        )
+
+        pools: list[list[EvalExample]] = []
+        for ids in grouped_ids:
+            pool = [task for paper_id in ids for task in self._tasks_by_paper[paper_id]]
+            rng.shuffle(pool)
+            pools.append(pool)
+
+        total = min(num_cases, len(self._tasks))
+        target = [
+            max(1, int(total * 0.5)),
+            max(1, int(total * 0.25)),
+        ]
+        target.append(total - sum(target))
+        counts = [min(wanted, len(pool)) for wanted, pool in zip(target, pools)]
+
+        remaining = total - sum(counts)
+        while remaining:
+            progressed = False
+            for index, pool in enumerate(pools):
+                if counts[index] < len(pool):
+                    counts[index] += 1
+                    remaining -= 1
+                    progressed = True
+                    if not remaining:
+                        break
+            if not progressed:
+                break
+
         return EvalDataset(
-            train=tasks[:n_train],
-            val=tasks[n_train:n_train + n_val],
-            holdout=tasks[n_train + n_val:],
+            train=pools[0][:counts[0]],
+            val=pools[1][:counts[1]],
+            holdout=pools[2][:counts[2]],
         )
 
     def score(self, task_input: str, output: str) -> FitnessScore:

--- a/evolution/verifiers/arxiv_verifier.py
+++ b/evolution/verifiers/arxiv_verifier.py
@@ -369,11 +369,35 @@ class ArxivVerifier(Verifier):
             if not progressed:
                 break
 
-        return EvalDataset(
+        dataset = EvalDataset(
             train=pools[0][:counts[0]],
             val=pools[1][:counts[1]],
             holdout=pools[2][:counts[2]],
         )
+        self._assert_disjoint_papers(dataset)
+        return dataset
+
+    def _assert_disjoint_papers(self, dataset: EvalDataset) -> None:
+        """Fail loudly if any paper reached more than one split.
+
+        The grouping above makes leakage structurally impossible, which is
+        exactly why this check is cheap and worth keeping: a later change to
+        the sampling would otherwise reintroduce it silently, and a leaked
+        holdout reports a score the run has not earned.
+        """
+        groups = {
+            name: {
+                self._answers[example.task_input].paper_id
+                for example in getattr(dataset, name)
+            }
+            for name in ("train", "val", "holdout")
+        }
+        for left, right in (("train", "val"), ("train", "holdout"), ("val", "holdout")):
+            shared = groups[left] & groups[right]
+            if shared:
+                raise AssertionError(
+                    f"paper leakage between {left} and {right}: {sorted(shared)}"
+                )
 
     def score(self, task_input: str, output: str) -> FitnessScore:
         truth = self.ground_truth_for(task_input)

--- a/evolution/verifiers/arxiv_verifier.py
+++ b/evolution/verifiers/arxiv_verifier.py
@@ -28,14 +28,12 @@ Task design notes:
     GEPA toward "verify with the API, do not guess".
 """
 
-import json
 import random
 import re
 import urllib.request
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 import click
 from rich.console import Console
@@ -316,7 +314,7 @@ class ArxivVerifier(Verifier):
                 self._tasks.append(example)
                 self._tasks_by_paper.setdefault(paper.arxiv_id, []).append(example)
 
-    def ground_truth_for(self, task_input: str) -> Optional[GroundTruth]:
+    def ground_truth_for(self, task_input: str) -> GroundTruth | None:
         """The authoritative answer for a task, or None if unknown."""
         return self._answers.get(task_input.strip())
 
@@ -503,9 +501,8 @@ def main(do_validate, do_demo, do_build, num_cases, output):
         console.print("Nothing to do. Pass --validate, --demo, or --build.")
         return
 
-    if do_validate:
-        if not validate_seed_papers():
-            raise SystemExit(1)
+    if do_validate and not validate_seed_papers():
+        raise SystemExit(1)
 
     if do_demo:
         run_demo()

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -122,6 +122,31 @@ class TestWilson:
         interval = wilson_interval(0, 0)
         assert (interval.low, interval.high) == (0.0, 1.0)
 
+    def test_boundary_counts_hit_the_boundary_at_every_n(self):
+        """The bound must be exactly 0 or 1, not merely near it.
+
+        Checking a single n only samples the floating-point luck of that n.
+        ``wilson_interval(0, 12).low`` is exactly 0.0, but ``(0, 10)`` lands on
+        2.8e-17, which is a different answer to ``contains(0.0)`` for an eval
+        set of a perfectly ordinary size.
+        """
+        for n in range(1, 201):
+            assert wilson_interval(0, n).low == 0.0, f"n={n}"
+            assert wilson_interval(n, n).high == 1.0, f"n={n}"
+
+    def test_boundary_intervals_contain_the_boundary(self):
+        """The property the exactness is for: 0 misses can still be a 0% rate."""
+        for n in (10, 13, 34, 47):
+            assert wilson_interval(0, n).contains(0.0), f"n={n}"
+            assert wilson_interval(n, n).contains(1.0), f"n={n}"
+
+    def test_interior_counts_stay_strictly_inside(self):
+        """The clamps must not drag a real interval onto the boundary."""
+        for n in range(2, 60):
+            for successes in range(1, n):
+                interval = wilson_interval(successes, n)
+                assert 0.0 < interval.low <= interval.high < 1.0, f"{successes}/{n}"
+
 
 class TestPower:
     def test_ten_examples_cannot_detect_less_than_fifty_points(self):

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -1,0 +1,485 @@
+"""Tests for the statistics core.
+
+Reference values are hand-computed or taken from standard tables and written as
+literals, so these tests validate the implementation rather than re-deriving it
+with the same code under test. Fully offline and deterministic: the bootstrap is
+seeded, and no test depends on wall-clock time.
+"""
+
+import math
+
+import pytest
+
+from evolution.core.stats import (
+    Interval,
+    binomial_cdf,
+    binomial_sf,
+    chance_accuracy,
+    cohens_d,
+    cohens_h,
+    holm_adjust,
+    compare_paired_binary,
+    compare_paired_continuous,
+    mcnemar_exact,
+    min_detectable_paired_shift,
+    ols_trend,
+    paired_bootstrap_ci,
+    student_t_sf,
+    wilcoxon_signed_rank,
+    wilson_interval,
+)
+
+
+class TestStudentT:
+    @pytest.mark.parametrize(
+        "t,df,two_sided_p",
+        [
+            (2.228, 10, 0.050),   # standard table: t(0.025, 10)
+            (1.812, 10, 0.100),   # t(0.05, 10)
+            (3.169, 10, 0.010),   # t(0.005, 10)
+            (2.086, 20, 0.050),   # t(0.025, 20)
+            (12.706, 1, 0.050),   # t(0.025, 1)
+        ],
+    )
+    def test_matches_published_tables(self, t, df, two_sided_p):
+        assert 2 * student_t_sf(t, df) == pytest.approx(two_sided_p, abs=1e-3)
+
+    def test_zero_is_the_median(self):
+        assert student_t_sf(0.0, 7) == pytest.approx(0.5)
+
+    def test_symmetric_about_zero(self):
+        assert student_t_sf(-1.5, 9) == pytest.approx(1 - student_t_sf(1.5, 9))
+
+    def test_converges_to_normal_at_high_df(self):
+        assert 2 * student_t_sf(1.96, 5_000_000) == pytest.approx(0.05, abs=1e-3)
+
+    def test_infinite_t_has_zero_tail(self):
+        assert student_t_sf(math.inf, 5) == 0.0
+
+
+class TestBinomial:
+    def test_cdf_matches_hand_computation(self):
+        # P(X <= 2 | n=12, p=0.5) = (1 + 12 + 66) / 4096
+        assert binomial_cdf(2, 12) == pytest.approx(79 / 4096)
+
+    def test_sf_matches_hand_computation(self):
+        assert binomial_sf(10, 12) == pytest.approx((66 + 12 + 1) / 4096)
+
+    def test_cdf_and_sf_are_complementary(self):
+        assert binomial_cdf(4, 9) + binomial_sf(5, 9) == pytest.approx(1.0)
+
+    def test_degenerate_inputs(self):
+        assert binomial_cdf(5, 0) == 1.0
+        assert binomial_sf(0, 10) == 1.0
+        assert binomial_sf(11, 10) == 0.0
+
+
+class TestMcNemar:
+    def test_two_sided_matches_hand_computation(self):
+        assert mcnemar_exact(10, 2) == pytest.approx(2 * 79 / 4096)
+
+    def test_one_sided_worse_is_half_the_symmetric_case(self):
+        assert mcnemar_exact(10, 2, "worse") == pytest.approx(79 / 4096)
+
+    def test_no_discordant_pairs_is_no_evidence(self):
+        assert mcnemar_exact(0, 0) == 1.0
+
+    def test_concordant_count_is_irrelevant(self):
+        """The whole point of the conditional test: only disagreements matter."""
+        small = compare_paired_binary([True] * 2 + [False] * 3, [True] * 5)
+        large = compare_paired_binary(
+            [True] * 200 + [False] * 3, [True] * 203
+        )
+        assert small.p_two_sided == pytest.approx(large.p_two_sided)
+
+    def test_direction_matters(self):
+        assert mcnemar_exact(8, 1, "worse") < mcnemar_exact(1, 8, "worse")
+
+    def test_symmetric_split_is_not_significant(self):
+        assert mcnemar_exact(5, 5) == pytest.approx(1.0)
+
+
+class TestWilson:
+    def test_perfect_score_does_not_claim_certainty(self):
+        interval = wilson_interval(10, 10)
+        assert interval.low == pytest.approx(0.7225, abs=1e-3)
+        assert interval.high == pytest.approx(1.0)
+
+    def test_matches_published_value(self):
+        interval = wilson_interval(50, 100)
+        assert interval.low == pytest.approx(0.4038, abs=1e-3)
+        assert interval.high == pytest.approx(0.5962, abs=1e-3)
+
+    def test_narrows_as_n_grows(self):
+        assert wilson_interval(80, 100).width < wilson_interval(8, 10).width
+
+    def test_zero_successes_stays_in_range(self):
+        interval = wilson_interval(0, 12)
+        assert interval.low == 0.0
+        assert 0.0 < interval.high < 1.0
+
+    def test_empty_sample_is_maximally_uncertain(self):
+        interval = wilson_interval(0, 0)
+        assert (interval.low, interval.high) == (0.0, 1.0)
+
+
+class TestPower:
+    def test_ten_examples_cannot_detect_less_than_fifty_points(self):
+        assert min_detectable_paired_shift(10, 0.05) == pytest.approx(0.5)
+
+    def test_hundred_examples_reach_five_points(self):
+        assert min_detectable_paired_shift(100, 0.05) == pytest.approx(0.05)
+
+    def test_stricter_alpha_needs_a_bigger_effect(self):
+        assert min_detectable_paired_shift(50, 0.01) > min_detectable_paired_shift(50, 0.05)
+
+    def test_underpowered_flag_is_honest_about_the_default_tolerance(self):
+        comparison = compare_paired_binary([True] * 34 + [False] * 6,
+                                           [True] * 30 + [False] * 10)
+        assert comparison.n == 40
+        assert comparison.underpowered_for(0.05) is True
+
+    def test_rejects_nonsense_alpha(self):
+        with pytest.raises(ValueError):
+            min_detectable_paired_shift(10, 0.0)
+
+
+class TestPairedBinary:
+    def test_counts_the_four_cells(self):
+        r = compare_paired_binary(
+            [True, True, False, False], [True, False, True, False]
+        )
+        assert (r.both_correct, r.baseline_only, r.candidate_only, r.both_wrong) == (1, 1, 1, 1)
+
+    def test_rates_and_delta(self):
+        r = compare_paired_binary([True] * 8 + [False] * 2, [True] * 6 + [False] * 4)
+        assert r.baseline_rate == pytest.approx(0.8)
+        assert r.candidate_rate == pytest.approx(0.6)
+        assert r.delta == pytest.approx(-0.2)
+
+    def test_identical_outcomes_centre_on_zero_but_stay_uncertain(self):
+        """No disagreement is not proof of no difference.
+
+        Three examples that both versions handled the same way put the estimate
+        at zero, but the rate of disagreement is unobserved rather than known to
+        be zero, so the interval has to stay open.
+        """
+        r = compare_paired_binary([True, False, True], [True, False, True])
+        interval = r.delta_interval()
+        assert interval.point == 0.0
+        assert interval.width > 0.0
+        assert interval.contains(0.0)
+        assert not r.significant_regression
+
+    def test_a_clean_sweep_does_not_report_a_zero_width_interval(self):
+        """The old Wald variance collapsed to zero exactly on the strongest result."""
+        r = compare_paired_binary([False] * 10, [True] * 10)
+        interval = r.delta_interval()
+        assert interval.point == pytest.approx(1.0)
+        assert interval.width > 0.1
+        assert interval.low < 1.0
+
+    def test_more_examples_narrow_the_no_disagreement_interval(self):
+        few = compare_paired_binary([True] * 5, [True] * 5).delta_interval()
+        many = compare_paired_binary([True] * 100, [True] * 100).delta_interval()
+        assert many.width < few.width
+
+    def test_large_consistent_regression_is_significant(self):
+        r = compare_paired_binary([True] * 20, [False] * 8 + [True] * 12)
+        assert r.significant_regression
+        assert r.p_worse < 0.05
+
+    def test_small_regression_on_few_examples_is_not_significant(self):
+        r = compare_paired_binary([True] * 8 + [False] * 2, [True] * 7 + [False] * 3)
+        assert not r.significant_regression
+
+    def test_improvement_is_not_flagged_as_regression(self):
+        r = compare_paired_binary([False] * 8 + [True] * 2, [True] * 10)
+        assert r.significant_improvement
+        assert not r.significant_regression
+
+    def test_mismatched_lengths_are_rejected(self):
+        with pytest.raises(ValueError, match="equal lengths"):
+            compare_paired_binary([True], [True, False])
+
+    def test_serialises(self):
+        r = compare_paired_binary([True, False], [False, True])
+        blob = r.to_dict()
+        assert blob["n"] == 2
+        assert "delta_ci" in blob and "p_worse" in blob
+
+
+class TestPairedContinuous:
+    def test_detects_a_consistent_shift(self):
+        base = [0.50, 0.52, 0.48, 0.51, 0.49, 0.50, 0.53, 0.47]
+        cand = [b + 0.20 for b in base]
+        r = compare_paired_continuous(base, cand)
+        assert r.delta == pytest.approx(0.20)
+        assert r.significant_improvement
+        assert not r.inconclusive
+
+    def test_noise_is_inconclusive(self):
+        base = [0.5, 0.7, 0.3, 0.6, 0.4, 0.55, 0.45, 0.65]
+        cand = [0.55, 0.65, 0.35, 0.55, 0.45, 0.5, 0.5, 0.6]
+        r = compare_paired_continuous(base, cand)
+        assert r.inconclusive
+
+    def test_empty_input_is_safe(self):
+        r = compare_paired_continuous([], [])
+        assert r.n == 0 and r.delta == 0.0
+
+    def test_bootstrap_is_deterministic(self):
+        base = [0.1, 0.4, 0.6, 0.2, 0.9, 0.3]
+        cand = [0.2, 0.5, 0.5, 0.4, 0.8, 0.5]
+        first = paired_bootstrap_ci(base, cand)
+        second = paired_bootstrap_ci(base, cand)
+        assert (first.low, first.high) == (second.low, second.high)
+
+    def test_bootstrap_interval_brackets_the_point_estimate(self):
+        base = [0.2, 0.4, 0.6, 0.8]
+        cand = [0.3, 0.5, 0.7, 0.9]
+        interval = paired_bootstrap_ci(base, cand)
+        assert interval.low <= interval.point <= interval.high
+
+    def test_constant_difference_has_no_spread(self):
+        interval = paired_bootstrap_ci([0.1, 0.2, 0.3], [0.2, 0.3, 0.4])
+        assert interval.low == pytest.approx(interval.high)
+
+
+class TestWilcoxon:
+    def test_all_positive_differences_are_significant(self):
+        base = list(range(10))
+        cand = [b + 5 for b in base]
+        _, p = wilcoxon_signed_rank(base, cand)
+        assert p < 0.05
+
+    def test_identical_series_is_not_significant(self):
+        _, p = wilcoxon_signed_rank([1, 2, 3], [1, 2, 3])
+        assert p == 1.0
+
+    def test_zero_differences_are_dropped(self):
+        stat_a, p_a = wilcoxon_signed_rank([1, 2, 3, 4], [2, 3, 4, 5])
+        stat_b, p_b = wilcoxon_signed_rank([1, 2, 3, 4, 9], [2, 3, 4, 5, 9])
+        assert (stat_a, p_a) == (stat_b, p_b)
+
+    def test_mismatched_lengths_are_rejected(self):
+        with pytest.raises(ValueError):
+            wilcoxon_signed_rank([1, 2], [1])
+
+
+class TestOLSTrend:
+    def test_recovers_a_known_line(self):
+        t = ols_trend([0, 1, 2, 3, 4], [1, 3, 5, 7, 9])
+        assert t.slope == pytest.approx(2.0)
+        assert t.intercept == pytest.approx(1.0)
+        assert t.r_squared == pytest.approx(1.0)
+
+    def test_pure_oscillation_is_not_a_trend(self):
+        """The exact case the previous magnitude rule got wrong."""
+        values = [0.90, 0.35, 0.85, 0.30, 0.88, 0.33, 0.60]
+        t = ols_trend(list(range(len(values))), values)
+        assert not t.significant
+        assert t.p_value > 0.5
+        assert t.r_squared < 0.2
+
+    def test_real_decline_is_significant(self):
+        values = [0.91, 0.86, 0.78, 0.71, 0.62, 0.55]
+        t = ols_trend(list(range(len(values))), values)
+        assert t.significant
+        assert t.slope < 0
+        assert t.r_squared > 0.95
+
+    def test_two_points_are_never_a_trend(self):
+        t = ols_trend([0, 1], [0.9, 0.1])
+        assert t.n == 2
+        assert not t.significant
+        assert t.slope == 0.0
+
+    def test_identical_timestamps_yield_no_slope(self):
+        t = ols_trend([5, 5, 5], [0.1, 0.5, 0.9])
+        assert t.slope == 0.0
+        assert not t.significant
+
+    def test_slope_interval_brackets_the_estimate(self):
+        values = [0.9, 0.82, 0.79, 0.70, 0.66, 0.55]
+        t = ols_trend(list(range(len(values))), values)
+        assert t.slope_ci.low <= t.slope <= t.slope_ci.high
+
+    def test_flat_data_is_not_significant(self):
+        t = ols_trend([0, 1, 2, 3], [0.5, 0.5, 0.5, 0.5])
+        assert not t.significant
+
+    def test_mismatched_lengths_are_rejected(self):
+        with pytest.raises(ValueError):
+            ols_trend([1, 2], [1])
+
+    def test_serialises(self):
+        blob = ols_trend([0, 1, 2, 3], [1, 2, 3, 5]).to_dict()
+        assert "p_value" in blob and "r_squared" in blob and "slope_ci" in blob
+
+
+class TestEffectSizes:
+    def test_cohens_h_is_zero_for_equal_proportions(self):
+        assert cohens_h(0.5, 0.5) == pytest.approx(0.0)
+
+    def test_cohens_h_weights_the_extremes_more(self):
+        near_ceiling = abs(cohens_h(0.99, 0.95))
+        mid_range = abs(cohens_h(0.54, 0.50))
+        assert near_ceiling > mid_range
+
+    def test_cohens_d_scales_by_variability(self):
+        tight = cohens_d([0.5] * 6, [0.6, 0.6, 0.6, 0.6, 0.6, 0.61])
+        loose = cohens_d([0.5] * 6, [0.1, 0.9, 0.3, 0.8, 0.2, 1.0])
+        assert abs(tight) > abs(loose)
+
+    def test_cohens_d_of_no_difference_is_zero(self):
+        assert cohens_d([1, 2, 3], [1, 2, 3]) == 0.0
+
+    def test_chance_accuracy(self):
+        assert chance_accuracy(12) == pytest.approx(1 / 12)
+        assert chance_accuracy(0) == 0.0
+
+
+class TestInterval:
+    def test_contains(self):
+        interval = Interval(0.1, -0.05, 0.25)
+        assert interval.contains(0.0)
+        assert not interval.contains(0.5)
+
+    def test_describe_renders_both_scales(self):
+        interval = Interval(0.1, 0.05, 0.15)
+        assert "%" in interval.describe(as_percent=True)
+        assert "0.100" in interval.describe(as_percent=False)
+
+
+class TestHolmAdjust:
+    """Correcting a disjunction, and only a disjunction.
+
+    Testing k candidates against one baseline and deploying any that clears is
+    selection of the best of k. Four sections at alpha = 0.05 give a family-wise
+    error of 1 - 0.95**4 = 18.6%, not 5%.
+    """
+
+    def test_matches_hand_computation(self):
+        # Sorted p is [0.01, 0.03, 0.04, 0.20]; multipliers are 4, 3, 2, 1
+        # with the running maximum enforced down the ladder.
+        assert holm_adjust([0.01, 0.04, 0.03, 0.20]) == pytest.approx(
+            [0.04, 0.09, 0.09, 0.20]
+        )
+
+    def test_a_single_test_is_left_alone(self):
+        assert holm_adjust([0.03]) == pytest.approx([0.03])
+
+    def test_empty_input(self):
+        assert holm_adjust([]) == []
+
+    def test_it_can_only_make_p_values_larger(self):
+        raw = [0.001, 0.02, 0.049, 0.3]
+        assert all(a >= r for r, a in zip(raw, holm_adjust(raw)))
+
+    def test_it_is_monotone_in_the_raw_ordering(self):
+        raw = [0.001, 0.02, 0.049, 0.3]
+        adjusted = holm_adjust(raw)
+        by_raw = [a for _, a in sorted(zip(raw, adjusted))]
+        assert by_raw == sorted(by_raw)
+
+    def test_borderline_results_stop_surviving(self):
+        raw = [0.01, 0.04, 0.03, 0.20]
+        assert sum(p < 0.05 for p in raw) == 3
+        assert sum(p < 0.05 for p in holm_adjust(raw)) == 1
+
+    def test_it_never_exceeds_one(self):
+        assert all(a <= 1.0 for a in holm_adjust([0.6, 0.7, 0.9]))
+
+    def test_it_is_more_powerful_than_plain_bonferroni(self):
+        raw = [0.01, 0.02, 0.03]
+        bonferroni = [min(1.0, len(raw) * p) for p in raw]
+        assert holm_adjust(raw)[0] <= bonferroni[0]
+
+
+class TestADegenerateIntervalSaysSo:
+    """A zero-width bootstrap interval is a fact about the sample, not certainty.
+
+    Interval's own contract reserves estimable=False for "a bootstrap over
+    differences that are all identical, which has no spread to resample", and
+    these are exactly those samples.
+    """
+
+    def test_an_empty_sample_is_not_estimable(self):
+        assert paired_bootstrap_ci([], []).estimable is False
+
+    def test_a_single_pair_is_not_estimable(self):
+        assert paired_bootstrap_ci([0.0], [1.0]).estimable is False
+
+    def test_identical_differences_are_not_estimable(self):
+        assert paired_bootstrap_ci([0.0, 0.0], [1.0, 1.0]).estimable is False
+
+    def test_differences_equal_within_float_noise_are_not_estimable(self):
+        """0.3 - 0.1 and 0.4 - 0.2 differ in the last bit. That is not spread."""
+        interval = paired_bootstrap_ci([0.1, 0.2], [0.3, 0.4])
+        assert interval.estimable is False
+
+    def test_a_sample_with_real_spread_is_still_estimable(self):
+        interval = paired_bootstrap_ci([0.1, 0.9, 0.4], [0.5, 0.2, 0.8])
+        assert interval.estimable is True
+        assert interval.width > 0
+
+    def test_the_empty_comparison_carries_a_non_estimable_interval(self):
+        assert compare_paired_continuous([], []).delta_ci.estimable is False
+
+    def test_a_non_estimable_interval_refuses_to_print_as_precision(self):
+        interval = paired_bootstrap_ci([0.0], [1.0])
+        assert "not estimable" in interval.describe()
+
+
+class TestInconclusiveReadsTheEvidenceNotTheWidth:
+    """A zero-width interval can mean no data, or it can mean total agreement.
+
+    Both produce estimable=False, and they are opposite verdicts, so the
+    signed-rank test decides which one it is.
+    """
+
+    def test_a_single_pair_settles_nothing(self):
+        assert compare_paired_continuous([0.0], [1.0]).inconclusive is True
+
+    def test_two_identical_pairs_settle_nothing(self):
+        assert compare_paired_continuous([0.0, 0.0], [1.0, 1.0]).inconclusive is True
+
+    def test_an_empty_comparison_settles_nothing(self):
+        assert compare_paired_continuous([], []).inconclusive is True
+
+    def test_perfect_consistency_is_evidence_not_the_absence_of_it(self):
+        """Eight pairs that every one move +0.20 is the cleanest signal there is.
+
+        The bootstrap has nothing to resample, so the interval is not
+        estimable, but the signed-rank test reads p = 0.008. Treating a
+        non-estimable interval as automatically inconclusive would throw this
+        away along with the single-pair case.
+        """
+        base = [0.50, 0.52, 0.48, 0.51, 0.49, 0.50, 0.53, 0.47]
+        result = compare_paired_continuous(base, [b + 0.20 for b in base])
+
+        assert result.delta_ci.estimable is False
+        assert result.wilcoxon_p < 0.01
+        assert result.significant_improvement is True
+        assert result.inconclusive is False
+
+    def test_a_consistent_regression_is_also_evidence(self):
+        base = [0.50, 0.52, 0.48, 0.51, 0.49, 0.50, 0.53, 0.47]
+        result = compare_paired_continuous(base, [b - 0.20 for b in base])
+
+        assert result.delta_ci.estimable is False
+        assert result.significant_regression is True
+        assert result.inconclusive is False
+
+    def test_a_straddling_interval_is_still_inconclusive(self):
+        base = [0.5, 0.7, 0.3, 0.6, 0.4, 0.55, 0.45, 0.65]
+        cand = [0.55, 0.65, 0.35, 0.55, 0.45, 0.5, 0.5, 0.6]
+        result = compare_paired_continuous(base, cand)
+        assert result.delta_ci.estimable is True
+        assert result.inconclusive is True
+
+    def test_the_serialised_form_agrees_with_the_property(self):
+        result = compare_paired_continuous([0.0], [1.0])
+        assert result.to_dict()["inconclusive"] is True
+        assert result.to_dict()["delta_ci"]["estimable"] is False

--- a/tests/core/test_verifier_registry.py
+++ b/tests/core/test_verifier_registry.py
@@ -1,0 +1,95 @@
+"""Tests for the verifier registry and the DSPy metric adapter."""
+
+import dspy
+import pytest
+
+from evolution.core.dataset_builder import EvalDataset
+from evolution.core.fitness import FitnessScore
+from evolution.core.verifier import (
+    Verifier,
+    get_verifier,
+    register_verifier,
+    registered_skills,
+    verifier_metric,
+)
+
+
+class StubVerifier(Verifier):
+    """Minimal verifier: the answer to everything is 42."""
+
+    skill_name = "stub"
+
+    def build_dataset(self, num_cases: int = 24, seed: int = 13) -> EvalDataset:
+        return EvalDataset()
+
+    def score(self, task_input: str, output: str) -> FitnessScore:
+        correct = "42" in output
+        return FitnessScore(
+            correctness=1.0 if correct else 0.0,
+            procedure_following=1.0 if correct else 0.0,
+            conciseness=1.0 if correct else 0.0,
+            feedback="Correct." if correct else "Expected the answer 42.",
+        )
+
+
+class TestRegistry:
+    def test_arxiv_verifier_is_registered(self):
+        verifier = get_verifier("arxiv")
+        assert verifier is not None
+        assert verifier.skill_name == "arxiv"
+
+    def test_unknown_skill_returns_none(self):
+        assert get_verifier("no-such-skill") is None
+
+    def test_registered_skills_includes_arxiv(self):
+        assert "arxiv" in registered_skills()
+
+    def test_register_requires_skill_name(self):
+        with pytest.raises(ValueError):
+            @register_verifier
+            class Nameless(Verifier):  # noqa: F811
+                skill_name = ""
+
+                def build_dataset(self, num_cases=24, seed=13):
+                    return EvalDataset()
+
+                def score(self, task_input, output):
+                    return FitnessScore()
+
+
+class TestVerifierMetric:
+    def setup_method(self):
+        self.metric = verifier_metric(StubVerifier())
+        self.gold = dspy.Example(task_input="what is the answer?").with_inputs("task_input")
+
+    def test_returns_float_for_two_arg_call(self):
+        score = self.metric(self.gold, dspy.Prediction(output="the answer is 42"))
+        assert isinstance(score, float)
+        assert score == pytest.approx(1.0)
+
+    def test_returns_float_for_three_arg_call(self):
+        score = self.metric(self.gold, dspy.Prediction(output="I do not know"), None)
+        assert isinstance(score, float)
+        assert score == pytest.approx(0.0)
+
+    def test_gepa_call_returns_score_with_feedback(self):
+        result = self.metric(
+            self.gold, dspy.Prediction(output="42"), None, "predictor", None
+        )
+        assert result.score == pytest.approx(1.0)
+        assert "Correct" in result.feedback
+
+    def test_gepa_feedback_explains_failure(self):
+        result = self.metric(
+            self.gold, dspy.Prediction(output="probably 7"), None, "predictor", None
+        )
+        assert result.score == pytest.approx(0.0)
+        assert "42" in result.feedback
+
+    def test_handles_missing_fields_gracefully(self):
+        score = self.metric(dspy.Example().with_inputs(), dspy.Prediction())
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
+    def test_metric_name_identifies_skill(self):
+        assert self.metric.__name__ == "stub_verifier_metric"

--- a/tests/test_admission_counterexamples.py
+++ b/tests/test_admission_counterexamples.py
@@ -1,0 +1,306 @@
+"""The three admission counterexamples from the review of #150, kept together.
+
+Each test here is a reproduction, not a paraphrase: the paper, the wrong
+answer, the dataset parameters and the win/loss pattern are the ones the audit
+reported at commit 448488e. They are collected in one module because they
+describe one failure mode with three faces — the pipeline calling something
+admissible when the evidence does not support it — and because a reviewer
+checking whether the report was addressed should not have to hunt through
+three packages to find out.
+
+Each one fails on the pre-fix code and passes after its fix:
+
+  1. a confidently wrong answer scored 0.500 on a metric it should score 0 on,
+     because the 0.3 procedure and 0.2 conciseness weights exactly cover a
+     correctness of zero;
+  2. papers appeared in more than one split at the default num_cases=24,
+     seed=13, so a holdout answer could be recited from training;
+  3. a mean that moved up on six examples counted as an improvement, when six
+     examples cannot make anything short of a near-unanimous flip significant.
+"""
+
+import dspy
+import pytest
+
+from evolution.core.admission import evaluate_admission
+from evolution.core.verifier import verifier_metric
+from evolution.skills import evolve_skill
+from evolution.verifiers.arxiv_verifier import (
+    KIND_ID,
+    PAPER_BY_ID,
+    ArxivVerifier,
+    task_input_for,
+)
+
+ATTENTION = PAPER_BY_ID["1706.03762"]
+
+# The audit's own wrong answer: right shape, right prefix, wrong paper.
+CONFIDENTLY_WRONG = "The paper is arXiv 1706.03799."
+
+
+@pytest.fixture
+def verifier():
+    return ArxivVerifier()
+
+
+# ── 1. Incorrect facts must not reach an admission-grade score ────────────
+
+
+def test_confidently_wrong_answer_scores_zero_for_admission(verifier):
+    """correctness == 0 must force the admission score to 0.
+
+    Pre-fix this returned 0.500: procedure_following and conciseness were both
+    1.0 for a well-formed wrong answer, and 0.3 + 0.2 is exactly the credit a
+    zero correctness gives up. Half marks for stating the wrong arXiv ID
+    fluently is precisely the signal an objective verifier exists to remove.
+    """
+    task = task_input_for(ATTENTION, KIND_ID)
+    fitness = verifier.score(task, CONFIDENTLY_WRONG)
+
+    assert fitness.correctness == pytest.approx(0.0)
+
+    # The feedback dimensions survive for GEPA's reflection, and still sum to
+    # the 0.500 that used to be handed to the optimizer as a score.
+    assert fitness.composite == pytest.approx(0.5)
+
+    metric = verifier_metric(verifier)
+    gold = dspy.Example(task_input=task).with_inputs("task_input")
+    score = metric(gold, dspy.Prediction(output=CONFIDENTLY_WRONG))
+
+    assert score == pytest.approx(0.0)
+
+
+def test_wrong_answer_scores_zero_in_gepa_feedback_form_too(verifier):
+    """The floor must hold on the feedback-aware call GEPA actually makes.
+
+    ``verifier_metric`` has two return paths. Flooring only the plain float
+    would leave the optimizer reading a 0.500 for a wrong answer through the
+    path it uses for reflection, which is the one that steers evolution.
+    """
+    task = task_input_for(ATTENTION, KIND_ID)
+    metric = verifier_metric(verifier)
+    gold = dspy.Example(task_input=task).with_inputs("task_input")
+
+    prediction = metric(
+        gold,
+        dspy.Prediction(output=CONFIDENTLY_WRONG),
+        None,
+        "predictor",
+        None,
+    )
+
+    assert prediction.score == pytest.approx(0.0)
+    # Reflection still gets told what was wrong, which is the point of keeping
+    # the dimensions rather than zeroing the FitnessScore itself.
+    assert "1706.03762" in prediction.feedback
+
+
+def test_partial_credit_is_not_floored(verifier):
+    """The floor is on zero correctness, not on partial correctness.
+
+    Hedging across two IDs earns 0.5 correctness by design. Flooring that too
+    would collapse a graded signal into pass/fail and cost GEPA the gradient
+    it needs, so the boundary is drawn at correctness == 0 exactly.
+    """
+    task = task_input_for(ATTENTION, KIND_ID)
+    hedged = "It is either 1706.03762 or 1810.04805."
+
+    assert verifier.score(task, hedged).correctness == pytest.approx(0.5)
+
+    metric = verifier_metric(verifier)
+    gold = dspy.Example(task_input=task).with_inputs("task_input")
+
+    assert metric(gold, dspy.Prediction(output=hedged)) > 0
+
+
+# ── 2. Papers must not leak across splits ─────────────────────────────────
+
+
+def _paper_of(task_input):
+    """Which seed paper a task is about, read from the task text itself.
+
+    Deliberately not ``ground_truth_for(...).paper_id``: the grouping the fix
+    introduced is the thing under test, so the test derives the answer
+    independently rather than asking the fix to confirm its own bookkeeping.
+    """
+    for paper_id, paper in PAPER_BY_ID.items():
+        if paper_id in task_input or paper.title in task_input:
+            return paper_id
+    raise AssertionError(f"no seed paper found in task: {task_input!r}")
+
+
+def _papers_by_split(verifier, dataset):
+    """Map each split to the set of papers its tasks came from."""
+    return {
+        name: {_paper_of(example.task_input) for example in getattr(dataset, name)}
+        for name in ("train", "val", "holdout")
+    }
+
+
+def test_default_dataset_has_no_paper_leakage(verifier):
+    """The audit's exact reproduction: num_cases=24, seed=13.
+
+    Pre-fix this shuffled 68 flat tasks and cut by index, so the same paper
+    supplied an ID lookup to train and a title lookup to holdout. The reported
+    overlaps were train n val = {1810.04805, 2201.11903}, train n holdout =
+    {1810.04805, 2006.11239, 2106.09685} and val n holdout = {1810.04805}.
+    """
+    dataset = verifier.build_dataset(num_cases=24, seed=13)
+    groups = _papers_by_split(verifier, dataset)
+
+    assert groups["train"] & groups["val"] == set()
+    assert groups["train"] & groups["holdout"] == set()
+    assert groups["val"] & groups["holdout"] == set()
+
+    # The split shape the pipeline depends on is unchanged by the grouping.
+    assert (len(dataset.train), len(dataset.val), len(dataset.holdout)) == (12, 6, 6)
+
+
+@pytest.mark.parametrize("seed", [1, 13, 7, 99, 2026])
+@pytest.mark.parametrize("num_cases", [8, 12, 24, 40, 68])
+def test_no_paper_leakage_at_any_size_or_seed(verifier, seed, num_cases):
+    """Disjointness is structural, so it must hold everywhere, not at seed 13.
+
+    A fix that only cleared the reported parameters would leave the defect
+    live for every other run.
+    """
+    dataset = verifier.build_dataset(num_cases=num_cases, seed=seed)
+    groups = _papers_by_split(verifier, dataset)
+
+    assert groups["train"].isdisjoint(groups["val"])
+    assert groups["train"].isdisjoint(groups["holdout"])
+    assert groups["val"].isdisjoint(groups["holdout"])
+
+    total = len(dataset.train) + len(dataset.val) + len(dataset.holdout)
+    assert total == min(num_cases, len(verifier._tasks))
+
+
+# ── 3. A small mean gain on six examples is not an improvement ────────────
+
+
+def test_single_win_on_six_examples_is_not_admitted():
+    """The audit's power argument, as a decision.
+
+    Six holdout examples, the candidate wins one and ties five. The mean rises
+    by 0.167 and the artifact changed, so the old rule called this a success
+    and reported an improvement. McNemar's exact test on the single discordant
+    pair gives p = 0.5: this is one coin flip landing heads.
+    """
+    baseline_correct = [True, True, True, False, False, False]
+    candidate_correct = [True, True, True, False, False, True]
+    baseline_scores = [float(x) for x in baseline_correct]
+    candidate_scores = [float(x) for x in candidate_correct]
+
+    improvement = (
+        sum(candidate_scores) / len(candidate_scores)
+        - sum(baseline_scores) / len(baseline_scores)
+    )
+
+    # The defect, stated exactly as the code stated it. `if improvement > 0`
+    # was the whole admission rule, and it is satisfied here.
+    assert improvement > 0
+
+    verdict = evolve_skill._admission_verdict(
+        baseline_scores,
+        candidate_scores,
+        baseline_correct=baseline_correct,
+        candidate_correct=candidate_correct,
+    )
+
+    assert not verdict.admitted
+    assert not verdict.significant_improvement
+    assert verdict.p_improvement == pytest.approx(0.5)
+
+
+def test_six_examples_are_declared_underpowered():
+    """Five aligned losses are needed to reach 0.05; four give p = 0.0625.
+
+    So the smallest shift six examples can resolve is 5/6, and a
+    'no significant regression' result here means 'no regression above 83.3%'.
+    The verdict has to say that rather than let it read as a clean bill.
+    """
+    verdict = evaluate_admission([1.0] * 6, [1.0] * 6, tolerance=0.05)
+
+    assert verdict.n == 6
+    assert verdict.min_detectable_shift == pytest.approx(5 / 6)
+    assert verdict.underpowered
+    assert "cannot resolve anything smaller" in verdict.power_note
+
+
+def test_a_clean_sweep_on_six_examples_is_admitted():
+    """The gate must still be able to say yes, or it is not a gate.
+
+    Five discordant pairs all favouring the candidate give p = 0.03125, which
+    clears alpha. This is the smallest result on six examples that can.
+    """
+    baseline_correct = [False, False, False, False, False, True]
+    candidate_correct = [True, True, True, True, True, True]
+
+    verdict = evaluate_admission(
+        [float(x) for x in baseline_correct],
+        [float(x) for x in candidate_correct],
+        baseline_correct=baseline_correct,
+        candidate_correct=candidate_correct,
+    )
+
+    assert verdict.p_improvement == pytest.approx(0.03125)
+    assert verdict.significant_improvement
+    assert verdict.admitted
+
+
+def test_a_significant_regression_is_refused():
+    """Non-regression is enforced, not merely reported."""
+    baseline_correct = [True, True, True, True, True, False]
+    candidate_correct = [False, False, False, False, False, False]
+
+    verdict = evaluate_admission(
+        [float(x) for x in baseline_correct],
+        [float(x) for x in candidate_correct],
+        baseline_correct=baseline_correct,
+        candidate_correct=candidate_correct,
+    )
+
+    assert verdict.significant_regression
+    assert not verdict.admitted
+    assert "regressed" in verdict.reason
+
+
+def test_an_unchanged_artifact_is_refused_when_the_caller_checks():
+    """An unchanged artifact is refused however good the numbers look."""
+    baseline_correct = [False] * 5 + [True]
+    candidate_correct = [True] * 6
+
+    verdict = evaluate_admission(
+        [float(x) for x in baseline_correct],
+        [float(x) for x in candidate_correct],
+        material_diff=False,
+        baseline_correct=baseline_correct,
+        candidate_correct=candidate_correct,
+    )
+
+    assert not verdict.admitted
+    assert "did not change" in verdict.reason
+
+
+def test_an_unchecked_artifact_is_recorded_as_unknown_not_as_passing():
+    """Not asking the question must not be recorded as having passed it.
+
+    This command does not compare the deployable artifacts, so the verdict
+    carries None. A default of True would have written an unverified claim
+    into metrics.json, which is the kind of quiet overstatement this whole
+    change exists to remove.
+    """
+    baseline_correct = [False] * 5 + [True]
+    candidate_correct = [True] * 6
+
+    verdict = evaluate_admission(
+        [float(x) for x in baseline_correct],
+        [float(x) for x in candidate_correct],
+        baseline_correct=baseline_correct,
+        candidate_correct=candidate_correct,
+    )
+
+    assert verdict.material_diff is None
+    assert verdict.to_dict()["material_diff"] is None
+    # Unknown does not block a result that carries evidence.
+    assert verdict.admitted

--- a/tests/verifiers/test_arxiv_verifier.py
+++ b/tests/verifiers/test_arxiv_verifier.py
@@ -1,0 +1,212 @@
+"""Tests for the arxiv objective verifier.
+
+Everything here runs offline against the embedded ground truth; the live
+arXiv API is only touched by the module's --validate CLI flag.
+"""
+
+import dspy
+import pytest
+
+from evolution.core.verifier import verifier_metric
+from evolution.verifiers.arxiv_verifier import (
+    KIND_AUTHOR,
+    KIND_ID,
+    KIND_TITLE,
+    KIND_YEAR,
+    ARXIV_ID_RE,
+    ArxivVerifier,
+    PAPER_BY_ID,
+    SEED_PAPERS,
+    _conciseness,
+    grade_arxiv_id,
+    grade_title,
+    grade_year,
+    task_input_for,
+)
+
+ATTENTION = PAPER_BY_ID["1706.03762"]
+GPT3 = PAPER_BY_ID["2005.14165"]
+
+
+@pytest.fixture()
+def verifier():
+    return ArxivVerifier()
+
+
+class TestSeedPapers:
+    def test_ids_are_unique_and_well_formed(self):
+        ids = [p.arxiv_id for p in SEED_PAPERS]
+        assert len(ids) == len(set(ids))
+        for arxiv_id in ids:
+            assert ARXIV_ID_RE.fullmatch(arxiv_id)
+
+    def test_years_derive_from_id_prefix(self):
+        for paper in SEED_PAPERS:
+            assert 2013 <= paper.year <= 2025
+
+
+class TestDataset:
+    def test_default_build_shape(self, verifier):
+        dataset = verifier.build_dataset()
+        assert len(dataset.all_examples) == 24
+        assert len(dataset.train) == 12
+        assert len(dataset.val) == 6
+        assert len(dataset.holdout) == 6
+
+    def test_every_example_is_gradable(self, verifier):
+        dataset = verifier.build_dataset()
+        for example in dataset.all_examples:
+            assert verifier.ground_truth_for(example.task_input) is not None
+            assert example.expected_behavior
+            assert example.source == "verifier"
+            assert example.category in {KIND_ID, KIND_TITLE, KIND_AUTHOR, KIND_YEAR}
+
+    def test_build_is_deterministic(self, verifier):
+        first = [ex.task_input for ex in verifier.build_dataset().all_examples]
+        second = [ex.task_input for ex in ArxivVerifier().build_dataset().all_examples]
+        assert first == second
+
+    def test_oversized_request_returns_full_pool(self, verifier):
+        dataset = verifier.build_dataset(num_cases=10_000)
+        assert len(dataset.all_examples) == len(SEED_PAPERS) * 4
+
+
+class TestIdGrading:
+    def test_correct_id_scores_full(self, verifier):
+        task = task_input_for(ATTENTION, KIND_ID)
+        fitness = verifier.score(task, "The paper is arXiv 1706.03762.")
+        assert fitness.correctness == pytest.approx(1.0)
+        assert fitness.composite == pytest.approx(1.0)
+
+    def test_versioned_id_still_matches(self, verifier):
+        task = task_input_for(ATTENTION, KIND_ID)
+        fitness = verifier.score(task, "See 1706.03762v7 on arXiv.")
+        assert fitness.correctness == pytest.approx(1.0)
+
+    def test_wrong_id_scores_zero_correctness(self, verifier):
+        task = task_input_for(ATTENTION, KIND_ID)
+        fitness = verifier.score(task, "That would be arXiv 1706.03799.")
+        assert fitness.correctness == pytest.approx(0.0)
+        assert "1706.03762" in fitness.feedback
+
+    def test_hedging_across_ids_gets_half_credit(self, verifier):
+        task = task_input_for(ATTENTION, KIND_ID)
+        fitness = verifier.score(task, "It is either 1706.03762 or 1810.04805.")
+        assert fitness.correctness == pytest.approx(0.5)
+
+    def test_no_id_scores_lowest(self, verifier):
+        task = task_input_for(ATTENTION, KIND_ID)
+        fitness = verifier.score(task, "A very famous transformer paper.")
+        assert fitness.correctness == pytest.approx(0.0)
+        assert fitness.procedure_following == pytest.approx(0.0)
+
+    def test_wrong_beats_nothing_only_slightly(self):
+        wrong = grade_arxiv_id("1706.03762", "It is 9999.99999.")
+        nothing = grade_arxiv_id("1706.03762", "No idea, sorry.")
+        assert wrong[0] == nothing[0] == 0.0
+        assert wrong[1] > nothing[1]
+
+
+class TestTitleGrading:
+    def test_exact_title_scores_full(self, verifier):
+        task = task_input_for(ATTENTION, KIND_TITLE)
+        fitness = verifier.score(task, 'The title is "Attention Is All You Need".')
+        assert fitness.correctness == pytest.approx(1.0)
+
+    def test_partial_title_gets_partial_credit(self):
+        correctness, well_formed, _ = grade_title(
+            "Attention Is All You Need", "It is about attention, and you need it."
+        )
+        assert correctness == pytest.approx(0.75)
+        assert well_formed == pytest.approx(1.0)
+
+    def test_unrelated_output_scores_zero(self):
+        correctness, well_formed, feedback = grade_title(
+            "Attention Is All You Need", "No idea."
+        )
+        assert correctness == 0.0
+        assert well_formed == 0.0
+        assert "Attention Is All You Need" in feedback
+
+
+class TestAuthorGrading:
+    def test_last_name_is_enough(self, verifier):
+        task = task_input_for(ATTENTION, KIND_AUTHOR)
+        fitness = verifier.score(task, "The first author is Ashish Vaswani.")
+        assert fitness.correctness == pytest.approx(1.0)
+
+    def test_missing_author_scores_zero(self, verifier):
+        task = task_input_for(ATTENTION, KIND_AUTHOR)
+        fitness = verifier.score(task, "Written by researchers at Google Brain.")
+        assert fitness.correctness == pytest.approx(0.0)
+        assert "Vaswani" in fitness.feedback
+
+
+class TestYearGrading:
+    def test_correct_year_scores_full(self, verifier):
+        task = task_input_for(ATTENTION, KIND_YEAR)
+        fitness = verifier.score(task, "It was first submitted in 2017.")
+        assert fitness.correctness == pytest.approx(1.0)
+
+    def test_wrong_year_scores_zero(self, verifier):
+        task = task_input_for(ATTENTION, KIND_YEAR)
+        fitness = verifier.score(task, "That was 2018.")
+        assert fitness.correctness == pytest.approx(0.0)
+
+    def test_id_prefix_is_not_misread_as_year(self):
+        # 2005.14165 must not have its YYMM prefix counted as the year 2005.
+        correctness, _, _ = grade_year("2020", "arXiv 2005.14165 came out in 2020.")
+        assert correctness == pytest.approx(1.0)
+
+    def test_hedging_across_years_gets_half_credit(self):
+        correctness, _, _ = grade_year("2017", "Around 2016 or 2017.")
+        assert correctness == pytest.approx(0.5)
+
+
+class TestScoreEdgeCases:
+    def test_unknown_task_scores_zero_with_explanation(self, verifier):
+        fitness = verifier.score("What is the meaning of life?", "42")
+        assert fitness.composite == pytest.approx(0.0)
+        assert "ground truth" in fitness.feedback.lower()
+
+    def test_empty_output_scores_zero(self, verifier):
+        task = task_input_for(ATTENTION, KIND_ID)
+        assert verifier.score(task, "   ").composite == pytest.approx(0.0)
+
+    def test_verbosity_lowers_the_score(self, verifier):
+        task = task_input_for(ATTENTION, KIND_ID)
+        short = verifier.score(task, "arXiv 1706.03762.")
+        long = verifier.score(task, "arXiv 1706.03762. " + "Additional context. " * 250)
+        assert short.composite > long.composite
+        assert long.correctness == pytest.approx(1.0)
+
+    def test_brief_evasion_scores_zero(self, verifier):
+        # Being short must never outscore actually answering.
+        task = task_input_for(ATTENTION, KIND_ID)
+        evasive = verifier.score(task, "Great question!")
+        verbose_correct = verifier.score(task, "arXiv 1706.03762. " + "Context. " * 400)
+        assert evasive.composite == pytest.approx(0.0)
+        assert verbose_correct.composite > evasive.composite
+
+    def test_conciseness_curve(self):
+        assert _conciseness("x" * 800) == pytest.approx(1.0)
+        assert _conciseness("x" * 2400) == pytest.approx(0.5)
+        assert _conciseness("x" * 4000) == pytest.approx(0.0)
+
+
+class TestMetricIntegration:
+    def test_metric_scores_dataset_examples(self, verifier):
+        metric = verifier_metric(verifier)
+        example = verifier.build_dataset().to_dspy_examples("train")[0]
+        score = metric(example, dspy.Prediction(output="some answer with 1706.03762"))
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
+    def test_gepa_form_carries_verifier_feedback(self, verifier):
+        metric = verifier_metric(verifier)
+        gold = dspy.Example(
+            task_input=task_input_for(ATTENTION, KIND_ID)
+        ).with_inputs("task_input")
+        result = metric(gold, dspy.Prediction(output="No clue."), None, "predictor", None)
+        assert result.score == pytest.approx(0.0)
+        assert "1706.03762" in result.feedback

--- a/tests/verifiers/test_arxiv_verifier.py
+++ b/tests/verifiers/test_arxiv_verifier.py
@@ -113,6 +113,13 @@ class TestTitleGrading:
         fitness = verifier.score(task, 'The title is "Attention Is All You Need".')
         assert fitness.correctness == pytest.approx(1.0)
 
+    def test_fused_spelling_variant_still_scores_full(self):
+        correctness, _, _ = grade_title(
+            "LoRA: Low-Rank Adaptation of Large Language Models",
+            "The title is LoRA: LowRank Adaptation of Large Language Models.",
+        )
+        assert correctness == pytest.approx(1.0)
+
     def test_partial_title_gets_partial_credit(self):
         correctness, well_formed, _ = grade_title(
             "Attention Is All You Need", "It is about attention, and you need it."

--- a/tests/verifiers/test_arxiv_verifier.py
+++ b/tests/verifiers/test_arxiv_verifier.py
@@ -9,14 +9,14 @@ import pytest
 
 from evolution.core.verifier import verifier_metric
 from evolution.verifiers.arxiv_verifier import (
+    ARXIV_ID_RE,
     KIND_AUTHOR,
     KIND_ID,
     KIND_TITLE,
     KIND_YEAR,
-    ARXIV_ID_RE,
-    ArxivVerifier,
     PAPER_BY_ID,
     SEED_PAPERS,
+    ArxivVerifier,
     _conciseness,
     grade_arxiv_id,
     grade_title,

--- a/tests/verifiers/test_arxiv_verifier.py
+++ b/tests/verifiers/test_arxiv_verifier.py
@@ -53,6 +53,25 @@ class TestDataset:
         assert len(dataset.val) == 6
         assert len(dataset.holdout) == 6
 
+    def test_papers_are_disjoint_across_splits(self, verifier):
+        dataset = verifier.build_dataset()
+
+        groups = {
+            split: {
+                verifier.ground_truth_for(example.task_input).paper_id
+                for example in getattr(dataset, split)
+            }
+            for split in ("train", "val", "holdout")
+        }
+
+        assert groups["train"].isdisjoint(groups["val"])
+        assert groups["train"].isdisjoint(groups["holdout"])
+        assert groups["val"].isdisjoint(groups["holdout"])
+
+    def test_too_few_cases_is_rejected(self, verifier):
+        with pytest.raises(ValueError, match="at least 3"):
+            verifier.build_dataset(num_cases=2)
+
     def test_every_example_is_gradable(self, verifier):
         dataset = verifier.build_dataset()
         for example in dataset.all_examples:
@@ -88,6 +107,16 @@ class TestIdGrading:
         fitness = verifier.score(task, "That would be arXiv 1706.03799.")
         assert fitness.correctness == pytest.approx(0.0)
         assert "1706.03762" in fitness.feedback
+
+    def test_wrong_but_well_formed_id_has_zero_admission_score(self, verifier):
+        metric = verifier_metric(verifier)
+        task = task_input_for(ATTENTION, KIND_ID)
+        gold = dspy.Example(task_input=task).with_inputs("task_input")
+
+        score = metric(gold, dspy.Prediction(output="That would be arXiv 1706.03799."))
+
+        assert verifier.score(task, "That would be arXiv 1706.03799.").composite > 0
+        assert score == pytest.approx(0.0)
 
     def test_hedging_across_ids_gets_half_credit(self, verifier):
         task = task_input_for(ATTENTION, KIND_ID)


### PR DESCRIPTION
## The problem

Phase 1's gate is "at least one skill measurably improved." Right now that measurement can't be trusted, because the metric the optimizer maximizes (and the holdout is scored with) is keyword overlap against the rubric text:

```python
# evolution/core/fitness.py
overlap = len(expected_words & output_words) / len(expected_words)
score = 0.3 + (0.7 * overlap)
```

This rewards echoing the rubric's vocabulary, not being right. `LLMJudge` exists but is dead code (imported in `evolve_skill.py`, never called), and even judge scoring is subjective: it never checks whether an answer is actually true. The Phase 1 validation report is honest about this and lists replacing the heuristic as its own next step.

So every reported improvement so far is unfalsifiable. Nothing downstream (benchmark gates, significance checks like #135/#136, Phase 2's tool-selection accuracy) means anything until the number being optimized measures reality.

## What this adds

A third, strongest tier of fitness signal: **objective verifiers** that grade outputs against checkable ground truth, plus a working reference implementation for the `arxiv` skill (the same skill the Phase 1 validation report used).

| Signal | How it scores | Trust |
|--------|--------------|-------|
| Objective verifier (new) | Compares output to verifiable facts; pure Python | Not gameable by rubric echoing, reproducible, $0 per grade |
| LLM-as-judge | Model grades a paraphrase on a rubric | Subjective, circular |
| Keyword overlap (current) | Lexical overlap with the rubric | Weakest |

### `evolution/core/verifier.py`

- `Verifier` ABC: a verifier owns both halves of the evaluation contract, `build_dataset()` (tasks whose answers are verifiable facts) and `score()` (grade an output against those facts). They must travel together, since the grader can only score tasks it knows the truth for.
- Registry (`@register_verifier`, `get_verifier(skill_name)`).
- `verifier_metric()` adapts a verifier to every metric calling convention in the pipeline: plain float for MIPROv2 and holdout comparison, and score-plus-feedback (`dspy.Prediction(score=..., feedback=...)`) when GEPA asks about a specific predictor. The verifier's feedback text ("expected ID 1706.03762, response said 1706.03799") is exactly the reflection signal GEPA mutates on.

### `evolution/verifiers/arxiv_verifier.py`

Grades four kinds of verifiable facts across 17 landmark ML papers (word2vec through the GEPA paper itself): arXiv IDs, exact titles, first authors, and submission years. Grading is regex plus normalization, no LLM calls.

Score shaping is monotone and anti-gaming:

| Output | Composite |
|--------|-----------|
| Correct and concise | 1.00 |
| Correct but hedged across several candidate IDs | 0.75 |
| Confidently wrong (an ID was given, it's the wrong one) | 0.50 |
| Evasive or empty | 0.00 |

Details that matter:

- **Hedging gets half credit.** Listing several candidate IDs where one happens to be right is not a usable answer, and full credit would reward shotgunning.
- **Conciseness only counts when an answer is present.** A brief evasion can never outscore a verbose correct answer (a test locks this in).
- **Year tasks are solvable from the ID alone** (the YYMM prefix), so they measure whether the skill teaches the arXiv ID format. That's a property a skill edit can genuinely flip, which is exactly the kind of headroom evolution needs.
- **ID-shaped substrings are stripped before year matching**, so quoting `2005.14165` doesn't get misread as the year 2005.

The embedded facts are historical constants, and every one is re-checkable against the live arXiv API:

```
$ python -m evolution.verifiers.arxiv_verifier --validate
All 17 papers verified against the live arXiv API.
```

All 51 facts (17 papers x title/author/year) passed at commit time.

### Wiring (`evolve_skill.py`)

New `--fitness auto|verifier|keyword` flag, default `auto`: use the objective verifier when one is registered for the skill, otherwise fall back to current behavior. When a verifier is active it also supplies the eval dataset (deterministic sample, 50/25/25 split, saved to `datasets/skills/<skill>-verifier/`).

```bash
# Objective fitness picked automatically
python -m evolution.skills.evolve_skill --skill arxiv --iterations 10

# See how the grader treats correct, wrong, and evasive answers
python -m evolution.verifiers.arxiv_verifier --demo
```

## Deliberate scope boundaries

- Does **not** touch GEPA instantiation, evolved-text extraction, or the frontmatter validator; #137, #146, #142, #140 and others own those fixes, and this composes with whichever of them land. The metric adapter already speaks GEPA's feedback protocol, so it plugs straight into a fixed optimizer loop.
- Does **not** replace judge or keyword scoring; the `--fitness` selector leaves room for an LLM-as-judge mode (as in #137) for skills where no objective verifier is possible.
- Adding a verifier for another skill is subclass-and-register; tool-selection accuracy (Phase 2) and test suites (Phase 4) are both objectively checkable, so this interface is the substrate those phases need anyway.

## Test plan

- 40 new tests (`tests/verifiers/test_arxiv_verifier.py`, `tests/core/test_verifier_registry.py`): grading correctness for all four fact kinds, the anti-gaming behaviors, dataset determinism and gradability, metric adapter under all three calling conventions, edge cases (empty output, unknown task, versioned IDs).
- Full suite: **183 passed** (143 existing + 40 new), offline; the live API is only touched by the `--validate` flag.
- Manual: `--validate` (17/17 papers verified), `--demo`, and `evolve_skill --dry-run` in both auto-verifier and forced-keyword modes.

No new dependencies (stdlib `urllib` + `xml.etree` for the validation fetch; `click`/`rich` already in use).
