### PR TITLE
feat(guardrails): semantic preservation constraint + holdout integrity (dedup, seeded splits)

### DIFF
--- a/evolution/core/config.py
+++ b/evolution/core/config.py
@@ -30,12 +30,23 @@ class EvolutionConfig:
     max_tool_desc_size: int = 500  # chars
     max_param_desc_size: int = 200  # chars
     max_prompt_growth: float = 0.2  # 20% max growth over baseline
+    # Minimum content-term cosine similarity between baseline and evolved
+    # text (PLAN.md constraint 4, semantic preservation). Calibrated on
+    # real hermes-agent skills: same-skill rewrites score 0.84+, pairs of
+    # unrelated skills below 0.16. Set to 0 to disable.
+    min_semantic_similarity: float = 0.4
 
     # Eval dataset
     eval_dataset_size: int = 20  # Total examples to generate
     train_ratio: float = 0.5
     val_ratio: float = 0.25
     holdout_ratio: float = 0.25
+    # Holdout integrity: near-duplicate tasks are removed before the
+    # train/val/holdout split so memorized train examples cannot leak
+    # into the holdout set, and the split itself is seeded so a dataset
+    # always splits the same way.
+    dedup_jaccard: float = 0.9  # Token-set Jaccard above this = duplicate
+    dataset_split_seed: int = 13
 
     # Benchmark gating
     run_pytest: bool = True

--- a/evolution/core/constraints.py
+++ b/evolution/core/constraints.py
@@ -4,12 +4,54 @@ Every candidate variant must pass ALL constraints before it can be
 considered valid. Failed constraints = immediate rejection.
 """
 
+import math
+import re
 import subprocess
+from collections import Counter
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Optional
 
 from evolution.core.config import EvolutionConfig
+
+# Common words that carry no topical signal. Deliberately small: the
+# 4+ char term filter already drops most function words, and an
+# aggressive stopword list would risk erasing domain vocabulary.
+_STOPWORDS = frozenset({
+    "about", "after", "also", "always", "been", "before", "being", "between",
+    "both", "cannot", "could", "does", "each", "either", "every", "from",
+    "have", "here", "instead", "into", "just", "like", "make", "more", "most",
+    "must", "never", "only", "other", "over", "should", "some", "such",
+    "than", "that", "them", "then", "there", "these", "they", "this",
+    "those", "under", "very", "want", "well", "were", "what", "when",
+    "where", "which", "while", "will", "with", "without", "would", "your",
+})
+
+
+def _content_terms(text: str) -> Counter:
+    """Frequency of topical terms: lowercase words of 4+ chars minus stopwords."""
+    words = re.findall(r"[a-z][a-z0-9_-]{3,}", text.lower())
+    return Counter(w for w in words if w not in _STOPWORDS)
+
+
+def semantic_similarity(baseline: str, evolved: str) -> float:
+    """Cosine similarity between the content-term frequencies of two texts.
+
+    A deterministic, dependency-free proxy for topical drift: a rewrite of
+    the same skill keeps most of its domain vocabulary (commands, API names,
+    concepts), while text that drifted to another purpose does not. Returns
+    a value in [0, 1].
+    """
+    a = _content_terms(baseline)
+    b = _content_terms(evolved)
+    if not a or not b:
+        return 1.0 if not a and not b else 0.0
+
+    shared = set(a) & set(b)
+    dot = sum(a[t] * b[t] for t in shared)
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
+    return dot / (norm_a * norm_b)
 
 
 @dataclass
@@ -39,9 +81,10 @@ class ConstraintValidator:
         # 1. Size limits
         results.append(self._check_size(artifact_text, artifact_type))
 
-        # 2. Growth limit (if baseline provided)
+        # 2. Baseline-relative checks (growth + semantic preservation)
         if baseline_text:
             results.append(self._check_growth(artifact_text, baseline_text, artifact_type))
+            results.append(self._check_semantic_preservation(artifact_text, baseline_text))
 
         # 3. Non-empty
         results.append(self._check_non_empty(artifact_text))
@@ -132,6 +175,38 @@ class ConstraintValidator:
                 constraint_name="growth_limit",
                 message=f"Growth exceeded: {growth:+.1%} (max {max_growth:+.1%})",
             )
+
+    def _check_semantic_preservation(self, text: str, baseline: str) -> ConstraintResult:
+        """Reject evolved text that drifted away from the baseline's purpose.
+
+        PLAN.md constraint 4: a skill for GitHub code review must still
+        perform code reviews, not drift into something else. Measured as
+        content-term cosine similarity against the baseline. Calibrated on
+        real hermes-agent skills: rewrites of the same skill score 0.84+,
+        while pairs of unrelated skills score below 0.16, so the default
+        threshold of 0.4 separates them with wide margin on both sides.
+        A threshold of 0 disables the check.
+        """
+        threshold = self.config.min_semantic_similarity
+        similarity = semantic_similarity(baseline, text)
+
+        if similarity >= threshold:
+            return ConstraintResult(
+                passed=True,
+                constraint_name="semantic_preservation",
+                message=f"Topic preserved: similarity {similarity:.2f} (min {threshold:.2f})",
+            )
+
+        # Show which topical vocabulary disappeared, for human review.
+        baseline_terms = _content_terms(baseline)
+        evolved_terms = _content_terms(text)
+        lost = [t for t, _ in baseline_terms.most_common(30) if t not in evolved_terms][:8]
+        return ConstraintResult(
+            passed=False,
+            constraint_name="semantic_preservation",
+            message=f"Topic drift: similarity {similarity:.2f} below minimum {threshold:.2f}",
+            details=f"Baseline terms missing from evolved text: {', '.join(lost)}" if lost else None,
+        )
 
     def _check_non_empty(self, text: str) -> ConstraintResult:
         if text.strip():

--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -8,6 +8,7 @@ C) Golden sets — hand-curated JSONL files
 
 import json
 import random
+import re
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Optional
@@ -15,6 +16,68 @@ from typing import Optional
 import dspy
 
 from evolution.core.config import EvolutionConfig
+
+
+def _dedup_key(text: str) -> str:
+    """Normalize a task for duplicate detection: casefold, strip punctuation,
+    collapse whitespace."""
+    return " ".join(re.sub(r"[^a-z0-9\s]", " ", text.lower()).split())
+
+
+def _token_jaccard(a: str, b: str) -> float:
+    """Jaccard similarity between the token sets of two normalized tasks."""
+    tokens_a = set(_dedup_key(a).split())
+    tokens_b = set(_dedup_key(b).split())
+    if not tokens_a or not tokens_b:
+        return 1.0 if tokens_a == tokens_b else 0.0
+    return len(tokens_a & tokens_b) / len(tokens_a | tokens_b)
+
+
+def dedupe_examples(examples: list["EvalExample"], jaccard_threshold: float = 0.9) -> list["EvalExample"]:
+    """Drop duplicate and near-duplicate tasks, keeping the first occurrence.
+
+    LLM generation and mined session history both produce repeats. If two
+    copies of the same task land on opposite sides of the train/holdout
+    split, the holdout is contaminated and "improvement" can be pure
+    memorization. Exact duplicates are matched on the normalized task text;
+    near-duplicates on token-set Jaccard similarity.
+    """
+    kept: list["EvalExample"] = []
+    seen_keys: set[str] = set()
+    for example in examples:
+        key = _dedup_key(example.task_input)
+        if key in seen_keys:
+            continue
+        if any(_token_jaccard(example.task_input, k.task_input) >= jaccard_threshold for k in kept):
+            continue
+        seen_keys.add(key)
+        kept.append(example)
+    return kept
+
+
+def split_examples(
+    examples: list["EvalExample"],
+    train_ratio: float = 0.5,
+    val_ratio: float = 0.25,
+    seed: int = 13,
+) -> "EvalDataset":
+    """Deterministic shuffled train/val/holdout split.
+
+    Seeded so the same examples always split the same way: re-running a
+    build cannot silently move an example from holdout into train.
+    """
+    shuffled = list(examples)
+    random.Random(seed).shuffle(shuffled)
+    n = len(shuffled)
+    if n == 0:
+        return EvalDataset()
+    n_train = max(1, int(n * train_ratio))
+    n_val = max(1, int(n * val_ratio))
+    return EvalDataset(
+        train=shuffled[:n_train],
+        val=shuffled[n_train:n_train + n_val],
+        holdout=shuffled[n_train + n_val:],
+    )
 
 
 @dataclass
@@ -156,16 +219,14 @@ class SyntheticDatasetBuilder:
             if c.get("task_input") and c.get("expected_behavior")
         ]
 
-        # Shuffle and split
-        random.shuffle(examples)
-        n_total = len(examples)
-        n_train = max(1, int(n_total * self.config.train_ratio))
-        n_val = max(1, int(n_total * self.config.val_ratio))
-
-        return EvalDataset(
-            train=examples[:n_train],
-            val=examples[n_train:n_train + n_val],
-            holdout=examples[n_train + n_val:],
+        # Dedupe (LLMs generate near-identical cases) and split with a
+        # fixed seed so holdout membership is stable across runs.
+        examples = dedupe_examples(examples, self.config.dedup_jaccard)
+        return split_examples(
+            examples,
+            train_ratio=self.config.train_ratio,
+            val_ratio=self.config.val_ratio,
+            seed=self.config.dataset_split_seed,
         )
 
 
@@ -189,13 +250,4 @@ class GoldenDatasetLoader:
                 if line.strip():
                     examples.append(EvalExample.from_dict(json.loads(line)))
 
-        random.shuffle(examples)
-        n = len(examples)
-        n_train = max(1, int(n * 0.5))
-        n_val = max(1, int(n * 0.25))
-
-        return EvalDataset(
-            train=examples[:n_train],
-            val=examples[n_train:n_train + n_val],
-            holdout=examples[n_train + n_val:],
-        )
+        return split_examples(dedupe_examples(examples))

--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -33,7 +33,7 @@ import dspy
 from rich.console import Console
 from rich.progress import Progress
 
-from evolution.core.dataset_builder import EvalExample, EvalDataset
+from evolution.core.dataset_builder import EvalExample, EvalDataset, dedupe_examples, split_examples
 
 console = Console()
 
@@ -668,17 +668,15 @@ def build_dataset_from_external(
             f"recommended for meaningful train/val/holdout split)[/yellow]"
         )
 
-    # Split into train/val/holdout (50/25/25)
-    random.shuffle(examples)
-    n = len(examples)
-    n_train = max(1, int(n * 0.5))
-    n_val = max(1, int(n * 0.25))
+    # Dedupe before splitting: session history repeats the same prompts,
+    # and a task present in both train and holdout contaminates the eval.
+    before = len(examples)
+    examples = dedupe_examples(examples)
+    if len(examples) < before:
+        console.print(f"  Removed {before - len(examples)} duplicate/near-duplicate tasks")
 
-    dataset = EvalDataset(
-        train=examples[:n_train],
-        val=examples[n_train:n_train + n_val],
-        holdout=examples[n_train + n_val:],
-    )
+    # Seeded split into train/val/holdout (50/25/25)
+    dataset = split_examples(examples)
 
     dataset.save(output_path)
     console.print(f"\n[bold]Saved to {output_path}/[/bold]")

--- a/tests/core/test_dataset_integrity.py
+++ b/tests/core/test_dataset_integrity.py
@@ -1,0 +1,125 @@
+"""Tests for holdout integrity: deduplication and seeded splits."""
+
+import json
+
+import pytest
+
+from evolution.core.dataset_builder import (
+    EvalExample,
+    GoldenDatasetLoader,
+    dedupe_examples,
+    split_examples,
+)
+
+
+def _example(task: str, rubric: str = "does the thing") -> EvalExample:
+    return EvalExample(task_input=task, expected_behavior=rubric)
+
+
+class TestDedupeExamples:
+    def test_exact_duplicates_removed_first_kept(self):
+        examples = [
+            _example("Find papers about transformers", rubric="first"),
+            _example("Find papers about transformers", rubric="second"),
+        ]
+        kept = dedupe_examples(examples)
+        assert len(kept) == 1
+        assert kept[0].expected_behavior == "first"
+
+    def test_case_and_punctuation_variants_are_duplicates(self):
+        examples = [
+            _example("Find papers about transformers."),
+            _example("find papers about Transformers"),
+        ]
+        assert len(dedupe_examples(examples)) == 1
+
+    def test_near_duplicates_removed(self):
+        examples = [
+            _example("Search the arxiv api for recent papers about diffusion models"),
+            _example("Search the arxiv api for recent papers about diffusion models today"),
+        ]
+        assert len(dedupe_examples(examples)) == 1
+
+    def test_distinct_tasks_kept(self):
+        examples = [
+            _example("Find the arXiv ID of the BERT paper"),
+            _example("Generate a BibTeX entry for the ResNet paper"),
+            _example("List recent papers on protein folding"),
+        ]
+        assert len(dedupe_examples(examples)) == 3
+
+    def test_threshold_is_respected(self):
+        examples = [
+            _example("alpha beta gamma delta"),
+            _example("alpha beta gamma epsilon"),  # Jaccard 3/5 = 0.6
+        ]
+        assert len(dedupe_examples(examples, jaccard_threshold=0.9)) == 2
+        assert len(dedupe_examples(examples, jaccard_threshold=0.5)) == 1
+
+    def test_empty_input(self):
+        assert dedupe_examples([]) == []
+
+
+class TestSplitExamples:
+    def _pool(self, n: int) -> list[EvalExample]:
+        return [_example(f"task number {i} about topic {i}") for i in range(n)]
+
+    def test_ratios(self):
+        dataset = split_examples(self._pool(20))
+        assert len(dataset.train) == 10
+        assert len(dataset.val) == 5
+        assert len(dataset.holdout) == 5
+
+    def test_same_seed_same_split(self):
+        pool = self._pool(20)
+        first = split_examples(pool, seed=13)
+        second = split_examples(pool, seed=13)
+        assert [e.task_input for e in first.holdout] == [e.task_input for e in second.holdout]
+
+    def test_different_seed_different_split(self):
+        pool = self._pool(40)
+        first = split_examples(pool, seed=13)
+        second = split_examples(pool, seed=14)
+        assert [e.task_input for e in first.holdout] != [e.task_input for e in second.holdout]
+
+    def test_splits_are_disjoint_and_complete(self):
+        pool = self._pool(21)
+        dataset = split_examples(pool)
+        train = {e.task_input for e in dataset.train}
+        val = {e.task_input for e in dataset.val}
+        holdout = {e.task_input for e in dataset.holdout}
+        assert not (train & val) and not (train & holdout) and not (val & holdout)
+        assert len(train | val | holdout) == 21
+
+    def test_input_order_is_not_mutated(self):
+        pool = self._pool(10)
+        original = [e.task_input for e in pool]
+        split_examples(pool)
+        assert [e.task_input for e in pool] == original
+
+    def test_empty_pool(self):
+        dataset = split_examples([])
+        assert dataset.all_examples == []
+
+
+class TestGoldenLoaderIntegrity:
+    def _write_golden(self, path, tasks):
+        golden = path / "golden.jsonl"
+        with open(golden, "w") as f:
+            for task in tasks:
+                f.write(json.dumps({"task_input": task, "expected_behavior": "rubric"}) + "\n")
+        return path
+
+    def test_load_is_deterministic_across_calls(self, tmp_path):
+        path = self._write_golden(tmp_path, [f"task number {i} about topic {i}" for i in range(12)])
+        first = GoldenDatasetLoader.load(path)
+        second = GoldenDatasetLoader.load(path)
+        assert [e.task_input for e in first.holdout] == [e.task_input for e in second.holdout]
+
+    def test_load_dedupes(self, tmp_path):
+        path = self._write_golden(
+            tmp_path,
+            ["do the thing", "Do the thing!", "a completely different task entirely"],
+        )
+        dataset = GoldenDatasetLoader.load(path)
+        assert len(dataset.all_examples) == 2

--- a/tests/core/test_semantic_preservation.py
+++ b/tests/core/test_semantic_preservation.py
@@ -1,0 +1,99 @@
+"""Tests for the semantic preservation constraint (PLAN.md constraint 4)."""
+
+import pytest
+
+from evolution.core.config import EvolutionConfig
+from evolution.core.constraints import ConstraintValidator, semantic_similarity
+
+# Two texts about the same skill, written very differently.
+REVIEW_SKILL = """
+# GitHub Code Review
+
+Fetch the pull request diff with `gh pr diff`. Read every changed file.
+Look for bugs, security issues, and missing tests. Post review comments
+with `gh pr review` explaining each finding with file and line references.
+"""
+
+REVIEW_SKILL_REWRITTEN = """
+# Reviewing Pull Requests on GitHub
+
+Start by pulling the diff (`gh pr diff`) and reading the changed files
+carefully. Hunt for security problems, bugs, and gaps in test coverage.
+Then submit findings as review comments (`gh pr review`), each anchored
+to a file and line so the author can act on them.
+"""
+
+# A different topic entirely.
+BAKING_TEXT = """
+# Sourdough Baking
+
+Feed the starter twice daily. Mix flour, water, and salt, then rest the
+dough for autolyse. Fold every thirty minutes, shape the boule, proof
+overnight in the fridge, and bake in a dutch oven at high heat.
+"""
+
+
+def _config():
+    return EvolutionConfig(hermes_agent_path=None)
+
+
+class TestSemanticSimilarity:
+    def test_identical_text_is_one(self):
+        assert semantic_similarity(REVIEW_SKILL, REVIEW_SKILL) == pytest.approx(1.0)
+
+    def test_rewrite_of_same_skill_scores_high(self):
+        assert semantic_similarity(REVIEW_SKILL, REVIEW_SKILL_REWRITTEN) > 0.5
+
+    def test_unrelated_topic_scores_low(self):
+        assert semantic_similarity(REVIEW_SKILL, BAKING_TEXT) < 0.2
+
+    def test_empty_evolved_text_is_zero(self):
+        assert semantic_similarity(REVIEW_SKILL, "") == pytest.approx(0.0)
+
+    def test_two_empty_texts_are_identical(self):
+        assert semantic_similarity("", "") == pytest.approx(1.0)
+
+    def test_symmetry(self):
+        forward = semantic_similarity(REVIEW_SKILL, BAKING_TEXT)
+        backward = semantic_similarity(BAKING_TEXT, REVIEW_SKILL)
+        assert forward == pytest.approx(backward)
+
+
+class TestSemanticPreservationConstraint:
+    def test_runs_only_with_baseline(self):
+        validator = ConstraintValidator(_config())
+        names = [r.constraint_name for r in validator.validate_all(REVIEW_SKILL, "skill")]
+        assert "semantic_preservation" not in names
+
+        names = [
+            r.constraint_name
+            for r in validator.validate_all(REVIEW_SKILL, "skill", baseline_text=REVIEW_SKILL)
+        ]
+        assert "semantic_preservation" in names
+
+    def test_faithful_rewrite_passes(self):
+        validator = ConstraintValidator(_config())
+        results = validator.validate_all(
+            REVIEW_SKILL_REWRITTEN, "skill", baseline_text=REVIEW_SKILL
+        )
+        result = next(r for r in results if r.constraint_name == "semantic_preservation")
+        assert result.passed
+        assert "similarity" in result.message
+
+    def test_topic_drift_fails_with_lost_terms(self):
+        validator = ConstraintValidator(_config())
+        results = validator.validate_all(BAKING_TEXT, "skill", baseline_text=REVIEW_SKILL)
+        result = next(r for r in results if r.constraint_name == "semantic_preservation")
+        assert not result.passed
+        assert "drift" in result.message.lower()
+        # The details should name baseline vocabulary that disappeared.
+        assert result.details
+        assert "review" in result.details or "diff" in result.details
+
+    def test_zero_threshold_disables_the_check(self):
+        config = _config()
+        config.min_semantic_similarity = 0.0
+        validator = ConstraintValidator(config)
+        results = validator.validate_all(BAKING_TEXT, "skill", baseline_text=REVIEW_SKILL)
+        result = next(r for r in results if r.constraint_name == "semantic_preservation")
+        assert result.passed


### PR DESCRIPTION
## The problem

PLAN.md's Constraints & Guardrails section says every candidate variant "must pass ALL of these" before it can be considered valid. Two of those guardrails exist only on paper:

**1. Semantic preservation (constraint 4).** The PLAN requires that evolved text is "compared against the original to ensure it hasn't drifted too far in meaning", and the README's guardrail list already advertises it. Nothing implements it. `validate_all` checks size, growth, non-emptiness, and structure; a skill for GitHub code review could evolve into a poem and pass every gate.

**2. Holdout integrity.** The Safety section relies on "Holdout test sets, separate from training data, to catch overfitting". Two things quietly break that separation today:

- No deduplication anywhere. LLM dataset generation emits near-identical test cases, and mined session history repeats the same prompts constantly. When two copies of one task land on opposite sides of the split, the holdout is contaminated and a measured "improvement" can be pure memorization.
- All three dataset sources (synthetic, golden, external importers) split with an unseeded global `random.shuffle`, so re-building a dataset silently reshuffles holdout membership between runs. An example that was holdout yesterday can be training data today.

Both problems corrupt the exact number Phase 1's gate ("at least one skill measurably improved") is judged on.

## What this adds

### Semantic preservation constraint

`semantic_similarity(baseline, evolved)` in `constraints.py`: cosine similarity over content-term frequencies (4+ char words minus a small stopword list). Deterministic, dependency-free, zero API cost. A new `semantic_preservation` check runs whenever `validate_all` receives a `baseline_text`, which is exactly the existing evolved-candidate call in `evolve_skill.py`, so no caller changes are needed and baseline-only validation is unaffected.

Calibrated against real hermes-agent skills (`arxiv`, `pixel-art`, `dcf-model`, `docker-management`, `cli`):

| Comparison | Similarity |
|------------|-----------|
| Same skill, rewritten (half-doc, or 33% deleted + lines shuffled) | 0.84 to 0.99 |
| Pairs of unrelated skills | 0.04 to 0.16 |

The default threshold of `0.4` sits in the middle of that gap with wide margin on both sides. Failures report the score plus the baseline vocabulary that disappeared ("Baseline terms missing from evolved text: review, diff, ..."), which tells a human reviewer at a glance what the mutation destroyed. `min_semantic_similarity = 0` disables the check.

### Holdout integrity

Two helpers in `dataset_builder.py`, applied to all three dataset sources:

- `dedupe_examples()`: removes exact duplicates (normalized task text) and near-duplicates (token-set Jaccard, default 0.9), keeping the first occurrence. The importer path reports how many were removed.
- `split_examples()`: one seeded shuffled split (default seed 13, configurable) replacing the three copies of the unseeded shuffle-and-slice logic. The same examples now always produce the same train/val/holdout membership, and the input list is not mutated.

New config knobs: `min_semantic_similarity`, `dedup_jaccard`, `dataset_split_seed`.

## Deliberate scope boundaries

- **No changes to `evolve_skill.py`, `skill_module.py`, or any optimizer code.** This PR does not overlap with the open fixes for GEPA compatibility, evolved-text extraction, or validator false positives (#137, #146, #142, #140, #134); it composes with all of them.
- New tests live in new files (`test_semantic_preservation.py`, `test_dataset_integrity.py`) rather than `test_constraints.py`, to avoid merge conflicts with PRs that edit that file.
- Deduplication uses lexical matching only, on purpose: it is deterministic, free, and catches the failure mode that actually occurs (repeated or trivially reworded tasks). Embedding-based near-dup detection would add a dependency and nondeterminism for marginal gain.

## Test plan

- 26 new tests: similarity behavior (identity, rewrite, drift, empty, symmetry), constraint gating (runs only with a baseline, pass/fail, lost-terms reporting, threshold 0 disables), dedup (exact, case/punctuation variants, near-dup, threshold respected, first-kept), splits (ratios, seed determinism, disjointness, input not mutated), and golden-loader integration (deterministic across calls, dedupes on load).
- Full suite: **169 passed** (143 existing + 26 new), fully offline.
- Calibration reproducible with the five skill files named above and `semantic_similarity()`.
