### PR TITLE
feat(core): run manifests with cost accounting and constraint audit trail

### DIFF
--- a/evolution/core/manifest.py
+++ b/evolution/core/manifest.py
@@ -1,0 +1,236 @@
+"""Run manifests: the evidence record for every evolution run.
+
+PLAN.md's deployment process requires each evolved artifact to ship with
+before/after scores on every split, the eval dataset used, the cost of
+the optimization run, and any constraint violations that were caught.
+None of that can be reported honestly unless it is recorded at run time.
+
+A RunManifest captures, in one machine-readable JSON file next to the
+evolved output:
+
+  - what ran: skill, config snapshot (models, iterations, thresholds)
+  - on what data: per-split counts and a content fingerprint of the
+    eval dataset, so two runs can be compared apples-to-apples
+  - what came out: content digests and sizes of baseline and evolved
+    text, constraint results, holdout scores per example
+  - what it cost: LLM calls, tokens, and dollars, summed from dspy's
+    call history
+  - whether it was deployable: constraints all passed or not
+
+Manifests are written on failed runs too; a rejected candidate with its
+violations on record is exactly the audit trail the PLAN asks for.
+"""
+
+import hashlib
+import json
+from dataclasses import dataclass, field, asdict, is_dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+try:
+    from dspy.clients.base_lm import GLOBAL_HISTORY, MAX_HISTORY_SIZE
+except ImportError:  # dspy internals moved; degrade to no usage tracking
+    GLOBAL_HISTORY: list = []
+    MAX_HISTORY_SIZE = 10_000
+
+SCHEMA_VERSION = 1
+
+
+def text_digest(text: str) -> str:
+    """Short, stable content digest for baseline/evolved text."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def config_snapshot(config: Any) -> dict:
+    """JSON-safe snapshot of an EvolutionConfig (Paths become strings)."""
+    raw = asdict(config) if is_dataclass(config) else dict(vars(config))
+    return {k: str(v) if isinstance(v, Path) else v for k, v in raw.items()}
+
+
+@dataclass
+class DatasetFingerprint:
+    """Identity of an eval dataset: split sizes plus a content hash.
+
+    The hash covers (split, task) pairs, order-independent within a
+    split but sensitive to split membership: moving one example from
+    holdout to train changes the fingerprint. Two runs with the same
+    fingerprint were measured on the same data.
+    """
+
+    train: int
+    val: int
+    holdout: int
+    sha256: str
+
+    @classmethod
+    def from_dataset(cls, dataset: Any) -> "DatasetFingerprint":
+        items = sorted(
+            (split, " ".join(example.task_input.split()))
+            for split in ("train", "val", "holdout")
+            for example in getattr(dataset, split)
+        )
+        digest = hashlib.sha256(json.dumps(items).encode("utf-8")).hexdigest()[:16]
+        return cls(
+            train=len(dataset.train),
+            val=len(dataset.val),
+            holdout=len(dataset.holdout),
+            sha256=digest,
+        )
+
+
+@dataclass
+class LMUsageSummary:
+    """LLM spend across a tracked window: calls, tokens, and dollars."""
+
+    calls: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    # Sum over calls whose cost the provider reported. None when no call
+    # had a known cost (unknown models, cache hits).
+    cost_usd: Optional[float] = None
+    calls_with_unknown_cost: int = 0
+    # True when dspy's bounded history may have evicted entries from
+    # this window, so the numbers are a lower bound.
+    possibly_incomplete: bool = False
+
+
+class UsageTracker:
+    """Sums LLM usage recorded by dspy between start() and finish().
+
+    dspy appends every LM call to a global, size-bounded history where
+    each entry carries token usage, provider-reported cost, and an ISO
+    timestamp. The tracker snapshots the clock at start() and attributes
+    every entry stamped at or after it to this run.
+
+    The history and its size cap are injectable for testing.
+    """
+
+    def __init__(self, history: Optional[list] = None, max_size: Optional[int] = None):
+        self._history = GLOBAL_HISTORY if history is None else history
+        self._max_size = MAX_HISTORY_SIZE if max_size is None else max_size
+        self._start_iso: Optional[str] = None
+
+    def start(self) -> "UsageTracker":
+        self._start_iso = datetime.now().isoformat()
+        return self
+
+    def finish(self) -> LMUsageSummary:
+        if self._start_iso is None:
+            return LMUsageSummary()
+
+        summary = LMUsageSummary()
+        cost_total = 0.0
+        cost_seen = False
+
+        for entry in self._history:
+            if entry.get("timestamp", "") < self._start_iso:
+                continue
+            summary.calls += 1
+
+            usage = entry.get("usage") or {}
+            for attr, key in (
+                ("prompt_tokens", "prompt_tokens"),
+                ("completion_tokens", "completion_tokens"),
+                ("total_tokens", "total_tokens"),
+            ):
+                value = usage.get(key)
+                if isinstance(value, (int, float)):
+                    setattr(summary, attr, getattr(summary, attr) + int(value))
+
+            cost = entry.get("cost")
+            if isinstance(cost, (int, float)):
+                cost_total += float(cost)
+                cost_seen = True
+            else:
+                summary.calls_with_unknown_cost += 1
+
+        if cost_seen:
+            summary.cost_usd = round(cost_total, 6)
+
+        # If the bounded history filled up and its oldest surviving entry
+        # is newer than our start, entries from this window were evicted.
+        if (
+            len(self._history) >= self._max_size
+            and self._history
+            and self._history[0].get("timestamp", "") > self._start_iso
+        ):
+            summary.possibly_incomplete = True
+
+        return summary
+
+
+@dataclass
+class RunManifest:
+    """Everything needed to audit or reproduce one evolution run."""
+
+    run_id: str
+    created_at: str
+    skill_name: str
+    skill_path: str
+    config: dict
+    dataset: DatasetFingerprint
+    baseline: dict  # {"sha256", "chars"}
+    evolved: dict  # {"sha256", "chars"}
+    constraints: list = field(default_factory=list)
+    # None when the run was rejected before holdout evaluation.
+    scores: Optional[dict] = None
+    deployed: bool = False
+    elapsed_seconds: Optional[float] = None
+    usage: LMUsageSummary = field(default_factory=LMUsageSummary)
+    schema_version: int = SCHEMA_VERSION
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        run_id: str,
+        skill_name: str,
+        skill_path: Path,
+        config: Any,
+        dataset: Any,
+        baseline_text: str,
+        evolved_text: str,
+        constraint_results: list,
+        scores: Optional[dict],
+        deployed: bool,
+        elapsed_seconds: Optional[float],
+        usage: LMUsageSummary,
+    ) -> "RunManifest":
+        return cls(
+            run_id=run_id,
+            created_at=datetime.now().isoformat(),
+            skill_name=skill_name,
+            skill_path=str(skill_path),
+            config=config_snapshot(config),
+            dataset=DatasetFingerprint.from_dataset(dataset),
+            baseline={"sha256": text_digest(baseline_text), "chars": len(baseline_text)},
+            evolved={"sha256": text_digest(evolved_text), "chars": len(evolved_text)},
+            constraints=[
+                {
+                    "name": getattr(r, "constraint_name", ""),
+                    "passed": bool(getattr(r, "passed", False)),
+                    "message": getattr(r, "message", ""),
+                    "details": getattr(r, "details", None),
+                }
+                for r in constraint_results
+            ],
+            scores=scores,
+            deployed=deployed,
+            elapsed_seconds=elapsed_seconds,
+            usage=usage,
+        )
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def save(self, path: Path) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.to_dict(), indent=2) + "\n")
+        return path
+
+    @classmethod
+    def load(cls, path: Path) -> dict:
+        """Read a saved manifest as a plain dict (for reports and tooling)."""
+        return json.loads(path.read_text())

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -23,6 +23,7 @@ from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset,
 from evolution.core.external_importers import build_dataset_from_external
 from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore
 from evolution.core.constraints import ConstraintValidator
+from evolution.core.manifest import RunManifest, UsageTracker
 from evolution.skills.skill_module import (
     SkillModule,
     load_skill,
@@ -75,6 +76,11 @@ def evolve(
         console.print(f"  Would run GEPA optimization ({iterations} iterations)")
         console.print(f"  Would validate constraints and create PR")
         return
+
+    # Track LLM usage and cost for the whole run (dataset generation,
+    # optimization, and holdout scoring) so the manifest can report it.
+    usage_tracker = UsageTracker().start()
+    run_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
     # ── 2. Build or load evaluation dataset ─────────────────────────────
     console.print(f"\n[bold]Building evaluation dataset[/bold] (source: {eval_source})")
@@ -201,6 +207,23 @@ def evolve(
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(evolved_full)
         console.print(f"  Saved failed variant to {output_path}")
+        # Record the rejection: caught violations are part of the audit trail
+        manifest = RunManifest.build(
+            run_id=f"{skill_name}-{run_timestamp}",
+            skill_name=skill_name,
+            skill_path=skill_path,
+            config=config,
+            dataset=dataset,
+            baseline_text=skill["body"],
+            evolved_text=evolved_body,
+            constraint_results=evolved_constraints,
+            scores=None,
+            deployed=False,
+            elapsed_seconds=elapsed,
+            usage=usage_tracker.finish(),
+        )
+        manifest_path = manifest.save(output_path.parent / "manifest_FAILED.json")
+        console.print(f"  Manifest: {manifest_path}")
         return
 
     # ── 8. Evaluate on holdout set ──────────────────────────────────────
@@ -225,6 +248,8 @@ def evolve(
     avg_evolved = sum(evolved_scores) / max(1, len(evolved_scores))
     improvement = avg_evolved - avg_baseline
 
+    usage = usage_tracker.finish()
+
     # ── 9. Report results ───────────────────────────────────────────────
     table = Table(title="Evolution Results")
     table.add_column("Metric", style="bold")
@@ -247,12 +272,18 @@ def evolve(
     )
     table.add_row("Time", "", f"{elapsed:.1f}s", "")
     table.add_row("Iterations", "", str(iterations), "")
+    if usage.calls:
+        table.add_row("LLM Calls", "", f"{usage.calls} ({usage.total_tokens:,} tokens)", "")
+        cost_text = f"${usage.cost_usd:.4f}" if usage.cost_usd is not None else "unknown"
+        if usage.calls_with_unknown_cost and usage.cost_usd is not None:
+            cost_text += f" (+{usage.calls_with_unknown_cost} unpriced calls)"
+        table.add_row("LLM Cost", "", cost_text, "")
 
     console.print()
     console.print(table)
 
     # ── 10. Save output ─────────────────────────────────────────────────
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    timestamp = run_timestamp
     output_dir = Path("output") / skill_name / timestamp
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -282,7 +313,32 @@ def evolve(
     }
     (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
 
+    # Full evidence record: config, dataset fingerprint, digests,
+    # constraint results, per-example scores, and LLM cost
+    manifest = RunManifest.build(
+        run_id=f"{skill_name}-{timestamp}",
+        skill_name=skill_name,
+        skill_path=skill_path,
+        config=config,
+        dataset=dataset,
+        baseline_text=skill["body"],
+        evolved_text=evolved_body,
+        constraint_results=evolved_constraints,
+        scores={
+            "baseline_holdout": avg_baseline,
+            "evolved_holdout": avg_evolved,
+            "improvement": improvement,
+            "baseline_scores": baseline_scores,
+            "evolved_scores": evolved_scores,
+        },
+        deployed=True,
+        elapsed_seconds=elapsed,
+        usage=usage,
+    )
+    manifest.save(output_dir / "manifest.json")
+
     console.print(f"\n  Output saved to {output_dir}/")
+    console.print(f"  Manifest: {output_dir}/manifest.json")
 
     if improvement > 0:
         console.print(f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement/max(0.001, avg_baseline)*100:+.1f}%)[/bold green]")

--- a/tests/core/test_manifest.py
+++ b/tests/core/test_manifest.py
@@ -1,0 +1,180 @@
+"""Tests for run manifests: usage tracking, fingerprints, serialization."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from evolution.core.config import EvolutionConfig
+from evolution.core.dataset_builder import EvalDataset, EvalExample
+from evolution.core.manifest import (
+    DatasetFingerprint,
+    LMUsageSummary,
+    RunManifest,
+    UsageTracker,
+    config_snapshot,
+    text_digest,
+)
+
+
+def _example(task: str) -> EvalExample:
+    return EvalExample(task_input=task, expected_behavior="rubric")
+
+
+def _dataset() -> EvalDataset:
+    return EvalDataset(
+        train=[_example("task a"), _example("task b")],
+        val=[_example("task c")],
+        holdout=[_example("task d")],
+    )
+
+
+def _entry(cost=0.001, prompt=100, completion=50, timestamp=None) -> dict:
+    return {
+        "timestamp": timestamp or datetime.now().isoformat(),
+        "cost": cost,
+        "usage": {
+            "prompt_tokens": prompt,
+            "completion_tokens": completion,
+            "total_tokens": prompt + completion,
+        },
+    }
+
+
+class TestTextDigest:
+    def test_deterministic(self):
+        assert text_digest("hello") == text_digest("hello")
+
+    def test_differs_by_content(self):
+        assert text_digest("hello") != text_digest("hello!")
+
+
+class TestConfigSnapshot:
+    def test_json_serializable_with_paths(self):
+        config = EvolutionConfig(hermes_agent_path=Path("/tmp/repo"))
+        snapshot = config_snapshot(config)
+        json.dumps(snapshot)  # Must not raise
+        assert snapshot["hermes_agent_path"] == "/tmp/repo"
+        assert snapshot["iterations"] == 10
+
+
+class TestDatasetFingerprint:
+    def test_counts(self):
+        fp = DatasetFingerprint.from_dataset(_dataset())
+        assert (fp.train, fp.val, fp.holdout) == (2, 1, 1)
+
+    def test_order_within_split_does_not_matter(self):
+        a = EvalDataset(train=[_example("x"), _example("y")], holdout=[_example("z")])
+        b = EvalDataset(train=[_example("y"), _example("x")], holdout=[_example("z")])
+        assert DatasetFingerprint.from_dataset(a).sha256 == DatasetFingerprint.from_dataset(b).sha256
+
+    def test_split_membership_matters(self):
+        a = EvalDataset(train=[_example("x")], holdout=[_example("z")])
+        b = EvalDataset(train=[_example("z")], holdout=[_example("x")])
+        assert DatasetFingerprint.from_dataset(a).sha256 != DatasetFingerprint.from_dataset(b).sha256
+
+
+class TestUsageTracker:
+    def test_sums_tokens_cost_and_calls(self):
+        history: list = []
+        tracker = UsageTracker(history=history).start()
+        history.append(_entry(cost=0.002))
+        history.append(_entry(cost=0.003))
+        summary = tracker.finish()
+        assert summary.calls == 2
+        assert summary.prompt_tokens == 200
+        assert summary.completion_tokens == 100
+        assert summary.total_tokens == 300
+        assert summary.cost_usd == pytest.approx(0.005)
+        assert not summary.possibly_incomplete
+
+    def test_ignores_entries_before_start(self):
+        history = [_entry(timestamp="2000-01-01T00:00:00")]
+        tracker = UsageTracker(history=history).start()
+        history.append(_entry())
+        assert tracker.finish().calls == 1
+
+    def test_unknown_cost_counted_separately(self):
+        history: list = []
+        tracker = UsageTracker(history=history).start()
+        history.append(_entry(cost=None))
+        history.append(_entry(cost=0.004))
+        summary = tracker.finish()
+        assert summary.cost_usd == pytest.approx(0.004)
+        assert summary.calls_with_unknown_cost == 1
+
+    def test_all_costs_unknown_reports_none(self):
+        history: list = []
+        tracker = UsageTracker(history=history).start()
+        history.append(_entry(cost=None))
+        summary = tracker.finish()
+        assert summary.cost_usd is None
+        assert summary.calls_with_unknown_cost == 1
+
+    def test_no_calls(self):
+        summary = UsageTracker(history=[]).start().finish()
+        assert summary.calls == 0
+        assert summary.cost_usd is None
+
+    def test_finish_without_start(self):
+        assert UsageTracker(history=[_entry()]).finish().calls == 0
+
+    def test_eviction_sets_incomplete_flag(self):
+        history: list = []
+        tracker = UsageTracker(history=history, max_size=2).start()
+        history.append(_entry())
+        history.append(_entry())
+        assert tracker.finish().possibly_incomplete
+
+
+class TestRunManifest:
+    def _build(self, scores=None, deployed=False) -> RunManifest:
+        return RunManifest.build(
+            run_id="arxiv-20260712_120000",
+            skill_name="arxiv",
+            skill_path=Path("/repo/skills/research/arxiv/SKILL.md"),
+            config=EvolutionConfig(hermes_agent_path=None),
+            dataset=_dataset(),
+            baseline_text="baseline skill text",
+            evolved_text="evolved skill text",
+            constraint_results=[
+                SimpleNamespace(constraint_name="size_limit", passed=True, message="ok", details=None),
+                SimpleNamespace(constraint_name="growth_limit", passed=False, message="too big", details="d"),
+            ],
+            scores=scores,
+            deployed=deployed,
+            elapsed_seconds=12.5,
+            usage=LMUsageSummary(calls=3, total_tokens=900, cost_usd=0.01),
+        )
+
+    def test_round_trip(self, tmp_path):
+        manifest = self._build(
+            scores={"baseline_holdout": 0.4, "evolved_holdout": 0.6, "improvement": 0.2},
+            deployed=True,
+        )
+        path = manifest.save(tmp_path / "run" / "manifest.json")
+        loaded = RunManifest.load(path)
+        assert loaded["run_id"] == "arxiv-20260712_120000"
+        assert loaded["deployed"] is True
+        assert loaded["scores"]["improvement"] == pytest.approx(0.2)
+        assert loaded["usage"]["cost_usd"] == pytest.approx(0.01)
+        assert loaded["dataset"]["train"] == 2
+        assert loaded["schema_version"] == 1
+
+    def test_constraints_recorded_including_failures(self):
+        manifest = self._build()
+        names = {c["name"]: c["passed"] for c in manifest.to_dict()["constraints"]}
+        assert names == {"size_limit": True, "growth_limit": False}
+
+    def test_rejected_run_has_no_scores(self, tmp_path):
+        manifest = self._build(scores=None, deployed=False)
+        loaded = RunManifest.load(manifest.save(tmp_path / "manifest.json"))
+        assert loaded["scores"] is None
+        assert loaded["deployed"] is False
+
+    def test_digests_distinguish_baseline_and_evolved(self):
+        d = self._build().to_dict()
+        assert d["baseline"]["sha256"] != d["evolved"]["sha256"]
+        assert d["baseline"]["chars"] == len("baseline skill text")


### PR DESCRIPTION
## The problem

PLAN.md's "Deployment via PR" section (the release process for evolved artifacts) requires each evolution to ship with:

- before/after scores on train, validation, AND holdout sets
- the eval dataset used
- **the cost of the optimization run**
- **any constraint violations that were caught and rejected during evolution**

Today none of that is recorded. `metrics.json` holds aggregate scores and character counts; cost is invisible (the README advertises "$2-10 per optimization run" but no run can actually report what it spent); a rejected candidate leaves nothing behind except an `evolved_FAILED.md` file with no record of which constraints failed or why; and there is no way to tell whether two runs were even measured on the same dataset. Whoever assembles the deployment PR has nothing trustworthy to quote.

## What this adds

`evolution/core/manifest.py`: one machine-readable `manifest.json` written next to every run's output, deployable or not.

**RunManifest** records, per run:

- a config snapshot (models, iterations, thresholds; Paths serialized)
- a **dataset fingerprint**: per-split counts plus a content hash that is order-independent within a split but sensitive to split membership, so moving one example from holdout to train changes the fingerprint. Two runs with the same fingerprint were measured on the same data.
- content digests and sizes of baseline and evolved text
- full constraint results (name, passed, message, details), including failures
- per-example holdout scores for baseline and evolved, not just the averages, so a later significance check has raw material to work with
- elapsed time and LLM usage

**UsageTracker** sums calls, tokens, and provider-reported cost from dspy's LM call history across the whole run: dataset generation, optimization, and holdout scoring. Honesty details:

- calls whose cost the provider does not report are counted separately (`calls_with_unknown_cost`) rather than silently treated as free
- dspy's call history is size-bounded; if entries from this run may have been evicted, the summary carries a `possibly_incomplete` flag so totals are never silently understated
- the history and its cap are injectable, so all tests run offline

**Rejected runs get manifests too.** The constraint-failure path now writes `manifest_FAILED.json` with the violations on record. That is the "caught and rejected" audit trail the PLAN asks for; today those rejections vanish.

`evolve_skill.py` changes are additive only: start the tracker after the dry-run gate, two new rows in the results table (LLM calls/tokens and cost), and manifest writes on both exit paths. The output directory now reuses the run's own timestamp so the run id and the directory name match.

```
Results table gains:
  LLM Calls    142 (81,304 tokens)
  LLM Cost     $0.3126 (+3 unpriced calls)
```

## Why this is the right next step

The pipeline's remaining pillars are already owned: correctness gates (#127), statistical significance (#136), and PR emission (#139) are open, and the optimizer fixes are contested across #137/#146/#142/#140. What every one of those consumers lacks is a trustworthy record to read from. The manifest is that substrate, and it stays useful standalone: it depends on none of those PRs and none of them depend on it.

## Deliberate scope boundaries

- Does not modify `skill_module.py`, the GEPA/MIPROv2 calls, constraints, or datasets; `evolve_skill.py` edits are purely additive.
- Does not format PR bodies from the manifest; that is #139's job, and it can read `manifest.json` if it lands.
- `metrics.json` is kept as-is for backward compatibility.

## Test plan

- 19 new tests in `tests/core/test_manifest.py`: digest determinism, config snapshot serialization with Paths, fingerprint properties (counts, order-independence, split sensitivity), usage tracking (summing, pre-start exclusion, unknown-cost accounting, all-unknown reporting None, empty history, finish-without-start, eviction flag), and manifest round-trips including the rejected-run shape.
- Full suite: **162 passed** (143 existing + 19 new), fully offline.
- `evolve_skill --dry-run` verified unchanged.
- The dspy history entry shape (`usage`, `cost`, ISO `timestamp`, 10,000-entry cap with FIFO eviction) was verified directly against dspy 3.2.1 source.
