### PR TITLE
fix: make DSPy skill evolution persist optimized instructions

### DIFF
--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -8,6 +8,7 @@ C) Golden sets — hand-curated JSONL files
 
 import json
 import random
+import re
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Optional
@@ -133,16 +134,33 @@ class SyntheticDatasetBuilder:
             )
 
         # Parse the generated test cases
+        response = result.test_cases.strip()
+        if response.startswith("```"):
+            fence, newline, fenced_body = response.partition("\n")
+            if fence.lower() not in {"```", "```json"} or not newline or not fenced_body.endswith("```"):
+                raise ValueError(f"Could not parse fenced test cases from LLM output: {response[:200]}")
+            response = fenced_body[:-3].strip()
         try:
-            cases_raw = json.loads(result.test_cases)
+            cases_raw = json.loads(response)
         except json.JSONDecodeError:
-            # Try to extract JSON from the response
-            import re
-            match = re.search(r'\[.*\]', result.test_cases, re.DOTALL)
-            if match:
-                cases_raw = json.loads(match.group())
-            else:
-                raise ValueError(f"Could not parse test cases from LLM output: {result.test_cases[:200]}")
+            start = response.find("[")
+            if start < 0:
+                raise ValueError(f"Could not parse test cases from LLM output: {response[:200]}")
+            try:
+                cases_raw, end = json.JSONDecoder().raw_decode(response[start:])
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Could not parse test cases from LLM output: {response[:200]}") from e
+
+            trailing = response[start + end:].strip()
+            completion = re.fullmatch(
+                r"\[\[ ## completed ## \]\](?:\s+Generation finished for [A-Za-z0-9_.-]+ skill cases\.)?",
+                trailing,
+            )
+            if not completion:
+                raise ValueError(f"Unexpected text after test-case JSON: {trailing[:200]}")
+
+        if not isinstance(cases_raw, list):
+            raise ValueError("Test-case JSON must be an array")
 
         examples = [
             EvalExample(

--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -490,7 +490,7 @@ class RelevanceFilter:
         # Stage 2: LLM relevance scoring
         examples = []
         errors = 0
-        lm = dspy.LM(self.model)
+        lm = dspy.LM(self.model, think=False) if self.model.startswith("ollama_chat/") else dspy.LM(self.model)
 
         with Progress() as progress:
             task = progress.add_task("Scoring relevance...", total=len(candidates))

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -104,7 +104,13 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+def skill_fitness_metric(
+    example: dspy.Example,
+    prediction: dspy.Prediction,
+    trace=None,
+    pred_name: str | None = None,
+    pred_trace=None,
+) -> float:
     """DSPy-compatible metric function for skill optimization.
 
     This is what gets passed to dspy.GEPA(metric=...).

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -137,7 +137,12 @@ def evolve(
     console.print(f"  Eval model: {eval_model}")
 
     # Configure DSPy
-    lm = dspy.LM(eval_model)
+    lm = dspy.LM(eval_model, think=False) if eval_model.startswith("ollama_chat/") else dspy.LM(eval_model)
+    reflection_lm = (
+        dspy.LM(optimizer_model, think=False)
+        if optimizer_model.startswith("ollama_chat/")
+        else dspy.LM(optimizer_model)
+    )
     dspy.configure(lm=lm)
 
     # Create the baseline skill module
@@ -152,28 +157,16 @@ def evolve(
 
     start_time = time.time()
 
-    try:
-        optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
-            max_steps=iterations,
-        )
-
-        optimized_module = optimizer.compile(
-            baseline_module,
-            trainset=trainset,
-            valset=valset,
-        )
-    except Exception as e:
-        # Fall back to MIPROv2 if GEPA isn't available in this DSPy version
-        console.print(f"[yellow]GEPA not available ({e}), falling back to MIPROv2[/yellow]")
-        optimizer = dspy.MIPROv2(
-            metric=skill_fitness_metric,
-            auto="light",
-        )
-        optimized_module = optimizer.compile(
-            baseline_module,
-            trainset=trainset,
-        )
+    optimizer = dspy.GEPA(
+        metric=skill_fitness_metric,
+        max_full_evals=iterations,
+        reflection_lm=reflection_lm,
+    )
+    optimized_module = optimizer.compile(
+        baseline_module,
+        trainset=trainset,
+        valset=valset,
+    )
 
     elapsed = time.time() - start_time
     console.print(f"\n  Optimization completed in {elapsed:.1f}s")
@@ -185,7 +178,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill")
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -103,12 +103,16 @@ class SkillModule(dspy.Module):
 
     def __init__(self, skill_text: str):
         super().__init__()
-        self.skill_text = skill_text
-        self.predictor = dspy.ChainOfThought(self.TaskWithSkill)
+        signature = dspy.Signature("task_input -> output", instructions=skill_text)
+        self.predictor = dspy.Predict(signature)
+
+    @property
+    def skill_text(self) -> str:
+        """Return the instruction text that DSPy optimizers can mutate."""
+        return self.predictor.signature.instructions
 
     def forward(self, task_input: str) -> dspy.Prediction:
         result = self.predictor(
-            skill_instructions=self.skill_text,
             task_input=task_input,
         )
         return dspy.Prediction(output=result.output)


### PR DESCRIPTION
## Summary

Fixes the Phase 1 skill-evolution path so DSPy/GEPA optimizes and saves the actual `SKILL.md` body.  

* Read the evolved skill from optimized predictor instructions.  
* Update GEPA integration for DSPy 3.x.  
* Remove the silent MIPROv2 fallback.  
* Handle GEPA callback arguments and DSPy completion markers correctly.  
* Use `think=False` for native Ollama scoring calls.  
* Validate the full reassembled `SKILL.md`, including YAML frontmatter.  
* Keep the 15 KB size limit while skipping baseline-relative growth checks.  

## Validation

```text
pytest -q
145 passed, 11 warnings
```

Manual runs also confirmed the pipeline executes end to end and produces improved holdout heuristic scores.