### PR TITLE
fix(evolution): restore GEPA skill evolution on dspy 3.2

### DIFF
--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -115,6 +115,13 @@ def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, tra
     expected = getattr(example, "expected_behavior", "") or ""
     task = getattr(example, "task_input", "") or ""
 
+    # Dataset generators may emit rubrics as a list of bullet strings —
+    # coerce to text before keyword-overlap scoring.
+    if isinstance(expected, list):
+        expected = "\n".join(str(item) for item in expected)
+    if isinstance(agent_output, list):
+        agent_output = "\n".join(str(item) for item in agent_output)
+
     if not agent_output.strip():
         return 0.0
 

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -118,7 +118,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -152,10 +152,17 @@ def evolve(
 
     start_time = time.time()
 
+    # GEPA (dspy>=3.2) requires a 5-arg metric (gold, pred, trace, pred_name,
+    # pred_trace). It must return a plain float: dspy.Evaluate aggregates
+    # metric results with sum(), so dict/Prediction returns break full evals.
+    def _gepa_metric(gold, pred, trace=None, pred_name=None, pred_trace=None):
+        return skill_fitness_metric(gold, pred)
+
     try:
         optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
-            max_steps=iterations,
+            metric=_gepa_metric,
+            max_full_evals=iterations,
+            reflection_lm=dspy.LM(optimizer_model, temperature=1.0, max_tokens=32000),
         )
 
         optimized_module = optimizer.compile(
@@ -179,13 +186,15 @@ def evolve(
     console.print(f"\n  Optimization completed in {elapsed:.1f}s")
 
     # ── 6. Extract evolved skill text ───────────────────────────────────
-    # The optimized module's instructions contain the evolved skill text
-    evolved_body = optimized_module.skill_text
+    # GEPA evolves the predictor's instruction (which is where SkillModule
+    # installs the skill body), so pull the mutated instruction back out of
+    # the optimized predictor's signature.
+    evolved_body = optimized_module.predictor.predict.signature.instructions
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -84,33 +84,26 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
 class SkillModule(dspy.Module):
     """A DSPy module that wraps a skill file for optimization.
 
-    The skill text (body) is the parameter that GEPA optimizes.
-    On each forward pass, the module:
+    The skill text (body) is the parameter that GEPA optimizes, so it is
+    installed as the predictor's *instruction* (GEPA mutates instructions
+    and demos — never plain input fields). On each forward pass, the module:
     1. Uses the skill text as instructions
     2. Processes the task input
     3. Returns the agent's response
     """
 
     class TaskWithSkill(dspy.Signature):
-        """Complete a task following the provided skill instructions.
-
-        You are an AI agent following specific skill instructions to complete a task.
-        Read the skill instructions carefully and follow the procedure described.
-        """
-        skill_instructions: str = dspy.InputField(desc="The skill instructions to follow")
+        """Placeholder instruction — replaced by the skill text in __init__."""
         task_input: str = dspy.InputField(desc="The task to complete")
         output: str = dspy.OutputField(desc="Your response following the skill instructions")
 
     def __init__(self, skill_text: str):
         super().__init__()
         self.skill_text = skill_text
-        self.predictor = dspy.ChainOfThought(self.TaskWithSkill)
+        self.predictor = dspy.ChainOfThought(self.TaskWithSkill.with_instructions(skill_text))
 
     def forward(self, task_input: str) -> dspy.Prediction:
-        result = self.predictor(
-            skill_instructions=self.skill_text,
-            task_input=task_input,
-        )
+        result = self.predictor(task_input=task_input)
         return dspy.Prediction(output=result.output)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
+    "optuna>=3.0",
 ]
 darwinian = [
     "darwinian-evolver",


### PR DESCRIPTION
## What does this PR do?

Fixes **seven defects** that made the Phase-1 GEPA skill-evolution pipeline unusable on the current dspy release (3.2.1). Depending on where execution stopped, users got a silent fallback to MIPROv2, a hard crash, or — worst — an "evolved" skill **byte-identical to the baseline** (the optimizer never touched the skill text; see fix 6).

Verified end-to-end with these fixes applied: a 150-rollout GEPA run on `github-code-review` (hermes-agent @ `9acc4b4`, `moonshot/kimi-k3` optimizer, `moonshot/kimi-k2.7-code` eval) completed 21 iterations, improved valset **0.474 → 0.579**, and produced a genuinely mutated skill (used downstream in NousResearch/hermes-agent#69641).

## The bugs

1. **`dspy.GEPA(max_steps=…)` no longer exists** in dspy 3.2 (budget args are `auto` / `max_full_evals` / `max_metric_calls`) → `TypeError` → silent MIPROv2 fallback. Now passes `max_full_evals=iterations`.
2. **GEPA requires an explicit `reflection_lm`** in dspy 3.2; none was passed → construction raised → fallback. Now passes `reflection_lm=dspy.LM(optimizer_model, temperature=1.0, max_tokens=32000)` (per dspy's own error-message guidance).
3. **Metric signature mismatch.** dspy 3.2 GEPA requires a 5-arg metric `(gold, pred, trace, pred_name, pred_trace)`; `skill_fitness_metric` takes `(example, prediction)` → `TypeError` → fallback. Wrapped it; the wrapper returns a plain `float` because dict/Prediction returns break `dspy.Evaluate`'s `sum()` aggregation.
4. **The MIPROv2 fallback itself was broken** — `optuna` is required but undeclared. Added to `dev` extras.
5. **Constraint validation always failed `skill_structure`** because it checked the frontmatter-less *body* for YAML frontmatter (warned at baseline, hard-stopped the evolved skill). Now validates the reassembled full text.
6. **The core flaw: the skill was never optimized.** `SkillModule` passed the skill text as an *input field* (`skill_instructions=…`); GEPA mutates signature *instructions* and demos, never plain inputs — so the skill body stayed frozen and `optimized_module.skill_text` returned the original text. Now the skill text is installed as the predictor instruction via `with_instructions(...)`, and extraction pulls the optimized instruction from `predictor.predict.signature.instructions`.
7. **`skill_fitness_metric` crashed on list rubrics** — dataset generators may emit `expected_behavior` as a list of bullet strings (observed with `moonshot/kimi-k2.7-code`), and the keyword-overlap code called `.lower()` on it. Lists are now coerced to text.

## Changes Made

- `evolution/skills/evolve_skill.py` — fixes 1, 2, 3, 5, and the extraction half of 6
- `evolution/skills/skill_module.py` — fix 6 (skill text as optimizable instruction)
- `evolution/core/fitness.py` — fix 7
- `pyproject.toml` — fix 4 (`optuna` in dev extras)

## How to Test

1. `pip install -e ".[dev]"` on a clean env with dspy 3.2.x.
2. `python -m evolution.skills.evolve_skill --skill github-code-review --hermes-repo <hermes-agent checkout> --optimizer-model <model> --eval-model <model> --iterations 1`
3. Expected: GEPA runs (no "falling back to MIPROv2" message), constraints pass, and `output/…/evolved_skill.md` **differs** from `baseline_skill.md` with a holdout comparison printed.

## Notes

- No behavior change to the intended design — this restores the documented GEPA pipeline (README: "GEPA Optimizer ◄── Execution traces") on current dspy.
- Fixes were developed against dspy 3.2.1; the metric wrapper and `with_instructions` approach follow dspy's public API.
