### PR TITLE
Fix GEPA integration silently falling back to MIPROv2 on DSPy >=3.1

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -152,10 +152,42 @@ def evolve(
 
     start_time = time.time()
 
+    # GEPA requires a five-argument metric that returns a score *and* textual
+    # feedback — the feedback is what it reflects on to propose mutations. The
+    # plain skill_fitness_metric returns a bare float from keyword overlap, which
+    # gives GEPA nothing to reason about, so route through LLMJudge instead (it
+    # already produces feedback for exactly this purpose) and fall back to the
+    # heuristic if the judge call fails.
+    _judge = LLMJudge(config)
+
+    def gepa_skill_metric(gold, pred, trace=None, pred_name=None, pred_trace=None):
+        agent_output = getattr(pred, "output", "") or ""
+        skill_text = getattr(pred, "skill_text", "") or skill["body"]
+        try:
+            fs = _judge.score(
+                task_input=getattr(gold, "task_input", "") or "",
+                expected_behavior=getattr(gold, "expected_behavior", "") or "",
+                agent_output=agent_output,
+                skill_text=skill_text,
+                artifact_size=len(skill_text),
+                max_size=config.max_skill_size,
+            )
+            return dspy.Prediction(score=fs.composite, feedback=fs.feedback)
+        except Exception as judge_error:  # noqa: BLE001 — never fail the whole run
+            score = skill_fitness_metric(gold, pred, trace)
+            return dspy.Prediction(
+                score=score,
+                feedback=f"Judge unavailable ({judge_error}); heuristic score only.",
+            )
+
     try:
+        # DSPy >=3.1 replaced max_steps with a metric-call budget, and requires an
+        # explicit reflection LM — that's the model that reads execution traces and
+        # proposes mutations, so it's what --optimizer-model is for.
         optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
-            max_steps=iterations,
+            metric=gepa_skill_metric,
+            max_metric_calls=iterations * len(trainset),
+            reflection_lm=dspy.LM(optimizer_model, temperature=1.0, max_tokens=32000),
         )
 
         optimized_module = optimizer.compile(


### PR DESCRIPTION
## Problem

`dspy.GEPA()` raises on every run with DSPy >= 3.1, and the surrounding `try/except` in `evolve_skill.py` catches it and drops to MIPROv2. Runs print `Running GEPA optimization`, complete successfully, and write out an "evolved" skill — without GEPA ever being involved. The fallback message scrolls past in the middle of optimizer output, so this is easy to miss entirely.

Reproduced on a clean install (`pip install -e ".[dev]"`, DSPy 3.2.1, gepa 0.0.27):

```
Running GEPA optimization (2 iterations)...

GEPA not available (GEPA.__init__() got an unexpected keyword argument 'max_steps'),
falling back to MIPROv2
```

and after fixing that, a second one:

```
GEPA not available (GEPA metric must accept five arguments:
(gold, pred, trace, pred_name, pred_trace).), falling back to MIPROv2
```

## Causes

1. **`max_steps` is not a DSPy >= 3.1 argument.** The budget is now `max_metric_calls` (or `auto` / `max_full_evals`).

2. **`reflection_lm` is required and was never passed** — GEPA raises without it. Separately, `--optimizer-model` (help text: "Model for GEPA reflections") was unused: printed to the console, then dropped. Only `--eval-model` ever reached DSPy. It now drives the reflection LM, which is what the flag already claimed to do.

3. **The metric signature and return type are wrong for GEPA.** It needs five arguments and a score *plus* textual feedback. `skill_fitness_metric` takes three and returns a bare float from keyword overlap, so even once constructed, GEPA would have had no trace-level signal to reflect on — which is the mechanism the README describes as the reason to use GEPA.

## Fix

(1) and (2) are direct argument fixes. For (3), the metric now routes through the existing `LLMJudge`, whose `feedback` field is already documented in `fitness.py` as "Textual feedback for GEPA's reflective analysis" but was never connected to the optimizer. `skill_fitness_metric` is kept as a fallback when a judge call fails, so a flaky judge degrades the score instead of killing the run.

## Verification

GEPA now engages instead of falling through:

```
INFO dspy.teleprompt.gepa.gepa: Running GEPA for approx 20 metric calls of the
program. This amounts to 1.33 full evals on the train+val set.
INFO dspy.teleprompt.gepa.gepa: Using 5 examples for tracking Pareto scores.
```

Existing suite passes unchanged (145 passed). Tested against a local Ollama-served model via litellm's `ollama_chat/` prefix rather than an OpenAI endpoint, so the fix is not verified against the default `openai/gpt-4.1` path — worth a second look from someone with those credentials.

## Note

You may want to reconsider the bare `except Exception` around the optimizer construction. It's what turned three straightforward API mismatches into a silent behavioral downgrade; narrowing it, or at least making the fallback loud, would surface the next DSPy break immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
