### PR TITLE
Validate the reassembled skill, not the bare body

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -185,7 +185,10 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    # Validate the reassembled file, not the bare body. skill_structure requires
+    # YAML frontmatter, which only exists on evolved_full — validating evolved_body
+    # fails that constraint unconditionally, so no evolved skill could ever deploy.
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["body"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"


### PR DESCRIPTION
## Problem

No evolved skill can ever be deployed.

`evolve_skill.py` validates the evolved result against `evolved_body`, which has no YAML frontmatter. But `_check_skill_structure` (`constraints.py:150`) requires the text to start with `---` and contain `name:` and `description:`. That constraint fails unconditionally, and a failing constraint blocks deployment — so the run always ends at `evolved_FAILED.md`.

`evolved_full` is built on the immediately preceding line for exactly this purpose, then never used.

Phase 1 (skill files) is the only implemented phase, so this means the tool cannot currently produce a deployable artifact at all.

## Observed

A real run improved the valset score from 0.862 to 1.0, then threw the result away:

```
Validating evolved skill
  ✓ size_limit: Size OK: 13216/15000 chars
  ✓ growth_limit: Growth OK: +0.0% (max +20.0%)
  ✓ non_empty: Artifact is non-empty
  ✗ skill_structure: Skill missing: YAML frontmatter (---), name field, description field
✗ Evolved skill FAILED constraints — not deploying
  Saved failed variant to output/github-code-review/evolved_FAILED.md
```

Running the same four constraints against the reassembled file passes all four:

```
PASS  size_limit - Size OK: 13856/15000 chars
PASS  growth_limit - Growth OK: +2.4% (max +20.0%)
PASS  non_empty - Artifact is non-empty
PASS  skill_structure - Skill has valid frontmatter (name + description)
```

## Fix

One line: validate `evolved_full` instead of `evolved_body`. Existing suite passes unchanged (145 passed).

## Related

The baseline check at line 121 has the same shape — it validates `skill["body"]`, which is why every run prints a spurious `skill_structure` violation for the *unmodified* skill and then continues with "proceeding anyway". I left that alone since it only affects a warning rather than blocking deployment, but it shares the root cause and you may want to fix both together.

Separately, #159 fixes the DSPy >= 3.1 incompatibilities that cause `dspy.GEPA()` to be silently swapped for MIPROv2. These two are independent, but you need both before an evolution run does what the README describes end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
