### PR TITLE
fix: make the GEPA skill-evolution path work end-to-end

### DIFF
--- a/evolution/core/constraints.py
+++ b/evolution/core/constraints.py
@@ -5,6 +5,7 @@ considered valid. Failed constraints = immediate rejection.
 """
 
 import subprocess
+import sys
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Optional
@@ -56,7 +57,7 @@ class ConstraintValidator:
         """Run the full hermes-agent test suite. Must pass 100%."""
         try:
             result = subprocess.run(
-                ["python", "-m", "pytest", "tests/", "-q", "--tb=no"],
+                [sys.executable, "-m", "pytest", "tests/", "-q", "--tb=no"],
                 capture_output=True,
                 text=True,
                 timeout=300,

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -104,18 +104,33 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+def skill_fitness_metric(
+    example: dspy.Example,
+    prediction: dspy.Prediction,
+    trace=None,
+    pred_name=None,
+    pred_trace=None,
+):
     """DSPy-compatible metric function for skill optimization.
 
-    This is what gets passed to dspy.GEPA(metric=...).
-    Returns a float 0-1 score.
+    This is what gets passed to dspy.GEPA(metric=...). GEPA's
+    GEPAFeedbackMetric protocol calls it with (gold, pred, trace, pred_name,
+    pred_trace); MIPROv2 and direct holdout scoring call it with the first
+    two or three arguments only, so the extra parameters default to None.
+
+    Returns a float 0-1 score — except when GEPA requests predictor-level
+    feedback (pred_name is not None), where it returns
+    dspy.Prediction(score=..., feedback=...) with a deterministic hint about
+    which expected-behavior terms are missing, giving the reflection LM
+    something concrete to act on.
     """
     # The prediction should have an 'output' field with the agent's response
     agent_output = getattr(prediction, "output", "") or ""
     expected = getattr(example, "expected_behavior", "") or ""
-    task = getattr(example, "task_input", "") or ""
 
     if not agent_output.strip():
+        if pred_name is not None:
+            return dspy.Prediction(score=0.0, feedback="The response was empty.")
         return 0.0
 
     # Quick heuristic scoring (for speed during optimization)
@@ -129,11 +144,27 @@ def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, tra
     # Simple keyword overlap as a fast proxy
     expected_words = set(expected_lower.split())
     output_words = set(output_lower.split())
+    missing: list[str] = []
     if expected_words:
         overlap = len(expected_words & output_words) / len(expected_words)
         score = 0.3 + (0.7 * overlap)
+        missing = sorted(
+            w for w in (expected_words - output_words) if len(w) > 4
+        )[:8]
 
-    return min(1.0, max(0.0, score))
+    score = min(1.0, max(0.0, score))
+
+    if pred_name is not None:
+        if missing:
+            feedback = (
+                f"Score {score:.2f}. The response does not address these "
+                f"expected-behavior elements: {', '.join(missing)}."
+            )
+        else:
+            feedback = f"Score {score:.2f}. The response covers the expected behavior."
+        return dspy.Prediction(score=score, feedback=feedback)
+
+    return score
 
 
 def _parse_score(value) -> float:

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -118,7 +118,9 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    # Validate the full file (frontmatter + body): skill_structure checks
+    # frontmatter, which load_skill strips from `body`.
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -185,7 +187,9 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    # Same rule as the baseline: validate the reassembled file, not the bare
+    # body — otherwise skill_structure always fails and nothing ever deploys.
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -33,6 +33,76 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+def _compile_optimizer(
+    *,
+    metric,
+    iterations: int,
+    reflection_lm,
+    baseline_module,
+    trainset,
+    valset,
+    num_threads: Optional[int] = None,
+):
+    """Build and compile GEPA, falling back only for API incompatibility.
+
+    The compatibility boundary deliberately covers construction only. Runtime
+    failures from ``compile`` (provider errors, judge failures, timeouts, and
+    optimizer bugs) propagate instead of silently changing the optimizer.
+    """
+    gepa_kwargs = {}
+    if num_threads is not None:
+        gepa_kwargs["num_threads"] = num_threads
+
+    try:
+        optimizer = dspy.GEPA(
+            metric=metric,
+            max_full_evals=iterations,
+            reflection_lm=reflection_lm,
+            **gepa_kwargs,
+        )
+        optimizer_name = "GEPA"
+    except (AttributeError, TypeError) as exc:
+        console.print(
+            f"[yellow]GEPA API is unavailable ({exc}), falling back to MIPROv2[/yellow]"
+        )
+        optimizer = dspy.MIPROv2(metric=metric, auto="light")
+        optimizer_name = "MIPROv2"
+
+    # Keep this outside the compatibility try/except. A runtime failure is not
+    # evidence that GEPA is unavailable and must never trigger a silent retry
+    # with a different optimizer. Both optimizers receive the same valset.
+    optimized_module = optimizer.compile(
+        baseline_module,
+        trainset=trainset,
+        valset=valset,
+    )
+    return optimized_module, optimizer_name
+
+
+def _run_test_suite_gate(validator: ConstraintValidator, hermes_repo: Path) -> bool:
+    """Run and report the requested test gate, returning its hard verdict."""
+    console.print("\n[bold]Running test suite gate[/bold]")
+    result = validator.run_test_suite(hermes_repo)
+    icon = "✓" if result.passed else "✗"
+    color = "green" if result.passed else "red"
+    console.print(
+        f"  [{color}]{icon} {result.constraint_name}[/{color}]: {result.message}"
+    )
+    if result.details:
+        console.print(f"  {result.details}")
+    return result.passed
+
+
+def _has_material_diff(baseline_body: str, evolved_body: str) -> bool:
+    """Whether the optimizer changed the deployable skill body."""
+    return evolved_body != baseline_body
+
+
+def _evolution_succeeded(improvement: float, material_diff: bool) -> bool:
+    """A score delta is deployable only when the saved artifact changed."""
+    return improvement > 0 and material_diff
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -172,39 +242,21 @@ def evolve(
 
     start_time = time.time()
 
-    try:
-        # dspy.GEPA requires exactly one budget parameter (auto /
-        # max_full_evals / max_metric_calls) — there is no `max_steps` —
-        # and a reflection LM for proposing mutations.
-        # num_threads matters on serial local endpoints: parallel rollouts
-        # queue behind each other and time out in cascade once queue depth
-        # times per-request latency exceeds the client timeout.
-        gepa_kwargs = {}
-        if num_threads is not None:
-            gepa_kwargs["num_threads"] = num_threads
-        optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
-            max_full_evals=iterations,
-            reflection_lm=dspy.LM(optimizer_model, **lm_kwargs),
-            **gepa_kwargs,
-        )
-
-        optimized_module = optimizer.compile(
-            baseline_module,
-            trainset=trainset,
-            valset=valset,
-        )
-    except Exception as e:
-        # Fall back to MIPROv2 if GEPA isn't available in this DSPy version
-        console.print(f"[yellow]GEPA not available ({e}), falling back to MIPROv2[/yellow]")
-        optimizer = dspy.MIPROv2(
-            metric=skill_fitness_metric,
-            auto="light",
-        )
-        optimized_module = optimizer.compile(
-            baseline_module,
-            trainset=trainset,
-        )
+    # dspy.GEPA requires exactly one budget parameter (auto /
+    # max_full_evals / max_metric_calls) — there is no `max_steps` —
+    # and a reflection LM for proposing mutations. Construct the reflection LM
+    # before the compatibility boundary so its own configuration errors cannot
+    # masquerade as an unavailable GEPA API.
+    reflection_lm = dspy.LM(optimizer_model, **lm_kwargs)
+    optimized_module, optimizer_name = _compile_optimizer(
+        metric=skill_fitness_metric,
+        iterations=iterations,
+        reflection_lm=reflection_lm,
+        baseline_module=baseline_module,
+        trainset=trainset,
+        valset=valset,
+        num_threads=num_threads,
+    )
 
     elapsed = time.time() - start_time
     console.print(f"\n  Optimization completed in {elapsed:.1f}s")
@@ -213,6 +265,7 @@ def evolve(
     # The optimized module's instructions contain the evolved skill text
     evolved_body = optimized_module.skill_text
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
+    material_diff = _has_material_diff(skill["body"], evolved_body)
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
@@ -235,6 +288,9 @@ def evolve(
         output_path.write_text(evolved_full)
         console.print(f"  Saved failed variant to {output_path}")
         return
+
+    if run_tests and not _run_test_suite_gate(validator, config.hermes_agent_path):
+        raise click.ClickException("Test suite gate failed; candidate rejected")
 
     # ── 8. Evaluate on holdout set ──────────────────────────────────────
     console.print(f"\n[bold]Evaluating on holdout set ({len(dataset.holdout)} examples)[/bold]")
@@ -278,6 +334,12 @@ def evolve(
         f"{len(evolved_body):,} chars",
         f"{len(evolved_body) - len(skill['body']):+,} chars",
     )
+    table.add_row(
+        "Material Diff",
+        "",
+        "yes" if material_diff else "no",
+        "" if material_diff else "score delta ignored",
+    )
     table.add_row("Time", "", f"{elapsed:.1f}s", "")
     table.add_row("Iterations", "", str(iterations), "")
 
@@ -300,11 +362,14 @@ def evolve(
         "skill_name": skill_name,
         "timestamp": timestamp,
         "iterations": iterations,
+        "optimizer": optimizer_name,
         "optimizer_model": optimizer_model,
         "eval_model": eval_model,
         "baseline_score": avg_baseline,
         "evolved_score": avg_evolved,
         "improvement": improvement,
+        "material_diff": material_diff,
+        "success": _evolution_succeeded(improvement, material_diff),
         "baseline_size": len(skill["body"]),
         "evolved_size": len(evolved_body),
         "train_examples": len(dataset.train),
@@ -317,9 +382,14 @@ def evolve(
 
     console.print(f"\n  Output saved to {output_dir}/")
 
-    if improvement > 0:
+    if _evolution_succeeded(improvement, material_diff):
         console.print(f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement/max(0.001, avg_baseline)*100:+.1f}%)[/bold green]")
         console.print(f"  Review the diff: diff {output_dir}/baseline_skill.md {output_dir}/evolved_skill.md")
+    elif not material_diff:
+        console.print(
+            "\n[yellow]⚠ Optimizer produced no material skill diff; "
+            "any score delta is ignored[/yellow]"
+        )
     else:
         console.print(f"\n[yellow]⚠ Evolution did not improve skill (change: {improvement:+.3f})[/yellow]")
         console.print("  Try: more iterations, better eval dataset, or different optimizer model")

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -45,6 +45,9 @@ def evolve(
     dry_run: bool = False,
     max_tokens: Optional[int] = None,
     temperature: Optional[float] = None,
+    num_threads: Optional[int] = None,
+    lm_timeout: Optional[float] = None,
+    lm_retries: Optional[int] = None,
 ):
     """Main evolution function — orchestrates the full optimization loop."""
 
@@ -150,6 +153,10 @@ def evolve(
         lm_kwargs["max_tokens"] = max_tokens
     if temperature is not None:
         lm_kwargs["temperature"] = temperature
+    if lm_timeout is not None:
+        lm_kwargs["timeout"] = lm_timeout
+    if lm_retries is not None:
+        lm_kwargs["num_retries"] = lm_retries
     lm = dspy.LM(eval_model, **lm_kwargs)
     dspy.configure(lm=lm)
 
@@ -169,10 +176,17 @@ def evolve(
         # dspy.GEPA requires exactly one budget parameter (auto /
         # max_full_evals / max_metric_calls) — there is no `max_steps` —
         # and a reflection LM for proposing mutations.
+        # num_threads matters on serial local endpoints: parallel rollouts
+        # queue behind each other and time out in cascade once queue depth
+        # times per-request latency exceeds the client timeout.
+        gepa_kwargs = {}
+        if num_threads is not None:
+            gepa_kwargs["num_threads"] = num_threads
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
             max_full_evals=iterations,
             reflection_lm=dspy.LM(optimizer_model, **lm_kwargs),
+            **gepa_kwargs,
         )
 
         optimized_module = optimizer.compile(
@@ -325,7 +339,11 @@ def evolve(
 @click.option("--max-tokens", default=None, type=int,
               help="Generation budget per LM call (needed for reasoning models on local endpoints)")
 @click.option("--temperature", default=None, type=float, help="Sampling temperature for LM calls")
-def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run, max_tokens, temperature):
+@click.option("--num-threads", default=None, type=int,
+              help="Parallel rollouts for GEPA evaluation (use 1 for serial local endpoints)")
+@click.option("--lm-timeout", default=None, type=float, help="Per-request LM timeout in seconds")
+@click.option("--lm-retries", default=None, type=int, help="LM retry count on failures")
+def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run, max_tokens, temperature, num_threads, lm_timeout, lm_retries):
     """Evolve a Hermes Agent skill using DSPy + GEPA optimization."""
     evolve(
         skill_name=skill,
@@ -339,6 +357,9 @@ def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_mod
         dry_run=dry_run,
         max_tokens=max_tokens,
         temperature=temperature,
+        num_threads=num_threads,
+        lm_timeout=lm_timeout,
+        lm_retries=lm_retries,
     )
 
 

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -43,6 +43,8 @@ def evolve(
     hermes_repo: Optional[str] = None,
     run_tests: bool = False,
     dry_run: bool = False,
+    max_tokens: Optional[int] = None,
+    temperature: Optional[float] = None,
 ):
     """Main evolution function — orchestrates the full optimization loop."""
 
@@ -138,8 +140,17 @@ def evolve(
     console.print(f"  Optimizer model: {optimizer_model}")
     console.print(f"  Eval model: {eval_model}")
 
-    # Configure DSPy
-    lm = dspy.LM(eval_model)
+    # Configure DSPy. Generation kwargs are only passed when explicitly set,
+    # so the default behavior is unchanged. Reasoning models served by local
+    # OpenAI-compatible endpoints (low server-side max_tokens defaults) need
+    # an explicit budget or the thinking phase consumes it and content comes
+    # back empty.
+    lm_kwargs = {}
+    if max_tokens is not None:
+        lm_kwargs["max_tokens"] = max_tokens
+    if temperature is not None:
+        lm_kwargs["temperature"] = temperature
+    lm = dspy.LM(eval_model, **lm_kwargs)
     dspy.configure(lm=lm)
 
     # Create the baseline skill module
@@ -161,7 +172,7 @@ def evolve(
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
             max_full_evals=iterations,
-            reflection_lm=dspy.LM(optimizer_model),
+            reflection_lm=dspy.LM(optimizer_model, **lm_kwargs),
         )
 
         optimized_module = optimizer.compile(
@@ -311,7 +322,10 @@ def evolve(
 @click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
 @click.option("--run-tests", is_flag=True, help="Run full pytest suite as constraint gate")
 @click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")
-def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run):
+@click.option("--max-tokens", default=None, type=int,
+              help="Generation budget per LM call (needed for reasoning models on local endpoints)")
+@click.option("--temperature", default=None, type=float, help="Sampling temperature for LM calls")
+def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, run_tests, dry_run, max_tokens, temperature):
     """Evolve a Hermes Agent skill using DSPy + GEPA optimization."""
     evolve(
         skill_name=skill,
@@ -323,6 +337,8 @@ def main(skill, iterations, eval_source, dataset_path, optimizer_model, eval_mod
         hermes_repo=hermes_repo,
         run_tests=run_tests,
         dry_run=dry_run,
+        max_tokens=max_tokens,
+        temperature=temperature,
     )
 
 

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -155,9 +155,13 @@ def evolve(
     start_time = time.time()
 
     try:
+        # dspy.GEPA requires exactly one budget parameter (auto /
+        # max_full_evals / max_metric_calls) — there is no `max_steps` —
+        # and a reflection LM for proposing mutations.
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
-            max_steps=iterations,
+            max_full_evals=iterations,
+            reflection_lm=dspy.LM(optimizer_model),
         )
 
         optimized_module = optimizer.compile(

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -84,33 +84,40 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
 class SkillModule(dspy.Module):
     """A DSPy module that wraps a skill file for optimization.
 
-    The skill text (body) is the parameter that GEPA optimizes.
-    On each forward pass, the module:
-    1. Uses the skill text as instructions
+    The skill text (body) is the parameter that GEPA optimizes. GEPA's
+    candidate space is exactly the `signature.instructions` of the module's
+    named predictors (see dspy.teleprompt.gepa), so the skill text must live
+    in the signature instructions — not in an input field, which GEPA never
+    mutates. On each forward pass, the module:
+    1. Uses the skill text as the predictor's signature instructions
     2. Processes the task input
     3. Returns the agent's response
+
+    `skill_text` is a read-through property over the predictor's current
+    instructions, so after `optimizer.compile()` it reflects the evolved
+    text rather than the original.
     """
 
     class TaskWithSkill(dspy.Signature):
-        """Complete a task following the provided skill instructions.
+        """Complete a task following the provided skill instructions."""
 
-        You are an AI agent following specific skill instructions to complete a task.
-        Read the skill instructions carefully and follow the procedure described.
-        """
-        skill_instructions: str = dspy.InputField(desc="The skill instructions to follow")
         task_input: str = dspy.InputField(desc="The task to complete")
         output: str = dspy.OutputField(desc="Your response following the skill instructions")
 
     def __init__(self, skill_text: str):
         super().__init__()
-        self.skill_text = skill_text
-        self.predictor = dspy.ChainOfThought(self.TaskWithSkill)
+        signature = self.TaskWithSkill.with_instructions(skill_text)
+        self.predictor = dspy.ChainOfThought(signature)
+
+    @property
+    def skill_text(self) -> str:
+        """The current skill text — evolved instructions after optimization."""
+        for _, predictor in self.named_predictors():
+            return predictor.signature.instructions
+        raise AttributeError("SkillModule has no predictors")
 
     def forward(self, task_input: str) -> dspy.Prediction:
-        result = self.predictor(
-            skill_instructions=self.skill_text,
-            task_input=task_input,
-        )
+        result = self.predictor(task_input=task_input)
         return dspy.Prediction(output=result.output)
 
 

--- a/tests/core/test_constraints.py
+++ b/tests/core/test_constraints.py
@@ -96,3 +96,25 @@ class TestValidateAll:
         results = validator.validate_all("", "skill")
         failed = [r for r in results if not r.passed]
         assert len(failed) > 0
+
+
+class TestValidateFullFileNotBody:
+    """Regression: skill_structure must be checked on the full file.
+
+    load_skill() strips frontmatter into a separate field; validating the
+    bare body always fails skill_structure and blocks every deploy.
+    """
+
+    def test_realistic_full_file_passes(self, validator):
+        raw = (
+            "---\nname: real-skill\ndescription: Does something real\n---\n\n"
+            "# Procedure\n1. Step"
+        )
+        results = validator.validate_all(raw, "skill")
+        assert all(r.passed for r in results)
+
+    def test_bare_body_fails_structure(self, validator):
+        body = "# Procedure\n1. Step"
+        results = validator.validate_all(body, "skill")
+        structure = [r for r in results if r.constraint_name == "skill_structure"][0]
+        assert not structure.passed

--- a/tests/core/test_fitness.py
+++ b/tests/core/test_fitness.py
@@ -1,0 +1,49 @@
+"""Tests for the GEPA-compatible fitness metric."""
+
+import dspy
+
+from evolution.core.fitness import skill_fitness_metric
+
+
+def _example_and_pred():
+    example = dspy.Example(
+        task_input="task",
+        expected_behavior="verify evidence before concluding done",
+    )
+    prediction = dspy.Prediction(output="I will verify the evidence first")
+    return example, prediction
+
+
+class TestMetricContract:
+    def test_direct_call_returns_float(self):
+        example, prediction = _example_and_pred()
+        score = skill_fitness_metric(example, prediction)
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
+    def test_miprov2_style_call_returns_float(self):
+        example, prediction = _example_and_pred()
+        score = skill_fitness_metric(example, prediction, None)
+        assert isinstance(score, float)
+
+    def test_gepa_reflection_call_returns_feedback(self):
+        # GEPA's GEPAFeedbackMetric protocol: (gold, pred, trace, pred_name,
+        # pred_trace); predictor-level calls expect Prediction(score, feedback).
+        example, prediction = _example_and_pred()
+        result = skill_fitness_metric(example, prediction, None, "predictor", None)
+        assert isinstance(result, dspy.Prediction)
+        assert 0.0 <= result.score <= 1.0
+        assert result.feedback
+
+    def test_empty_output_scores_zero(self):
+        example, _ = _example_and_pred()
+        assert skill_fitness_metric(example, dspy.Prediction(output="")) == 0.0
+
+    def test_gepa_accepts_metric_with_valid_budget(self):
+        # Regression: GEPA has no `max_steps` — the old call always raised
+        # TypeError and silently fell back to MIPROv2.
+        lm = dspy.LM("openai/test", api_base="http://127.0.0.1:1/v1", api_key="x")
+        optimizer = dspy.GEPA(
+            metric=skill_fitness_metric, max_full_evals=5, reflection_lm=lm,
+        )
+        assert optimizer is not None

--- a/tests/skills/test_evolve_skill.py
+++ b/tests/skills/test_evolve_skill.py
@@ -1,0 +1,251 @@
+"""Focused gates for the Phase 1 skill-evolution orchestrator."""
+
+import json
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+
+from evolution.core.constraints import ConstraintResult
+from evolution.core.dataset_builder import EvalDataset, EvalExample
+from evolution.skills import evolve_skill
+
+
+class _Optimizer:
+    def __init__(self, result=None, error=None):
+        self.result = result if result is not None else object()
+        self.error = error
+        self.compile_kwargs = None
+
+    def compile(self, module, **kwargs):
+        self.compile_kwargs = {"module": module, **kwargs}
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+def _compile(monkeypatch, gepa_factory, mipro_factory):
+    monkeypatch.setattr(evolve_skill.dspy, "GEPA", gepa_factory)
+    monkeypatch.setattr(evolve_skill.dspy, "MIPROv2", mipro_factory)
+    return evolve_skill._compile_optimizer(
+        metric="metric",
+        iterations=7,
+        reflection_lm="reflection-lm",
+        baseline_module="baseline",
+        trainset="train",
+        valset="validation",
+        num_threads=1,
+    )
+
+
+def test_gepa_keeps_reflection_lm_and_valset(monkeypatch):
+    captured = {}
+    gepa = _Optimizer(result="evolved")
+
+    def build_gepa(**kwargs):
+        captured.update(kwargs)
+        return gepa
+
+    def unexpected_mipro(**kwargs):
+        raise AssertionError(f"unexpected MIPRO fallback: {kwargs}")
+
+    result, name = _compile(monkeypatch, build_gepa, unexpected_mipro)
+
+    assert (result, name) == ("evolved", "GEPA")
+    assert captured == {
+        "metric": "metric",
+        "max_full_evals": 7,
+        "reflection_lm": "reflection-lm",
+        "num_threads": 1,
+    }
+    assert gepa.compile_kwargs == {
+        "module": "baseline",
+        "trainset": "train",
+        "valset": "validation",
+    }
+
+
+@pytest.mark.parametrize("compatibility_error", [AttributeError("missing"), TypeError("renamed")])
+def test_api_construction_error_uses_mipro_with_same_valset(
+    monkeypatch, compatibility_error
+):
+    mipro = _Optimizer(result="fallback-evolved")
+
+    def incompatible_gepa(**kwargs):
+        raise compatibility_error
+
+    def build_mipro(**kwargs):
+        assert kwargs == {"metric": "metric", "auto": "light"}
+        return mipro
+
+    result, name = _compile(monkeypatch, incompatible_gepa, build_mipro)
+
+    assert (result, name) == ("fallback-evolved", "MIPROv2")
+    assert mipro.compile_kwargs == {
+        "module": "baseline",
+        "trainset": "train",
+        "valset": "validation",
+    }
+
+
+def test_gepa_compile_failure_propagates_without_mipro(monkeypatch):
+    gepa = _Optimizer(error=RuntimeError("provider timeout"))
+
+    def unexpected_mipro(**kwargs):
+        raise AssertionError(f"runtime failure triggered MIPRO: {kwargs}")
+
+    with pytest.raises(RuntimeError, match="provider timeout"):
+        _compile(monkeypatch, lambda **kwargs: gepa, unexpected_mipro)
+
+
+@pytest.mark.parametrize("runtime_error", [ConnectionError("offline"), ValueError("bad judge")])
+def test_gepa_construction_runtime_error_fails_closed(
+    monkeypatch, runtime_error
+):
+    def broken_gepa(**kwargs):
+        raise runtime_error
+
+    def unexpected_mipro(**kwargs):
+        raise AssertionError(f"runtime failure triggered MIPRO: {kwargs}")
+
+    with pytest.raises(type(runtime_error), match=str(runtime_error)):
+        _compile(monkeypatch, broken_gepa, unexpected_mipro)
+
+
+def test_requested_test_suite_is_a_hard_gate():
+    validator = SimpleNamespace(
+        run_test_suite=lambda repo: ConstraintResult(
+            passed=False,
+            constraint_name="test_suite",
+            message="Test suite failed",
+            details="1 failed",
+        )
+    )
+
+    assert not evolve_skill._run_test_suite_gate(validator, SimpleNamespace())
+
+
+def test_success_requires_a_material_diff():
+    assert evolve_skill._has_material_diff("before", "after")
+    assert not evolve_skill._has_material_diff("same", "same")
+    assert evolve_skill._evolution_succeeded(0.1, material_diff=True)
+    assert not evolve_skill._evolution_succeeded(0.1, material_diff=False)
+    assert not evolve_skill._evolution_succeeded(0.0, material_diff=True)
+
+
+def _skill_repo(tmp_path):
+    repo = tmp_path / "hermes-agent"
+    skill_dir = repo / "skills" / "tests" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Demo skill\n---\n\n"
+        "# Demo\n\nFollow the original procedure.\n"
+    )
+    return repo
+
+
+def _dataset():
+    example = EvalExample(
+        task_input="Use the demo skill",
+        expected_behavior="Follow the demo procedure",
+        source="golden",
+    )
+    return EvalDataset(train=[example], val=[example], holdout=[example])
+
+
+def _stub_runtime(monkeypatch, dataset):
+    monkeypatch.setattr(
+        evolve_skill.GoldenDatasetLoader,
+        "load",
+        lambda _path: dataset,
+    )
+    monkeypatch.setattr(evolve_skill.dspy, "LM", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(evolve_skill.dspy, "configure", lambda **_kwargs: None)
+
+
+def test_run_tests_failure_stops_before_holdout_and_output(tmp_path, monkeypatch):
+    repo = _skill_repo(tmp_path)
+    _stub_runtime(monkeypatch, _dataset())
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        evolve_skill,
+        "_compile_optimizer",
+        lambda **_kwargs: (
+            SimpleNamespace(skill_text="# Demo\n\nFollow the improved procedure."),
+            "GEPA",
+        ),
+    )
+    gate_calls = []
+
+    def fail_tests(self, hermes_repo):
+        gate_calls.append(hermes_repo)
+        return ConstraintResult(False, "test_suite", "Test suite failed", "1 failed")
+
+    monkeypatch.setattr(
+        evolve_skill.ConstraintValidator,
+        "run_test_suite",
+        fail_tests,
+    )
+    monkeypatch.setattr(
+        evolve_skill,
+        "skill_fitness_metric",
+        lambda *_args, **_kwargs: pytest.fail("holdout ran after failed test gate"),
+    )
+
+    with pytest.raises(evolve_skill.click.ClickException, match="candidate rejected"):
+        evolve_skill.evolve(
+            skill_name="demo",
+            eval_source="golden",
+            dataset_path=str(tmp_path),
+            hermes_repo=str(repo),
+            run_tests=True,
+        )
+
+    assert gate_calls == [repo]
+    assert not (tmp_path / "output").exists()
+
+
+def test_noop_candidate_cannot_report_success_from_score_noise(tmp_path, monkeypatch):
+    repo = _skill_repo(tmp_path)
+    dataset = _dataset()
+    _stub_runtime(monkeypatch, dataset)
+    monkeypatch.chdir(tmp_path)
+
+    class FakeSkillModule:
+        def __init__(self, skill_text):
+            self.skill_text = skill_text
+
+        def __call__(self, **_kwargs):
+            return SimpleNamespace(output="same behavior")
+
+    monkeypatch.setattr(evolve_skill, "SkillModule", FakeSkillModule)
+    monkeypatch.setattr(
+        evolve_skill,
+        "_compile_optimizer",
+        lambda baseline_module, **_kwargs: (baseline_module, "GEPA"),
+    )
+    monkeypatch.setattr(
+        evolve_skill.dspy,
+        "context",
+        lambda **_kwargs: nullcontext(),
+    )
+    scores = iter([0.1, 0.9])
+    monkeypatch.setattr(
+        evolve_skill,
+        "skill_fitness_metric",
+        lambda *_args, **_kwargs: next(scores),
+    )
+
+    evolve_skill.evolve(
+        skill_name="demo",
+        eval_source="golden",
+        dataset_path=str(tmp_path),
+        hermes_repo=str(repo),
+    )
+
+    metrics_files = list((tmp_path / "output" / "demo").glob("*/metrics.json"))
+    assert len(metrics_files) == 1
+    metrics = json.loads(metrics_files[0].read_text())
+    assert metrics["improvement"] == pytest.approx(0.8)
+    assert metrics["material_diff"] is False
+    assert metrics["success"] is False

--- a/tests/skills/test_skill_module.py
+++ b/tests/skills/test_skill_module.py
@@ -2,7 +2,7 @@
 
 import pytest
 from pathlib import Path
-from evolution.skills.skill_module import load_skill, reassemble_skill
+from evolution.skills.skill_module import SkillModule, load_skill, reassemble_skill
 
 
 SAMPLE_SKILL = """---
@@ -90,3 +90,30 @@ class TestReassembleSkill:
 
         assert "EVOLVED" in result
         assert "New and improved" in result
+
+
+class TestSkillModuleOptimizable:
+    """The skill text must live where GEPA mutates: signature.instructions.
+
+    GEPA's candidate space is {name: pred.signature.instructions} over
+    named_predictors() (dspy.teleprompt.gepa). A plain module attribute is
+    invisible to it, so the evolved text could never reach the saved artifact.
+    """
+
+    def test_skill_text_lives_in_signature_instructions(self):
+        text = "# My Skill\nAlways verify before concluding."
+        module = SkillModule(text)
+
+        predictors = list(module.named_predictors())
+        assert len(predictors) == 1
+        _, predictor = predictors[0]
+        assert predictor.signature.instructions == text
+
+    def test_skill_text_property_reflects_mutation(self):
+        module = SkillModule("# Original")
+
+        # Mutate the way GEPA applies candidates: rewrite the instructions.
+        for _, predictor in module.named_predictors():
+            predictor.signature = predictor.signature.with_instructions("# Evolved")
+
+        assert module.skill_text == "# Evolved"


### PR DESCRIPTION
## Summary

Six focused commits remove the blockers that prevented Phase 1 (skill evolution) from producing a validated evolved skill, then harden its admission gates. Exercised end-to-end with dspy 3.3.0 / gepa 0.1.1 against a local OpenAI-compatible endpoint: GEPA now actually runs (no silent fallback) and evolved candidates can pass the constraint gate.

## Bug 1 — evolved text never reached the artifact (5915499)

GEPA's candidate space is exactly `{name: pred.signature.instructions}` over `named_predictors()` (dspy `teleprompt/gepa/gepa.py`, seed + candidate build). `SkillModule` kept the skill body in a plain attribute passed as an `InputField`, which GEPA never mutates — so `optimized_module.skill_text` always returned the original text and `evolved_skill.md` was always identical to the baseline. The optimizer measured improvements it never persisted.

Fix: the skill body becomes the predictor's signature instructions (`with_instructions()`); `skill_text` is a read-through property over `named_predictors()`, so extraction reflects the evolved candidate with no change to the extraction call site.

## Bug 2 — constraint gate rejected every candidate (44caaf5)

`validate_all()` was called with `skill['body']` / `evolved_body`, but `_check_skill_structure()` looks for YAML frontmatter — which `load_skill()` strips from `body`. The structure constraint therefore failed on every run and every evolved candidate ended in 'not deploying'.

Fix: validate `skill['raw']` for the baseline and the reassembled `evolved_full` for the candidate.

## Bug 3 — GEPA never ran at all (916661d)

`dspy.GEPA` has no `max_steps` parameter: the call raised `TypeError` on every run and silently fell back to MIPROv2, so the GEPA path advertised in the README could never execute. GEPA also requires exactly one budget parameter and a reflection LM, and its `GEPAFeedbackMetric` protocol calls the metric with `(gold, pred, trace, pred_name, pred_trace)`.

Fix: pass `max_full_evals=iterations` and `reflection_lm`; extend `skill_fitness_metric` to the GEPA calling convention, returning `Prediction(score, feedback)` with deterministic missing-terms feedback for predictor-level reflection calls and a plain float everywhere else (holdout and MIPROv2 behavior unchanged).

## Enhancement — generation budget for local endpoints (5b7fbd9, d23cd1f)

Reasoning models served by local OpenAI-compatible endpoints often sit behind low server-side `max_tokens` defaults: the thinking phase consumes the whole budget and content comes back empty ('LM returned an empty or null response' on every rollout). New `--max-tokens` / `--temperature` options apply to both the eval LM and GEPA's reflection LM; `--num-threads`, `--lm-timeout`, and `--lm-retries` support serial local endpoints without changing defaults.

## V2 hardening — fail closed at the admission boundary (6073ab2)

- GEPA fallback is limited to construction-time API incompatibilities (`AttributeError` / `TypeError`). The reflection LM is built before that boundary, and `compile()` runs outside it, so provider, judge, timeout, and optimizer runtime failures propagate instead of silently switching to MIPROv2.
- GEPA retains its explicit `reflection_lm`; GEPA and the compatibility fallback both compile with the same trainset and valset.
- `--run-tests` is now a real hard gate. It uses the active Python interpreter, rejects the candidate before holdout/output on failure, and returns a non-zero Click error to automation.
- A positive score is no longer sufficient when the deployable skill body is unchanged. `material_diff` and the combined `success` verdict are recorded in `metrics.json`, and no-op score noise is reported honestly.

## Tests

145 → 164 (19 new overall). The V2 adds focused coverage for the normal GEPA contract, both allowed compatibility fallback errors, runtime/construction fail-closed behavior, valset preservation, hard test-gate rejection, and the adversarial positive-score/no-artifact-diff case. Full suite: `164 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) and hardened with Codex.
