### PR TITLE
fix: harden skill evolution gates

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -33,6 +33,33 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+def _build_gepa_optimizer(metric, iterations: int):
+    """Build a GEPA optimizer using the current DSPy 3.x API."""
+    if not hasattr(dspy, "GEPA"):
+        raise AttributeError("DSPy GEPA optimizer is not available")
+
+    return dspy.GEPA(
+        metric=metric,
+        max_metric_calls=iterations,
+    )
+
+
+def _validate_skill_constraints(
+    validator: ConstraintValidator,
+    skill: dict,
+    body_text: str,
+    baseline_text: Optional[str] = None,
+):
+    """Validate a complete SKILL.md, not just the body.
+
+    Structural validation requires YAML frontmatter, while DSPy optimizes only
+    the markdown body. Reassemble the full file before applying constraints.
+    """
+    full_text = reassemble_skill(skill["frontmatter"], body_text)
+    baseline_full = baseline_text or skill.get("raw")
+    return validator.validate_all(full_text, "skill", baseline_text=baseline_full)
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -73,7 +100,7 @@ def evolve(
         console.print(f"\n[bold green]DRY RUN — setup validated successfully.[/bold green]")
         console.print(f"  Would generate eval dataset (source: {eval_source})")
         console.print(f"  Would run GEPA optimization ({iterations} iterations)")
-        console.print(f"  Would validate constraints and create PR")
+        console.print(f"  Would validate constraints and save local output for review")
         return
 
     # ── 2. Build or load evaluation dataset ─────────────────────────────
@@ -118,7 +145,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -153,27 +180,22 @@ def evolve(
     start_time = time.time()
 
     try:
-        optimizer = dspy.GEPA(
+        optimizer = _build_gepa_optimizer(
             metric=skill_fitness_metric,
-            max_steps=iterations,
+            iterations=iterations,
         )
-
-        optimized_module = optimizer.compile(
-            baseline_module,
-            trainset=trainset,
-            valset=valset,
-        )
-    except Exception as e:
-        # Fall back to MIPROv2 if GEPA isn't available in this DSPy version
+    except (AttributeError, TypeError) as e:
         console.print(f"[yellow]GEPA not available ({e}), falling back to MIPROv2[/yellow]")
         optimizer = dspy.MIPROv2(
             metric=skill_fitness_metric,
             auto="light",
         )
-        optimized_module = optimizer.compile(
-            baseline_module,
-            trainset=trainset,
-        )
+
+    optimized_module = optimizer.compile(
+        baseline_module,
+        trainset=trainset,
+        valset=valset,
+    )
 
     elapsed = time.time() - start_time
     console.print(f"\n  Optimization completed in {elapsed:.1f}s")
@@ -185,7 +207,11 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = _validate_skill_constraints(
+        validator,
+        skill,
+        evolved_body,
+    )
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"
@@ -202,6 +228,18 @@ def evolve(
         output_path.write_text(evolved_full)
         console.print(f"  Saved failed variant to {output_path}")
         return
+
+    if run_tests:
+        console.print(f"\n[bold]Running test suite gate[/bold]")
+        test_result = validator.run_test_suite(config.hermes_agent_path)
+        icon = "✓" if test_result.passed else "✗"
+        color = "green" if test_result.passed else "red"
+        console.print(f"  [{color}]{icon} {test_result.constraint_name}[/{color}]: {test_result.message}")
+        if test_result.details:
+            console.print(f"  {test_result.details}")
+        if not test_result.passed:
+            console.print("[red]✗ Test suite gate FAILED — not saving evolved output[/red]")
+            return
 
     # ── 8. Evaluate on holdout set ──────────────────────────────────────
     console.print(f"\n[bold]Evaluating on holdout set ({len(dataset.holdout)} examples)[/bold]")

--- a/tests/skills/test_evolve_skill.py
+++ b/tests/skills/test_evolve_skill.py
@@ -1,0 +1,116 @@
+"""Regression tests for skill evolution orchestration."""
+
+from pathlib import Path
+
+import dspy
+from click.testing import CliRunner
+
+from evolution.core.constraints import ConstraintResult
+from evolution.core.dataset_builder import EvalDataset, EvalExample
+
+
+def _make_skill_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "hermes-agent"
+    skill_dir = repo / "skills" / "testing" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Demo skill\n---\n\n# Demo\n\nFollow the demo procedure.\n"
+    )
+    return repo
+
+
+def _dataset() -> EvalDataset:
+    example = EvalExample(
+        task_input="Use the demo skill",
+        expected_behavior="A concise demo response",
+        source="golden",
+    )
+    return EvalDataset(train=[example], val=[example], holdout=[])
+
+
+def test_gepa_optimizer_uses_current_dspy_api(monkeypatch):
+    """DSPy 3.x GEPA does not accept the removed max_steps argument."""
+    from evolution.skills.evolve_skill import _build_gepa_optimizer
+
+    captured = {}
+
+    class FakeGEPA:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(dspy, "GEPA", FakeGEPA)
+
+    optimizer = _build_gepa_optimizer(metric=lambda *_: 1.0, iterations=7)
+
+    assert isinstance(optimizer, FakeGEPA)
+    assert captured["max_metric_calls"] == 7
+    assert "max_steps" not in captured
+
+
+def test_skill_constraints_validate_full_skill_not_body():
+    """Skill structure validation needs YAML frontmatter, so validate reassembled raw text."""
+    from evolution.core.config import EvolutionConfig
+    from evolution.core.constraints import ConstraintValidator
+    from evolution.skills.evolve_skill import _validate_skill_constraints
+
+    validator = ConstraintValidator(EvolutionConfig())
+    skill = {
+        "frontmatter": "name: demo\ndescription: Demo skill",
+        "body": "# Demo\n\nFollow the demo procedure.",
+    }
+
+    results = _validate_skill_constraints(validator, skill, skill["body"])
+
+    by_name = {result.constraint_name: result for result in results}
+    assert by_name["skill_structure"].passed
+
+
+def test_run_tests_flag_is_a_hard_gate(tmp_path, monkeypatch):
+    """--run-tests must stop deployment/output when the project test suite fails."""
+    from evolution.core import constraints as constraints_mod
+    from evolution.skills import evolve_skill as evolve_mod
+
+    repo = _make_skill_repo(tmp_path)
+    monkeypatch.setattr(evolve_mod.GoldenDatasetLoader, "load", lambda _path: _dataset())
+    monkeypatch.setattr(evolve_mod.dspy, "LM", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(evolve_mod.dspy, "configure", lambda **_kwargs: None)
+
+    class FakeOptimizer:
+        def compile(self, module, trainset=None, valset=None):
+            module.skill_text = "# Demo\n\nImproved procedure."
+            return module
+
+    monkeypatch.setattr(evolve_mod, "_build_gepa_optimizer", lambda **_kwargs: FakeOptimizer())
+    monkeypatch.setattr(evolve_mod, "skill_fitness_metric", lambda *_args, **_kwargs: 1.0)
+    monkeypatch.setattr(
+        constraints_mod.ConstraintValidator,
+        "run_test_suite",
+        lambda self, hermes_repo: ConstraintResult(False, "test_suite", "Test suite failed", "boom"),
+    )
+
+    evolve_mod.evolve(
+        skill_name="demo",
+        eval_source="golden",
+        dataset_path=str(tmp_path),
+        hermes_repo=str(repo),
+        run_tests=True,
+    )
+
+    assert not Path("output/demo").exists()
+
+
+def test_dry_run_does_not_claim_to_create_pr(tmp_path, monkeypatch):
+    from evolution.skills.evolve_skill import main
+
+    monkeypatch.setenv("HOME", str(tmp_path / "empty"))
+    repo = _make_skill_repo(tmp_path)
+
+    result = CliRunner().invoke(
+        main,
+        ["--skill", "demo", "--hermes-repo", str(repo), "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "create PR" not in result.output
+    assert "PR" not in result.output
+    assert "Would validate constraints" in result.output


### PR DESCRIPTION
## Summary
- update skill evolution GEPA construction for the current DSPy API
- validate full SKILL.md content, including YAML frontmatter, for skill constraints
- make `--run-tests` a hard output gate
- remove misleading dry-run PR wording

## Test Plan
- `pytest tests/skills/test_evolve_skill.py -q -vv`
- `pytest -q`
- `python -m evolution.skills.evolve_skill --skill nano-pdf --hermes-repo "$HOME/.hermes/hermes-agent" --dry-run`
- `git diff --check`
