### PR TITLE
fix: constraint validation target + GEPA compatibility with dspy 3.3.0

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -33,6 +33,11 @@ from evolution.skills.skill_module import (
 console = Console()
 
 
+def _gepa_fitness_metric(gold, pred, trace=None, pred_name=None, pred_trace=None):
+    """GEPA 3.x requires a 5-arg metric protocol; delegate to the 3-arg skill metric."""
+    return skill_fitness_metric(gold, pred, trace)
+
+
 def evolve(
     skill_name: str,
     iterations: int = 10,
@@ -118,7 +123,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -154,8 +159,9 @@ def evolve(
 
     try:
         optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
-            max_steps=iterations,
+            metric=_gepa_fitness_metric,
+            max_full_evals=iterations,
+            reflection_lm=dspy.LM(eval_model, temperature=1.0, max_tokens=4096),
         )
 
         optimized_module = optimizer.compile(
@@ -185,7 +191,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"


### PR DESCRIPTION
**Title:** fix: constraint validation target + GEPA compatibility with dspy 3.3.0

**Branch:** `fix/gepa-compat-and-constraint-validation`

## Summary

Four small fixes in `evolution/skills/evolve_skill.py` discovered while integrating on Windows with dspy 3.3.0 / gepa 1.x:

### 1. Constraint validation was checking the wrong text (always FAILED)

`_check_skill_structure` validates a **full SKILL.md** (expects `---` frontmatter + name + description), but `evolve_skill.py` passed the bare **body**:

```python
# before
baseline_constraints = validator.validate_all(skill["body"], "skill")
...
evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
```

A bare body never starts with `---`, so **every** run — including perfectly valid ones — reported `skill_structure` FAILED and the evolved skill was saved as `evolved_FAILED.md`.

```python
# after
baseline_constraints = validator.validate_all(skill["raw"], "skill")
...
evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
```

### 2–4. GEPA API drift (dspy 3.3.0)

The repo targets an older GEPA API. On dspy 3.3.0 all three of these throw, the `except Exception` silently falls back to MIPROv2 (the fallback message is easy to miss in rich-console logs), and GEPA's main path never runs:

- `max_steps=N` → **`max_full_evals=N`** (`TypeError: GEPA.__init__() got an unexpected keyword argument 'max_steps'`)
- Metric protocol: dspy 3.3.0's GEPA requires a 5-arg metric `(gold, pred, trace, pred_name, pred_trace)`. `skill_fitness_metric` takes 3 — added a thin adapter:
  ```python
  def _gepa_fitness_metric(gold, pred, trace=None, pred_name=None, pred_trace=None):
      return skill_fitness_metric(gold, pred, trace)
  ```
- `reflection_lm` is mandatory (`AssertionError: GEPA requires a reflection language model…`):
  ```python
  reflection_lm=dspy.LM(eval_model, temperature=1.0, max_tokens=4096),
  ```

## Verification (Windows, dspy 3.3.0, DeepSeek, arxiv skill)

- `pytest tests/ -q`: 144 passed / 1 failed (`test_resolve_expands_user_home` — pre-existing POSIX path assumption, unrelated)
- GEPA **main path** now runs: 9 iterations, 68/75 rollouts, `dspy.teleprompt.gepa.gepa: Iteration N: New subsample score …` visible in logs
- All 4 constraint gates pass (size ≤15KB, growth ≤+20%, non-empty, structure)
- Holdout behavior score 0.431 → 0.564 (+30.7%)

## Note

This PR fixes the *pipeline* so evolution runs and gates correctly, but **skill text itself still never changes on disk** — that is a separate design issue in `SkillModule` (`skill_text` is an input field, not the optimized instruction). Tracked in issue #172.