### PR TITLE
fix(skills): validate full skill file, recover MIPROv2 instruction, unbreak fallback

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -118,7 +118,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -168,11 +168,17 @@ def evolve(
         console.print(f"[yellow]GEPA not available ({e}), falling back to MIPROv2[/yellow]")
         optimizer = dspy.MIPROv2(
             metric=skill_fitness_metric,
-            auto="light",
+            auto=None,
+            num_candidates=max(3, min(10, iterations // 3)),
+            num_threads=1,
         )
         optimized_module = optimizer.compile(
             baseline_module,
             trainset=trainset,
+            valset=valset,
+            num_trials=iterations,
+            minibatch=False,
+            requires_permission_to_run=False,
         )
 
     elapsed = time.time() - start_time
@@ -181,11 +187,24 @@ def evolve(
     # ── 6. Extract evolved skill text ───────────────────────────────────
     # The optimized module's instructions contain the evolved skill text
     evolved_body = optimized_module.skill_text
+    # MIPROv2 does not mutate skill_text; it rewrites the predictor instruction.
+    # Recover the evolved instruction so the run produces a real change.
+    try:
+        _instr = optimized_module.predictor.signature.instructions
+        if _instr and _instr.strip() and _instr.strip() not in evolved_body:
+            evolved_body = (
+                evolved_body.rstrip()
+                + "\n\n## Optimizer-Evolved Guidance\n\n"
+                + _instr.strip()
+                + "\n"
+            )
+    except Exception as _e:
+        console.print(f"[yellow]Could not extract evolved instruction: {_e}[/yellow]")
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"

--- a/tests/core/test_config_repo_path.py
+++ b/tests/core/test_config_repo_path.py
@@ -47,6 +47,10 @@ def test_resolve_expands_user_home(monkeypatch):
     from evolution.core.config import resolve_hermes_agent_path
 
     monkeypatch.setenv("HOME", "/home/example")
+    # Windows' expanduser prefers USERPROFILE/HOMEDRIVE+HOMEPATH over HOME.
+    monkeypatch.setenv("USERPROFILE", "/home/example")
+    monkeypatch.delenv("HOMEDRIVE", raising=False)
+    monkeypatch.delenv("HOMEPATH", raising=False)
     assert resolve_hermes_agent_path("~/code/hermes-agent") == Path("/home/example/code/hermes-agent")
 
 


### PR DESCRIPTION
Four bugs hit while running `evolution.skills.evolve_skill` end-to-end on Windows against a real (session-mined) dataset.

**1. Every run falsely failed `skill_structure` and refused to deploy.**
`validate_all()` was called with `skill["body"]` — the frontmatter-stripped body — so the structure check always reported "missing YAML frontmatter (---), name field, description field", even for a perfectly valid SKILL.md. Now validates the full text (`skill["raw"]` for baseline, `evolved_full` for the result).

**2. The MIPROv2 fallback produced a no-op "evolved" skill.**
GEPA raises on current DSPy (`GEPA.__init__() got an unexpected keyword argument 'max_steps'`), so the fallback path is what actually runs. MIPROv2 rewrites `predictor.signature.instructions`, not `module.skill_text` — so `evolved_body` came back byte-identical to the baseline and every run reported a 0-char diff. Now extracts the optimized instruction and appends it as an `## Optimizer-Evolved Guidance` section.

**3. The fallback ignored `--iterations` and dropped the valset.**
It used `auto="light"` (hardcoded 10 trials) and passed no `valset`. Now sets `num_trials=iterations`, passes `valset`, and `minibatch=False` (default minibatch size exceeds a small valset -> `ValueError: Minibatch size cannot exceed the size of the valset`). Also `num_threads=1`: parallel eval calls tripped provider rate limiting, surfacing as a misleading `AuthenticationError: API key is invalid, blocked or out of funds` mid-run.

**4. `test_resolve_expands_user_home` failed on Windows.**
`Path.expanduser()` prefers `USERPROFILE`/`HOMEDRIVE`+`HOMEPATH` over `HOME` on Windows, so setting only `HOME` didn't take. Test now sets `USERPROFILE` and clears `HOMEDRIVE`/`HOMEPATH`.

**Testing:** `pytest -q` -> 145 passed, 0 failed (was 144 passed / 1 failed pre-change). Pipeline verified end-to-end against Nous free-tier models: dataset build -> instruction proposal -> compile -> constraint validation -> holdout eval, now reaching the holdout stage instead of aborting at validation.