### PR TITLE
fix(evolve): GEPA never executed and evolved output always failed validation

### DIFF
--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -153,9 +153,17 @@ def evolve(
     start_time = time.time()
 
     try:
+        # dspy.GEPA (bundled with DSPy >= 3.x) has no `max_steps` — that kwarg is
+        # from an older standalone gepa API. Use max_metric_calls to bound the run.
+        # dspy.GEPA also requires a 5-arg metric: (gold, pred, trace, pred_name,
+        # pred_trace). Adapt our 3-arg DSPy metric to that signature.
+        def _gepa_metric(gold, pred, trace=None, pred_name=None, pred_trace=None):
+            return skill_fitness_metric(gold, pred, trace)
+
         optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
-            max_steps=iterations,
+            metric=_gepa_metric,
+            max_metric_calls=max(12, iterations * 6),
+            reflection_lm=dspy.LM(optimizer_model, temperature=1.0, max_tokens=8000),
         )
 
         optimized_module = optimizer.compile(
@@ -179,13 +187,25 @@ def evolve(
     console.print(f"\n  Optimization completed in {elapsed:.1f}s")
 
     # ── 6. Extract evolved skill text ───────────────────────────────────
-    # The optimized module's instructions contain the evolved skill text
-    evolved_body = optimized_module.skill_text
+    # GEPA optimizes the PREDICTOR's instruction (ChainOfThought signature), not
+    # the self.skill_text attribute. ChainOfThought wraps its inner predictor, so
+    # reach the signature through named_predictors().
+    try:
+        evolved_instructions = next(iter(
+            pred.signature.instructions
+            for _, pred in optimized_module.predictor.named_predictors()
+        ))
+    except StopIteration:
+        evolved_instructions = optimized_module.predictor.signature.instructions
+    evolved_body = evolved_instructions
     evolved_full = reassemble_skill(skill["frontmatter"], evolved_body)
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    # The evolved artifact is body-only (frontmatter is reassembled separately),
+    # so validate the REASSEMBLED file — the raw body would always fail the
+    # frontmatter structure check by construction.
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"


### PR DESCRIPTION
## Summary

Three bugs in `evolve_skill.py` meant the Phase 1 pipeline could never produce a valid evolved skill:

### 1. Validation ran against a body-only artifact
The evolved text (`evolved_body`) is the skill body with frontmatter stripped, but `skill_structure` requires YAML frontmatter (`---`, `name:`, `description:`). Every evolved variant failed this check **by construction** — no improvement could ever deploy.

**Fix:** validate the reassembled file (`reassemble_skill(frontmatter, body)`).

### 2. GEPA never actually ran
```python
dspy.GEPA(metric=..., max_steps=iterations)  # TypeError: unexpected kwarg
```
Current DSPy's `GEPA` has no `max_steps`; every run hit the except block and silently fell back to MIPROv2 — despite GEPA being the project's headline engine. Also:
- GEPA's metric signature is `(gold, pred, trace, pred_name, pred_trace)`, not DSPy's 3-arg form → adapted via wrapper
- GEPA raises without a `reflection_lm` → wired to `optimizer_model`

### 3. Evolved text was read from a field GEPA never mutates
`optimized_module.skill_text` is untouched by optimization; GEPA evolves the predictor's signature instruction. Verified on real runs: baseline/evolved files had **identical md5** while reporting +0.006/+0.024 "improvements" (judge variance). Now extracted via `named_predictors()`.

## Verification

- Full test suite: **145 passed**
- Real run (hermes-agent skill, 3 iterations): holdout **0.599 → 0.628**, size 12,598 → 3,027 chars, constraints PASS, **non-empty diff present**
- Before fix: same run reported fake improvements with md5-identical output

## Notes

- The MIPROv2 fallback remains as a safety net but no longer triggers.
- Related: `computer-use` SKILL.md (18.5KB) exceeds the 15KB size constraint at baseline — separate concern, not addressed here.