### PR TITLE
feat(prompts): add prompt-section evolution pipeline

### DIFF
--- a/evolution/core/dataset_builder.py
+++ b/evolution/core/dataset_builder.py
@@ -136,13 +136,20 @@ class SyntheticDatasetBuilder:
         try:
             cases_raw = json.loads(result.test_cases)
         except json.JSONDecodeError:
-            # Try to extract JSON from the response
+            # Try to extract JSON from the response; strip JS-style comments and
+            # repair invalid escape sequences LLMs emit (e.g. \w, \d inside strings).
             import re
-            match = re.search(r'\[.*\]', result.test_cases, re.DOTALL)
-            if match:
-                cases_raw = json.loads(match.group())
-            else:
+            candidate = re.sub(r"^\s*//.*$", "", result.test_cases, flags=re.MULTILINE)
+            match = re.search(r'\[.*\]', candidate, re.DOTALL)
+            if not match:
                 raise ValueError(f"Could not parse test cases from LLM output: {result.test_cases[:200]}")
+            raw = match.group()
+            try:
+                cases_raw = json.loads(raw)
+            except json.JSONDecodeError:
+                # Escape backslashes that aren't valid JSON escapes (e.g. \w, \d).
+                repaired = re.sub(r'\\([^\s"\\/bfnrtu])', lambda m: '\\\\' + m.group(1), raw)
+                cases_raw = json.loads(repaired)
 
         examples = [
             EvalExample(

--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -369,7 +369,7 @@ class HermesSessionImporter:
         for session_file in session_files:
             try:
                 data = json.loads(session_file.read_text())
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                 continue
 
             msg_list = data.get("messages", [])

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -104,36 +104,68 @@ class LLMJudge:
         )
 
 
-def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, trace=None) -> float:
+_judge_predictor: Optional[dspy.Module] = None
+
+
+def _get_judge_predictor() -> dspy.Module:
+    global _judge_predictor
+    if _judge_predictor is None:
+        _judge_predictor = dspy.ChainOfThought(LLMJudge.JudgeSignature)
+    return _judge_predictor
+
+
+def _skill_text_from_trace(pred_trace) -> str:
+    """Pull the skill text the module was actually run with out of the trace.
+
+    ``pred_trace`` is a list of ``(predictor, predictor_inputs, prediction)`` tuples.
+    ``SkillModule`` bakes the skill text into the predictor's signature instructions
+    (not an input field — see skill_module.py) so it's read off the predictor itself.
+    """
+    if not pred_trace:
+        return ""
+    for item in pred_trace:
+        predictor = item[0] if len(item) > 0 else None
+        signature = getattr(predictor, "signature", None)
+        if signature is not None and getattr(signature, "instructions", None):
+            return signature.instructions
+    return ""
+
+
+def skill_fitness_metric(
+    example: dspy.Example,
+    prediction: dspy.Prediction,
+    trace=None,
+    pred_name=None,
+    pred_trace=None,
+) -> dspy.Prediction:
     """DSPy-compatible metric function for skill optimization.
 
-    This is what gets passed to dspy.GEPA(metric=...).
-    Returns a float 0-1 score.
+    This is what gets passed to dspy.GEPA(metric=...). GEPA requires this exact
+    five-argument signature (gold, pred, trace, pred_name, pred_trace) and uses
+    the returned feedback text for its reflective mutation step — a bare float
+    works but gives GEPA nothing to reason about *why* a candidate scored low.
     """
-    # The prediction should have an 'output' field with the agent's response
     agent_output = getattr(prediction, "output", "") or ""
     expected = getattr(example, "expected_behavior", "") or ""
     task = getattr(example, "task_input", "") or ""
 
     if not agent_output.strip():
-        return 0.0
+        return dspy.Prediction(score=0.0, feedback="The skill produced an empty response for this task.")
 
-    # Quick heuristic scoring (for speed during optimization)
-    # Full LLM-as-judge scoring is expensive — use it selectively
-    score = 0.5  # Base score for non-empty output
+    judge = _get_judge_predictor()
+    result = judge(
+        task_input=task,
+        expected_behavior=expected,
+        agent_output=agent_output,
+        skill_text=_skill_text_from_trace(pred_trace),
+    )
 
-    # Check if key phrases from expected behavior appear
-    expected_lower = expected.lower()
-    output_lower = agent_output.lower()
+    correctness = _parse_score(result.correctness)
+    procedure_following = _parse_score(result.procedure_following)
+    conciseness = _parse_score(result.conciseness)
+    score = min(1.0, max(0.0, 0.5 * correctness + 0.3 * procedure_following + 0.2 * conciseness))
 
-    # Simple keyword overlap as a fast proxy
-    expected_words = set(expected_lower.split())
-    output_words = set(output_lower.split())
-    if expected_words:
-        overlap = len(expected_words & output_words) / len(expected_words)
-        score = 0.3 + (0.7 * overlap)
-
-    return min(1.0, max(0.0, score))
+    return dspy.Prediction(score=score, feedback=str(result.feedback))
 
 
 def _parse_score(value) -> float:

--- a/evolution/prompts/evolve_prompt_section.py
+++ b/evolution/prompts/evolve_prompt_section.py
@@ -1,0 +1,165 @@
+"""Evolve a named Hermes prompt-builder section using DSPy + GEPA.
+
+Usage:
+    python -m evolution.prompts.evolve_prompt_section \
+        --section MEMORY_GUIDANCE --iterations 5 --eval-source synthetic
+"""
+
+import json
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import click
+import dspy
+from rich.console import Console
+from rich.table import Table
+
+from evolution.core.config import EvolutionConfig, resolve_hermes_agent_path
+from evolution.core.constraints import ConstraintValidator
+from evolution.core.dataset_builder import EvalDataset, GoldenDatasetLoader, SyntheticDatasetBuilder
+from evolution.core.fitness import skill_fitness_metric
+from evolution.prompts.prompt_module import PromptSectionModule, list_prompt_sections, load_prompt_section
+
+console = Console()
+
+
+def evolve(
+    section_name: str,
+    iterations: int = 5,
+    eval_source: str = "synthetic",
+    dataset_path: Optional[str] = None,
+    optimizer_model: str = "openai/gpt-4.1",
+    eval_model: str = "openai/gpt-4.1-mini",
+    hermes_repo: Optional[str] = None,
+    dry_run: bool = False,
+):
+    """Run prompt-section evolution and save artifacts under output/prompts/."""
+    config = EvolutionConfig(
+        hermes_agent_path=resolve_hermes_agent_path(hermes_repo),
+        iterations=iterations,
+        optimizer_model=optimizer_model,
+        eval_model=eval_model,
+        judge_model=eval_model,
+    )
+
+    console.print(f"\n[bold cyan]🧬 Hermes Agent Self-Evolution[/bold cyan] — Evolving prompt section: [bold]{section_name}[/bold]\n")
+    section = load_prompt_section(config.hermes_agent_path, section_name)
+    baseline_text = str(section["text"])
+    console.print(f"  Loaded: {section['path']}")
+    console.print(f"  Size: {len(baseline_text):,} chars")
+
+    if dry_run:
+        console.print("\n[bold green]DRY RUN — setup validated successfully.[/bold green]")
+        console.print(f"  Available sections: {', '.join(sorted(list_prompt_sections(config.hermes_agent_path)))}")
+        return
+
+    console.print(f"\n[bold]Building evaluation dataset[/bold] (source: {eval_source})")
+    if eval_source == "golden" and dataset_path:
+        dataset = GoldenDatasetLoader.load(Path(dataset_path))
+    elif eval_source == "synthetic":
+        dataset = SyntheticDatasetBuilder(config).generate(
+            artifact_text=baseline_text,
+            artifact_type="prompt_section",
+        )
+        save_path = Path("datasets") / "prompts" / section_name
+        dataset.save(save_path)
+        console.print(f"  Generated {len(dataset.all_examples)} synthetic examples")
+        console.print(f"  Saved to {save_path}/")
+    elif dataset_path:
+        dataset = EvalDataset.load(Path(dataset_path))
+    else:
+        console.print("[red]✗ Specify --dataset-path or use --eval-source synthetic[/red]")
+        sys.exit(1)
+    console.print(f"  Split: {len(dataset.train)} train / {len(dataset.val)} val / {len(dataset.holdout)} holdout")
+
+    validator = ConstraintValidator(config)
+    baseline_constraints = validator.validate_all(baseline_text, "prompt_section")
+    for c in baseline_constraints:
+        icon = "✓" if c.passed else "✗"
+        color = "green" if c.passed else "yellow"
+        console.print(f"  [{color}]{icon} {c.constraint_name}[/{color}]: {c.message}")
+
+    lm = dspy.LM(eval_model)
+    dspy.configure(lm=lm)
+
+    baseline_module = PromptSectionModule(baseline_text)
+    trainset = dataset.to_dspy_examples("train")
+    valset = dataset.to_dspy_examples("val")
+
+    console.print(f"\n[bold cyan]Running GEPA optimization ({iterations} iterations)...[/bold cyan]\n")
+    start_time = time.time()
+    optimizer = dspy.GEPA(
+        metric=skill_fitness_metric,
+        max_full_evals=iterations,
+        reflection_lm=dspy.LM(optimizer_model),
+    )
+    optimized_module = optimizer.compile(baseline_module, trainset=trainset, valset=valset)
+    elapsed = time.time() - start_time
+    console.print(f"\n  Optimization completed in {elapsed:.1f}s")
+
+    evolved_text = optimized_module.section_text
+    evolved_constraints = validator.validate_all(evolved_text, "prompt_section", baseline_text=baseline_text)
+    all_pass = True
+    for c in evolved_constraints:
+        icon = "✓" if c.passed else "✗"
+        color = "green" if c.passed else "red"
+        console.print(f"  [{color}]{icon} {c.constraint_name}[/{color}]: {c.message}")
+        all_pass = all_pass and c.passed
+
+    console.print(f"\n[bold]Evaluating on holdout set ({len(dataset.holdout)} examples)[/bold]")
+    baseline_scores = []
+    evolved_scores = []
+    with dspy.context(lm=lm):
+        for ex in dataset.to_dspy_examples("holdout"):
+            baseline_scores.append(skill_fitness_metric(ex, baseline_module(task_input=ex.task_input)).score)
+            evolved_scores.append(skill_fitness_metric(ex, optimized_module(task_input=ex.task_input)).score)
+
+    n = max(1, len(baseline_scores))
+    baseline_score = sum(baseline_scores) / n
+    evolved_score = sum(evolved_scores) / n
+    change = evolved_score - baseline_score
+
+    table = Table(title="Prompt Section Evolution Results")
+    table.add_column("Metric", style="bold")
+    table.add_column("Baseline", justify="right")
+    table.add_column("Evolved", justify="right")
+    table.add_column("Change", justify="right")
+    table.add_row("Holdout Score", f"{baseline_score:.3f}", f"{evolved_score:.3f}", f"{change:+.3f}")
+    console.print(table)
+
+    output_dir = Path("output") / "prompts" / section_name / datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "baseline_section.md").write_text(baseline_text)
+    (output_dir / "evolved_section.md").write_text(evolved_text)
+    (output_dir / "metrics.json").write_text(json.dumps({
+        "section": section_name,
+        "iterations": iterations,
+        "optimizer_model": optimizer_model,
+        "eval_model": eval_model,
+        "baseline_score": baseline_score,
+        "evolved_score": evolved_score,
+        "improvement": change,
+        "constraints_passed": all_pass,
+        "elapsed_seconds": elapsed,
+    }, indent=2))
+    console.print(f"\n  Output saved to {output_dir}/")
+
+
+@click.command()
+@click.option("--section", required=True, help="Prompt-builder constant to evolve, e.g. MEMORY_GUIDANCE")
+@click.option("--iterations", default=5, help="Number of GEPA iterations")
+@click.option("--eval-source", type=click.Choice(["synthetic", "golden"]), default="synthetic")
+@click.option("--dataset-path", default=None, help="Path to existing eval dataset")
+@click.option("--optimizer-model", default="openai/gpt-4.1", help="Model for GEPA reflections")
+@click.option("--eval-model", default="openai/gpt-4.1-mini", help="Model for evaluations")
+@click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
+@click.option("--dry-run", is_flag=True, help="Validate setup without optimization")
+def main(section, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, dry_run):
+    evolve(section, iterations, eval_source, dataset_path, optimizer_model, eval_model, hermes_repo, dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/evolution/prompts/prompt_module.py
+++ b/evolution/prompts/prompt_module.py
@@ -1,0 +1,88 @@
+"""Wrap Hermes prompt-builder sections as DSPy optimizable modules.
+
+Phase 3 optimizes named text constants from ``agent/prompt_builder.py`` (for
+example ``MEMORY_GUIDANCE`` or ``DEFAULT_AGENT_IDENTITY``) without importing the
+Hermes runtime. Static AST loading keeps this safe and dependency-light.
+"""
+
+import ast
+from pathlib import Path
+from typing import Optional
+
+import dspy
+
+
+PROMPT_BUILDER_RELATIVE = Path("agent") / "prompt_builder.py"
+
+
+def _literal_string(node: ast.AST) -> Optional[str]:
+    """Return a statically evaluable string expression, if possible."""
+    try:
+        value = ast.literal_eval(node)
+    except (ValueError, SyntaxError):
+        return None
+    return value if isinstance(value, str) else None
+
+
+def list_prompt_sections(hermes_agent_path: Path) -> dict[str, str]:
+    """List uppercase string constants in ``agent/prompt_builder.py``.
+
+    Returns ``{SECTION_NAME: text}`` for constants that are useful prompt
+    sections. Non-string values and private/internal constants are ignored.
+    """
+    path = hermes_agent_path / PROMPT_BUILDER_RELATIVE
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    sections: dict[str, str] = {}
+
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        value = _literal_string(node.value)
+        if not value:
+            continue
+        for target in node.targets:
+            if not isinstance(target, ast.Name):
+                continue
+            name = target.id
+            if name.isupper() and not name.startswith("_"):
+                sections[name] = value
+
+    return sections
+
+
+def load_prompt_section(hermes_agent_path: Path, section_name: str) -> dict[str, object]:
+    """Load one named prompt-builder section.
+
+    Returns a dict with ``name``, ``text`` and ``path`` keys.
+    """
+    sections = list_prompt_sections(hermes_agent_path)
+    if section_name not in sections:
+        available = ", ".join(sorted(sections))
+        raise ValueError(f"Prompt section {section_name!r} not found. Available: {available}")
+    return {
+        "name": section_name,
+        "text": sections[section_name],
+        "path": hermes_agent_path / PROMPT_BUILDER_RELATIVE,
+    }
+
+
+class PromptSectionModule(dspy.Module):
+    """DSPy module that uses a prompt section as mutable instructions."""
+
+    class TaskWithPromptSection(dspy.Signature):
+        task_input: str = dspy.InputField(desc="The task or situation to handle")
+        output: str = dspy.OutputField(desc="Your response following the prompt section")
+
+    def __init__(self, section_text: str):
+        super().__init__()
+        signature = self.TaskWithPromptSection.with_instructions(section_text)
+        self.predictor = dspy.ChainOfThought(signature)
+
+    @property
+    def section_text(self) -> str:
+        """The current prompt-section instructions mutated by GEPA/MIPRO."""
+        return self.predictor.predict.signature.instructions  # type: ignore[attr-defined]
+
+    def forward(self, task_input: str) -> dspy.Prediction:
+        result = self.predictor(task_input=task_input)
+        return dspy.Prediction(output=result.output)

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -118,7 +118,7 @@ def evolve(
     # ── 3. Validate constraints on baseline ─────────────────────────────
     console.print(f"\n[bold]Validating baseline constraints[/bold]")
     validator = ConstraintValidator(config)
-    baseline_constraints = validator.validate_all(skill["body"], "skill")
+    baseline_constraints = validator.validate_all(skill["raw"], "skill")
     all_pass = True
     for c in baseline_constraints:
         icon = "✓" if c.passed else "✗"
@@ -155,7 +155,8 @@ def evolve(
     try:
         optimizer = dspy.GEPA(
             metric=skill_fitness_metric,
-            max_steps=iterations,
+            max_full_evals=iterations,
+            reflection_lm=dspy.LM(optimizer_model),
         )
 
         optimized_module = optimizer.compile(
@@ -185,7 +186,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"

--- a/evolution/skills/skill_module.py
+++ b/evolution/skills/skill_module.py
@@ -84,33 +84,33 @@ def find_skill(skill_name: str, hermes_agent_path: Path) -> Optional[Path]:
 class SkillModule(dspy.Module):
     """A DSPy module that wraps a skill file for optimization.
 
-    The skill text (body) is the parameter that GEPA optimizes.
+    The skill text is the *instructions* of the predictor's signature — not an
+    input field — because GEPA/MIPRO only mutate predictor instructions. Any
+    part of the skill passed as an input field is invisible to the optimizer
+    and would silently freeze, leaving `.skill_text` stuck at its baseline
+    value while the optimizer mutates a disconnected wrapper prompt instead.
     On each forward pass, the module:
-    1. Uses the skill text as instructions
+    1. Uses the skill text as the predictor's instructions
     2. Processes the task input
     3. Returns the agent's response
     """
 
     class TaskWithSkill(dspy.Signature):
-        """Complete a task following the provided skill instructions.
-
-        You are an AI agent following specific skill instructions to complete a task.
-        Read the skill instructions carefully and follow the procedure described.
-        """
-        skill_instructions: str = dspy.InputField(desc="The skill instructions to follow")
         task_input: str = dspy.InputField(desc="The task to complete")
         output: str = dspy.OutputField(desc="Your response following the skill instructions")
 
     def __init__(self, skill_text: str):
         super().__init__()
-        self.skill_text = skill_text
-        self.predictor = dspy.ChainOfThought(self.TaskWithSkill)
+        signature = self.TaskWithSkill.with_instructions(skill_text)
+        self.predictor = dspy.ChainOfThought(signature)
+
+    @property
+    def skill_text(self) -> str:
+        """The current skill instructions — mutated in place by GEPA/MIPRO."""
+        return self.predictor.predict.signature.instructions
 
     def forward(self, task_input: str) -> dspy.Prediction:
-        result = self.predictor(
-            skill_instructions=self.skill_text,
-            task_input=task_input,
-        )
+        result = self.predictor(task_input=task_input)
         return dspy.Prediction(output=result.output)
 
 

--- a/evolution/tools/evolve_tool_descriptions.py
+++ b/evolution/tools/evolve_tool_descriptions.py
@@ -1,0 +1,274 @@
+"""Evolve hermes-agent tool descriptions using DSPy + GEPA (Phase 2).
+
+Unlike skill evolution, tool descriptions are optimized as a *group*: all
+target tools' descriptions live in one router instructions block (see
+tool_module.build_router_instructions) so GEPA sees cross-tool competition —
+mutating one tool's description to steal selections from another shows up as
+a fitness regression on the stolen-from tool, not just a gain on the mutated one.
+
+Usage:
+    python -m evolution.tools.evolve_tool_descriptions \\
+        --tools read_file,write_file,search_files,terminal --iterations 5
+"""
+
+import json
+import time
+from pathlib import Path
+from datetime import datetime
+from typing import Optional
+
+import click
+import dspy
+from rich.console import Console
+from rich.table import Table
+
+from evolution.core.config import EvolutionConfig, resolve_hermes_agent_path
+from evolution.core.dataset_builder import EvalExample, EvalDataset
+from evolution.core.constraints import ConstraintValidator
+from evolution.tools.tool_module import ToolRouterModule, load_tool_descriptions
+
+console = Console()
+
+
+class GenerateToolSelectionCases(dspy.Signature):
+    """Generate a tool-selection evaluation dataset for a set of agent tools.
+
+    Given several tool descriptions, produce realistic tasks that test whether
+    an agent would pick the right tool. For EACH tool, include a mix of:
+    - Clear-cut tasks where that tool is obviously correct
+    - Confusing tasks where a DIFFERENT tool in the list could plausibly be
+      picked instead, to test whether descriptions clearly disambiguate
+    Do not include tasks for tools outside the given list.
+    """
+    tool_descriptions_block: str = dspy.InputField(desc="All candidate tools and their current descriptions")
+    tool_names: str = dspy.InputField(desc="Comma-separated list of valid tool names — every correct_tool value must be one of these, verbatim")
+    cases_per_tool: int = dspy.InputField(desc="How many test cases to generate per tool")
+    test_cases: str = dspy.OutputField(desc="JSON array of objects: {task_input, correct_tool, difficulty}")
+
+
+def _generate_tool_selection_dataset(
+    descriptions: dict[str, str],
+    config: EvolutionConfig,
+    cases_per_tool: int = 6,
+) -> EvalDataset:
+    from evolution.tools.tool_module import build_router_instructions
+
+    generator = dspy.ChainOfThought(GenerateToolSelectionCases)
+    lm = dspy.LM(config.judge_model)
+
+    with dspy.context(lm=lm):
+        result = generator(
+            tool_descriptions_block=build_router_instructions(descriptions),
+            tool_names=", ".join(descriptions.keys()),
+            cases_per_tool=cases_per_tool,
+        )
+
+    try:
+        cases_raw = json.loads(result.test_cases)
+    except json.JSONDecodeError:
+        import re
+        match = re.search(r"\[.*\]", result.test_cases, re.DOTALL)
+        if not match:
+            raise ValueError(f"Could not parse test cases from LLM output: {result.test_cases[:200]}")
+        cases_raw = json.loads(match.group())
+
+    valid_names = set(descriptions.keys())
+    examples = [
+        EvalExample(
+            task_input=c["task_input"],
+            expected_behavior=c["correct_tool"],
+            difficulty=c.get("difficulty", "medium"),
+            category=c["correct_tool"],
+            source="synthetic",
+        )
+        for c in cases_raw
+        if c.get("task_input") and c.get("correct_tool") in valid_names
+    ]
+
+    dropped = len(cases_raw) - len(examples)
+    if dropped:
+        console.print(f"  [yellow]Dropped {dropped}/{len(cases_raw)} generated cases (missing fields or unknown tool name)[/yellow]")
+
+    import random
+    random.shuffle(examples)
+    n = len(examples)
+    n_train = max(1, int(n * config.train_ratio))
+    n_val = max(1, int(n * config.val_ratio))
+
+    return EvalDataset(
+        train=examples[:n_train],
+        val=examples[n_train:n_train + n_val],
+        holdout=examples[n_train + n_val:],
+    )
+
+
+def tool_selection_metric(
+    example: dspy.Example,
+    prediction: dspy.Prediction,
+    trace=None,
+    pred_name=None,
+    pred_trace=None,
+) -> dspy.Prediction:
+    """GEPA-compatible metric: did the router pick the gold tool name?"""
+    predicted = (getattr(prediction, "tool_name", "") or "").strip()
+    gold = (getattr(example, "expected_behavior", "") or "").strip()
+
+    if predicted == gold:
+        return dspy.Prediction(score=1.0, feedback=f"Correctly routed to '{gold}'.")
+
+    return dspy.Prediction(
+        score=0.0,
+        feedback=(
+            f"Task: {example.task_input!r} — expected tool '{gold}' but the router "
+            f"picked '{predicted}'. The descriptions for these two tools don't "
+            f"clearly disambiguate this case; sharpen what distinguishes them."
+        ),
+    )
+
+
+def evolve(
+    tool_names: list[str],
+    iterations: int = 5,
+    optimizer_model: str = "openai/gpt-4.1",
+    eval_model: str = "openai/gpt-4.1-mini",
+    hermes_repo: Optional[str] = None,
+    cases_per_tool: int = 6,
+    dry_run: bool = False,
+):
+    config = EvolutionConfig(
+        hermes_agent_path=resolve_hermes_agent_path(hermes_repo),
+        iterations=iterations,
+        optimizer_model=optimizer_model,
+        eval_model=eval_model,
+        judge_model=eval_model,
+    )
+
+    console.print(f"\n[bold cyan]🧬 Hermes Agent Self-Evolution[/bold cyan] — Evolving tool descriptions: [bold]{', '.join(tool_names)}[/bold]\n")
+
+    descriptions = load_tool_descriptions(config.hermes_agent_path, tool_names)
+    for name, desc in descriptions.items():
+        console.print(f"  {name}: {len(desc):,} chars")
+
+    if dry_run:
+        console.print("\n[bold green]DRY RUN — setup validated successfully.[/bold green]")
+        console.print(f"  Would generate ~{cases_per_tool * len(tool_names)} synthetic selection cases")
+        console.print(f"  Would run GEPA optimization ({iterations} iterations)")
+        return
+
+    console.print("\n[bold]Generating tool-selection eval dataset[/bold]")
+    dataset = _generate_tool_selection_dataset(descriptions, config, cases_per_tool)
+    console.print(f"  Split: {len(dataset.train)} train / {len(dataset.val)} val / {len(dataset.holdout)} holdout")
+
+    validator = ConstraintValidator(config)
+    console.print("\n[bold]Baseline description sizes[/bold]")
+    for name, desc in descriptions.items():
+        result = validator._check_size(desc, "tool_description")
+        icon = "✓" if result.passed else "✗"
+        console.print(f"  [{'green' if result.passed else 'yellow'}]{icon} {name}[/]: {result.message}")
+
+    dspy.configure(lm=dspy.LM(eval_model))
+
+    baseline_module = ToolRouterModule(descriptions)
+    trainset = dataset.to_dspy_examples("train")
+    valset = dataset.to_dspy_examples("val")
+
+    console.print(f"\n[bold cyan]Running GEPA optimization ({iterations} iterations)...[/bold cyan]\n")
+    start_time = time.time()
+
+    optimizer = dspy.GEPA(
+        metric=tool_selection_metric,
+        max_full_evals=iterations,
+        reflection_lm=dspy.LM(optimizer_model),
+    )
+    optimized_module = optimizer.compile(baseline_module, trainset=trainset, valset=valset)
+
+    elapsed = time.time() - start_time
+    console.print(f"\n  Optimization completed in {elapsed:.1f}s")
+
+    evolved_descriptions = optimized_module.descriptions
+    missing = set(tool_names) - evolved_descriptions.keys()
+    if missing:
+        console.print(f"[red]✗ Lost marker for tool(s) {sorted(missing)} during optimization — structure did not survive[/red]")
+
+    console.print("\n[bold]Evolved description sizes[/bold]")
+    per_tool_ok = {}
+    for name in tool_names:
+        desc = evolved_descriptions.get(name, "")
+        result = validator._check_size(desc, "tool_description") if desc else None
+        ok = bool(desc) and result.passed
+        per_tool_ok[name] = ok
+        icon = "✓" if ok else "✗"
+        msg = result.message if result else "missing after optimization"
+        console.print(f"  [{'green' if ok else 'red'}]{icon} {name}[/]: {msg}")
+
+    console.print(f"\n[bold]Evaluating on holdout set ({len(dataset.holdout)} examples)[/bold]")
+    holdout_examples = dataset.to_dspy_examples("holdout")
+
+    baseline_correct = evolved_correct = 0
+    lm = dspy.LM(eval_model)
+    with dspy.context(lm=lm):
+        for ex in holdout_examples:
+            baseline_correct += int(baseline_module(task_input=ex.task_input).tool_name.strip() == ex.expected_behavior)
+            evolved_correct += int(optimized_module(task_input=ex.task_input).tool_name.strip() == ex.expected_behavior)
+
+    n_holdout = max(1, len(holdout_examples))
+    baseline_acc = baseline_correct / n_holdout
+    evolved_acc = evolved_correct / n_holdout
+
+    table = Table(title="Tool Description Evolution Results")
+    table.add_column("Metric", style="bold")
+    table.add_column("Baseline", justify="right")
+    table.add_column("Evolved", justify="right")
+    table.add_column("Change", justify="right")
+    change = evolved_acc - baseline_acc
+    table.add_row(
+        "Holdout tool-selection accuracy",
+        f"{baseline_acc:.3f}",
+        f"{evolved_acc:.3f}",
+        f"[{'green' if change > 0 else 'red'}]{change:+.3f}[/]",
+    )
+    console.print()
+    console.print(table)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = Path("output") / "tools" / timestamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "baseline_descriptions.json").write_text(json.dumps(descriptions, indent=2))
+    (output_dir / "evolved_descriptions.json").write_text(json.dumps(evolved_descriptions, indent=2))
+    (output_dir / "metrics.json").write_text(json.dumps({
+        "tools": tool_names,
+        "iterations": iterations,
+        "optimizer_model": optimizer_model,
+        "eval_model": eval_model,
+        "baseline_accuracy": baseline_acc,
+        "evolved_accuracy": evolved_acc,
+        "improvement": change,
+        "per_tool_constraints_passed": per_tool_ok,
+        "elapsed_seconds": elapsed,
+    }, indent=2))
+    console.print(f"\n  Output saved to {output_dir}/")
+
+
+@click.command()
+@click.option("--tools", required=True, help="Comma-separated tool names to evolve together")
+@click.option("--iterations", default=5, help="Number of GEPA iterations")
+@click.option("--cases-per-tool", default=6, help="Synthetic eval cases to generate per tool")
+@click.option("--optimizer-model", default="openai/gpt-4.1", help="Model for GEPA reflections")
+@click.option("--eval-model", default="openai/gpt-4.1-mini", help="Model for evaluations")
+@click.option("--hermes-repo", default=None, help="Path to hermes-agent repo")
+@click.option("--dry-run", is_flag=True, help="Validate setup without running optimization")
+def main(tools, iterations, cases_per_tool, optimizer_model, eval_model, hermes_repo, dry_run):
+    """Evolve a group of hermes-agent tool descriptions using DSPy + GEPA."""
+    evolve(
+        tool_names=[t.strip() for t in tools.split(",") if t.strip()],
+        iterations=iterations,
+        optimizer_model=optimizer_model,
+        eval_model=eval_model,
+        hermes_repo=hermes_repo,
+        cases_per_tool=cases_per_tool,
+        dry_run=dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/evolution/tools/evolve_tool_descriptions.py
+++ b/evolution/tools/evolve_tool_descriptions.py
@@ -39,11 +39,56 @@ class GenerateToolSelectionCases(dspy.Signature):
     - Confusing tasks where a DIFFERENT tool in the list could plausibly be
       picked instead, to test whether descriptions clearly disambiguate
     Do not include tasks for tools outside the given list.
+
+    HARD REQUIREMENTS — the dataset is only useful if it produces errors:
+    - At least 70% of cases must be 'hard': boundary cases where two tools in
+      the list genuinely overlap and either could plausibly be argued for.
+      Examples of real overlaps: searching file contents (search_files) vs
+      running grep/rg via terminal; reading a file (read_file) vs cat/head/tail
+      or sed -n via terminal; creating/editing a file (write_file) vs shell
+      redirection or patch via terminal; structured multi-file search
+      (search_files) vs a one-off find command.
+    - For each hard case, the correct answer must be decided by a SPECIFIC,
+      defensible criterion stated in the task itself (e.g. "needs line numbers
+      and regex with lookaheads" favors grep in terminal; "results will be
+      re-read programmatically many times" favors search_files). Do not write
+      trick questions whose answer is arbitrary — write cases where the right
+      choice follows from what the descriptions SHOULD say.
+    - Vary phrasing: some tasks terse, some verbose, some with context noise.
     """
     tool_descriptions_block: str = dspy.InputField(desc="All candidate tools and their current descriptions")
     tool_names: str = dspy.InputField(desc="Comma-separated list of valid tool names — every correct_tool value must be one of these, verbatim")
     cases_per_tool: int = dspy.InputField(desc="How many test cases to generate per tool")
     test_cases: str = dspy.OutputField(desc="JSON array of objects: {task_input, correct_tool, difficulty}")
+
+
+# Curated adversarial seed cases for the read_file/write_file/search_files/terminal
+# group. These are always mixed into the synthetic dataset so the run never
+# depends solely on LLM-generated cases being hard enough. Each answer follows
+# from a defensible criterion, not arbitrariness.
+CURATED_SEED_CASES: dict[str, list[dict]] = {
+    "read_file,write_file,search_files,terminal": [
+        # search_files vs terminal(grep)
+        {"task_input": "Show every line in the repo matching the regex 'def \\w+_schema' with line numbers and 2 lines of context after", "correct_tool": "terminal", "difficulty": "hard"},
+        {"task_input": "Find all call sites of the helper function build_payload across src/ — we'll iterate over the matches programmatically afterwards", "correct_tool": "search_files", "difficulty": "hard"},
+        {"task_input": "Count how many TODO comments exist in the project and produce a sorted per-file breakdown", "correct_tool": "terminal", "difficulty": "hard"},
+        {"task_input": "Locate where the constant MAX_RETRIES is defined or referenced; I just need to know if it exists and roughly where", "correct_tool": "search_files", "difficulty": "hard"},
+        # read_file vs terminal(cat/head/sed)
+        {"task_input": "Print the first 40 lines of build.log to see why compilation started failing", "correct_tool": "terminal", "difficulty": "hard"},
+        {"task_input": "I need to review pyproject.toml in full before editing it — show me everything including any long sections", "correct_tool": "read_file", "difficulty": "hard"},
+        {"task_input": "Extract only lines 500-560 of the generated report.md without loading the rest", "correct_tool": "terminal", "difficulty": "hard"},
+        # write_file vs terminal redirection/patch
+        {"task_input": "Replace the version string '1.2.0' with '1.3.0' everywhere it appears in setup.cfg — surgical edit, nothing else changes", "correct_tool": "terminal", "difficulty": "hard"},
+        {"task_input": "Write a brand-new CONTRIBUTING.md from this outline I'm giving you", "correct_tool": "write_file", "difficulty": "hard"},
+        {"task_input": "Append one line 'generated-by-ci: true' to the end of .gitignore", "correct_tool": "terminal", "difficulty": "hard"},
+    ],
+}
+
+
+def _curated_seed_cases(tool_names: list[str]) -> list[dict]:
+    """Return curated seed cases matching this tool group, if any."""
+    key = ",".join(tool_names)
+    return CURATED_SEED_CASES.get(key, [])
 
 
 def _generate_tool_selection_dataset(
@@ -67,7 +112,10 @@ def _generate_tool_selection_dataset(
         cases_raw = json.loads(result.test_cases)
     except json.JSONDecodeError:
         import re
-        match = re.search(r"\[.*\]", result.test_cases, re.DOTALL)
+        candidate = result.test_cases
+        # LLMs sometimes emit JS-style comments inside the JSON array — strip them.
+        candidate = re.sub(r"^\s*//.*$", "", candidate, flags=re.MULTILINE)
+        match = re.search(r"\[.*\]", candidate, re.DOTALL)
         if not match:
             raise ValueError(f"Could not parse test cases from LLM output: {result.test_cases[:200]}")
         cases_raw = json.loads(match.group())
@@ -88,6 +136,20 @@ def _generate_tool_selection_dataset(
     dropped = len(cases_raw) - len(examples)
     if dropped:
         console.print(f"  [yellow]Dropped {dropped}/{len(cases_raw)} generated cases (missing fields or unknown tool name)[/yellow]")
+
+    seed = _curated_seed_cases(list(descriptions.keys()))
+    if seed:
+        examples.extend(
+            EvalExample(
+                task_input=c["task_input"],
+                expected_behavior=c["correct_tool"],
+                difficulty=c.get("difficulty", "hard"),
+                category="curated_seed",
+                source="golden",
+            )
+            for c in seed
+        )
+        console.print(f"  Added {len(seed)} curated adversarial seed cases")
 
     import random
     random.shuffle(examples)
@@ -186,9 +248,12 @@ def evolve(
     console.print(f"\n  Optimization completed in {elapsed:.1f}s")
 
     evolved_descriptions = optimized_module.descriptions
-    missing = set(tool_names) - evolved_descriptions.keys()
-    if missing:
-        console.print(f"[red]✗ Lost marker for tool(s) {sorted(missing)} during optimization — structure did not survive[/red]")
+    evolved_block = optimized_module.raw_instructions
+    markers_lost = set(tool_names) - evolved_descriptions.keys()
+    if markers_lost and evolved_block.strip():
+        console.print(f"[yellow]! GEPA dropped the ### TOOL: markers for {sorted(markers_lost)} — keeping the full evolved block as one unit[/yellow]")
+    elif markers_lost:
+        console.print(f"[red]✗ Lost marker for tool(s) {sorted(markers_lost)} during optimization — structure did not survive[/red]")
 
     console.print("\n[bold]Evolved description sizes[/bold]")
     per_tool_ok = {}
@@ -235,6 +300,7 @@ def evolve(
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / "baseline_descriptions.json").write_text(json.dumps(descriptions, indent=2))
     (output_dir / "evolved_descriptions.json").write_text(json.dumps(evolved_descriptions, indent=2))
+    (output_dir / "evolved_block.md").write_text(evolved_block)
     (output_dir / "metrics.json").write_text(json.dumps({
         "tools": tool_names,
         "iterations": iterations,
@@ -244,6 +310,7 @@ def evolve(
         "evolved_accuracy": evolved_acc,
         "improvement": change,
         "per_tool_constraints_passed": per_tool_ok,
+        "markers_survived": not markers_lost,
         "elapsed_seconds": elapsed,
     }, indent=2))
     console.print(f"\n  Output saved to {output_dir}/")

--- a/evolution/tools/tool_module.py
+++ b/evolution/tools/tool_module.py
@@ -146,8 +146,23 @@ class ToolRouterModule(dspy.Module):
 
     @property
     def descriptions(self) -> dict[str, str]:
-        """Current per-tool descriptions — mutated in place by GEPA/MIPRO."""
-        return parse_router_instructions(self.predictor.predict.signature.instructions, self.tool_names)
+        """Current per-tool descriptions — mutated in place by GEPA/MIPRO.
+
+        If GEPA rewrote the block and dropped the `### TOOL:` markers (common
+        once the optimizer starts restructuring prose), fall back to keeping
+        the whole evolved block as a single entry keyed by the first tool name.
+        The block is still fully usable as routing instructions; only per-tool
+        splitting is lost, which downstream consumers must handle gracefully.
+        """
+        parsed = parse_router_instructions(self.predictor.predict.signature.instructions, self.tool_names)  # type: ignore[attr-defined]
+        if parsed:
+            return parsed
+        return {self.tool_names[0]: self.predictor.predict.signature.instructions}  # type: ignore[attr-defined]
+
+    @property
+    def raw_instructions(self) -> str:
+        """The full (possibly evolved) instructions block, markers or not."""
+        return self.predictor.predict.signature.instructions  # type: ignore[attr-defined]
 
     def forward(self, task_input: str) -> dspy.Prediction:
         result = self.predictor(task_input=task_input)

--- a/evolution/tools/tool_module.py
+++ b/evolution/tools/tool_module.py
@@ -1,0 +1,154 @@
+"""Wraps a set of hermes-agent tool descriptions as a DSPy module for optimization.
+
+Mirrors evolution/skills/skill_module.py: the descriptions become the
+*instructions* of a single router predictor (not input fields), since GEPA/MIPRO
+only mutate predictor instructions. Cross-tool evaluation matters here more than
+for a single skill — evolving one tool's description can "steal" selections
+from another, so all target tools are optimized together in one instructions
+block, not independently.
+"""
+
+import ast
+from pathlib import Path
+from typing import Optional
+
+import dspy
+
+TOOL_BLOCK_START = "### TOOL: "
+
+ROUTER_PREAMBLE = (
+    "You are a tool router for an AI coding agent. Given a task, pick the single "
+    "best tool from the list below. Respond with only the tool name.\n\n"
+    "Available tools:\n"
+)
+
+
+def _resolve_string_constant(tree: ast.Module, name: str) -> Optional[str]:
+    """Find a module-level `NAME = "..."` (or triple-quoted) string assignment."""
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == name for t in node.targets):
+            continue
+        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            return node.value.value
+    return None
+
+
+def _extract_schema_dicts(tree: ast.Module) -> list[dict]:
+    """Find module-level `X_SCHEMA = {...}` dict literals with name+description keys."""
+    schemas = []
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Dict):
+            continue
+        name_val = None
+        desc_val = None
+        for key, val in zip(node.value.keys, node.value.values):
+            if not isinstance(key, ast.Constant):
+                continue
+            if key.value == "name" and isinstance(val, ast.Constant):
+                name_val = val.value
+            elif key.value == "description":
+                if isinstance(val, ast.Constant) and isinstance(val.value, str):
+                    desc_val = val.value
+                elif isinstance(val, ast.Name):
+                    desc_val = _resolve_string_constant(tree, val.id)
+        if name_val and desc_val:
+            schemas.append({"name": name_val, "description": desc_val})
+    return schemas
+
+
+def load_tool_descriptions(hermes_agent_path: Path, tool_names: list[str]) -> dict[str, str]:
+    """Statically parse tools/*.py for the description of each requested tool name.
+
+    Uses ast (not import) so this never has to satisfy hermes-agent's own runtime
+    dependencies — same approach registry.py itself uses for tool discovery.
+    """
+    tools_dir = hermes_agent_path / "tools"
+    found: dict[str, str] = {}
+    remaining = set(tool_names)
+
+    for py_file in sorted(tools_dir.glob("*.py")):
+        if not remaining:
+            break
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        except (SyntaxError, OSError):
+            continue
+        for schema in _extract_schema_dicts(tree):
+            if schema["name"] in remaining:
+                found[schema["name"]] = schema["description"]
+                remaining.discard(schema["name"])
+
+    missing = tool_names_not_found = set(tool_names) - found.keys()
+    if missing:
+        raise ValueError(f"Could not find description for tool(s): {sorted(missing)}")
+    return found
+
+
+def build_router_instructions(descriptions: dict[str, str]) -> str:
+    """Render tool descriptions into one instructions block GEPA can mutate.
+
+    Each tool is delimited by a `### TOOL: <name>` marker so the block can be
+    parsed back into per-tool descriptions after optimization, even if GEPA
+    rewrote the surrounding prose.
+    """
+    parts = [ROUTER_PREAMBLE]
+    for name, desc in descriptions.items():
+        parts.append(f"{TOOL_BLOCK_START}{name}\n{desc}\n")
+    return "\n".join(parts)
+
+
+def parse_router_instructions(instructions: str, tool_names: list[str]) -> dict[str, str]:
+    """Inverse of build_router_instructions — split a (possibly mutated) block
+    back into {tool_name: description}, keyed on the still-present markers.
+
+    Tools whose marker GEPA dropped are omitted from the result; callers should
+    treat that as a constraint failure (structure didn't survive optimization).
+    """
+    sections: dict[str, str] = {}
+    marker_positions = []
+    for name in tool_names:
+        marker = f"{TOOL_BLOCK_START}{name}"
+        idx = instructions.find(marker)
+        if idx != -1:
+            marker_positions.append((idx, name, marker))
+    marker_positions.sort()
+
+    for i, (idx, name, marker) in enumerate(marker_positions):
+        start = idx + len(marker)
+        end = marker_positions[i + 1][0] if i + 1 < len(marker_positions) else len(instructions)
+        sections[name] = instructions[start:end].strip()
+
+    return sections
+
+
+class ToolRouterModule(dspy.Module):
+    """DSPy module that picks a tool name given a task description.
+
+    The combined tool-descriptions block is the optimizable instructions —
+    see build_router_instructions/parse_router_instructions for the marker
+    scheme that lets per-tool descriptions round-trip through GEPA mutation.
+    """
+
+    class RouteTask(dspy.Signature):
+        # Field name must be task_input — EvalDataset.to_dspy_examples() always
+        # keys the input on "task_input", regardless of skill vs tool usage.
+        task_input: str = dspy.InputField(desc="The task the agent needs to accomplish")
+        tool_name: str = dspy.OutputField(desc="The exact name of the single best tool to use")
+
+    def __init__(self, descriptions: dict[str, str]):
+        super().__init__()
+        self.tool_names = list(descriptions.keys())
+        instructions = build_router_instructions(descriptions)
+        signature = self.RouteTask.with_instructions(instructions)
+        self.predictor = dspy.ChainOfThought(signature)
+
+    @property
+    def descriptions(self) -> dict[str, str]:
+        """Current per-tool descriptions — mutated in place by GEPA/MIPRO."""
+        return parse_router_instructions(self.predictor.predict.signature.instructions, self.tool_names)
+
+    def forward(self, task_input: str) -> dspy.Prediction:
+        result = self.predictor(task_input=task_input)
+        return dspy.Prediction(tool_name=result.tool_name.strip())

--- a/run_long_loop.sh
+++ b/run_long_loop.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Long evolution loop: Phase 1 (skills) + Phase 2 (tool descriptions).
+# Eval model: openrouter/openai/gpt-4.1-nano (chosen: weak-but-stable = real GEPA signal).
+# Optimizer:  openrouter/openai/gpt-4.1 for both phases.
+set -a
+. /home/raul/.hermes/.env >/dev/null 2>&1
+set +a
+export OPENAI_API_KEY="$OPENROUTER_API_KEY"
+cd /home/raul/dev/active/hermes/hermes-agent-self-evolution
+
+echo "=== LOOP START $(date -Is) ==="
+
+# ---------- PHASE 1: skills ----------
+for skill in github-code-review systematic-debugging; do
+  echo "--- [phase1] skill=$skill synthetic $(date -Is)"
+  .venv/bin/python -m evolution.skills.evolve_skill \
+    --skill "$skill" --iterations 10 --eval-source synthetic \
+    --optimizer-model "openrouter/openai/gpt-4.1" \
+    --eval-model "openrouter/openai/gpt-4.1-nano" \
+    > "loop_phase1_${skill}_synthetic.log" 2>&1
+  echo "exit=$?"
+
+  echo "--- [phase1] skill=$skill sessiondb $(date -Is)"
+  .venv/bin/python -m evolution.skills.evolve_skill \
+    --skill "$skill" --iterations 10 --eval-source sessiondb \
+    --optimizer-model "openrouter/openai/gpt-4.1" \
+    --eval-model "openrouter/openai/gpt-4.1-nano" \
+    > "loop_phase1_${skill}_sessiondb.log" 2>&1
+  echo "exit=$?"
+done
+
+# ---------- PHASE 2: tool descriptions (hardened dataset) ----------
+for group in "read_file,write_file,search_files,terminal" "web_search,web_extract" ; do
+  tag=$(echo "$group" | tr ',' '_')
+  echo "--- [phase2] tools=$group $(date -Is)"
+  .venv/bin/python -m evolution.tools.evolve_tool_descriptions \
+    --tools "$group" --iterations 12 --cases-per-tool 4 \
+    --optimizer-model "openrouter/openai/gpt-4.1" \
+    --eval-model "openrouter/openai/gpt-4.1-nano" \
+    > "loop_phase2_${tag}.log" 2>&1
+  echo "exit=$?"
+done
+
+echo "=== LOOP DONE $(date -Is) ==="
+grep -H '"improvement"' output/*/*/*/metrics.json 2>/dev/null | tail -20
+grep -HE "Holdout|Change|improvement" loop_*.log | tail -30

--- a/tests/prompts/test_prompt_module.py
+++ b/tests/prompts/test_prompt_module.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from evolution.prompts.prompt_module import (
+    PROMPT_BUILDER_RELATIVE,
+    PromptSectionModule,
+    list_prompt_sections,
+    load_prompt_section,
+)
+
+
+def _write_prompt_builder(root: Path):
+    path = root / PROMPT_BUILDER_RELATIVE
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        'DEFAULT_AGENT_IDENTITY = "You are concise."\n'
+        'MEMORY_GUIDANCE = ("Remember stable facts. " "Skip stale facts.")\n'
+        '_PRIVATE = "ignore me"\n'
+        'NOT_STRING = 123\n'
+    )
+    return path
+
+
+def test_list_prompt_sections_static_parse(tmp_path):
+    _write_prompt_builder(tmp_path)
+
+    sections = list_prompt_sections(tmp_path)
+
+    assert sections == {
+        "DEFAULT_AGENT_IDENTITY": "You are concise.",
+        "MEMORY_GUIDANCE": "Remember stable facts. Skip stale facts.",
+    }
+
+
+def test_load_prompt_section_returns_metadata(tmp_path):
+    path = _write_prompt_builder(tmp_path)
+
+    section = load_prompt_section(tmp_path, "MEMORY_GUIDANCE")
+
+    assert section["name"] == "MEMORY_GUIDANCE"
+    assert section["text"] == "Remember stable facts. Skip stale facts."
+    assert section["path"] == path
+
+
+def test_load_prompt_section_error_lists_available(tmp_path):
+    _write_prompt_builder(tmp_path)
+
+    try:
+        load_prompt_section(tmp_path, "MISSING")
+    except ValueError as exc:
+        assert "DEFAULT_AGENT_IDENTITY" in str(exc)
+        assert "MEMORY_GUIDANCE" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_prompt_section_module_exposes_instruction_text():
+    module = PromptSectionModule("Follow the prompt section exactly.")
+
+    assert module.section_text == "Follow the prompt section exactly."


### PR DESCRIPTION
## Summary
- Adds Phase 3 prompt-section evolution for named constants in agent/prompt_builder.py.
- Adds static AST prompt-section loader and DSPy PromptSectionModule.
- Adds CLI: python -m evolution.prompts.evolve_prompt_section --section MEMORY_GUIDANCE ...
- Hardens synthetic dataset JSON parsing and tool-description evolution artifacts from the Phase 2 work.
- Adds run_long_loop.sh for longer Phase 1 + Phase 2 loops.

## Validation
- pytest tests -q: 149 passed
- Dry run: python -m evolution.prompts.evolve_prompt_section --section MEMORY_GUIDANCE --hermes-repo /home/raul/.hermes/hermes-agent --dry-run
- Smoke run: MEMORY_GUIDANCE, 2 iterations, gpt-4.1-nano eval; output saved locally under output/prompts/MEMORY_GUIDANCE/20260825_103331/

Note: upstream merge permissions are not available to ideas24h, so this PR is published for maintainer merge.