### PR TITLE
feat: add portable evolve.sh launcher script

### DIFF
--- a/evolve.sh
+++ b/evolve.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# One-shot runner for the Hermes skill self-evolution tool.
+# Usage: ./evolve.sh <skill-name> [iterations] [extra args...]
+# Examples:
+#   ./evolve.sh github-code-review 10
+#   ./evolve.sh excel-vba-automation 5 --eval-source sessiondb
+set -e
+cd "$(dirname "$0")"
+
+SKILL="$1"; shift || true
+ITER="${1:-10}"; shift 2>/dev/null || true
+
+if [ -z "$SKILL" ]; then
+  echo "Usage: ./evolve.sh <skill-name> [iterations] [--eval-source synthetic|sessiondb|golden] ..."
+  exit 1
+fi
+
+# Locate the hermes-agent repo: explicit env var wins, then common locations.
+if [ -z "$HERMES_AGENT_REPO" ]; then
+  for candidate in \
+    "$HOME/.hermes/hermes-agent" \
+    "$LOCALAPPDATA/hermes/hermes-agent" \
+    "$HOME/AppData/Local/hermes/hermes-agent" \
+    "../hermes-agent"; do
+    if [ -d "$candidate" ]; then
+      HERMES_AGENT_REPO="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$HERMES_AGENT_REPO" ]; then
+  echo "hermes-agent repo not found. Set HERMES_AGENT_REPO=/path/to/hermes-agent" >&2
+  exit 1
+fi
+
+# Pick the venv interpreter for the current platform.
+if [ -x .venv/Scripts/python.exe ]; then
+  PYTHON=".venv/Scripts/python.exe"
+elif [ -x .venv/bin/python ]; then
+  PYTHON=".venv/bin/python"
+else
+  echo "No .venv found. Run: python -m venv .venv && .venv/bin/pip install -e ." >&2
+  exit 1
+fi
+
+# Clear PYTHONPATH: a globally-set value can collide with hermes' own venv.
+env -u PYTHONPATH \
+  "$PYTHON" -m evolution.skills.evolve_skill \
+  --skill "$SKILL" \
+  --iterations "$ITER" \
+  --hermes-repo "$HERMES_AGENT_REPO" \
+  "$@"


### PR DESCRIPTION
## Summary
Adds `evolve.sh`, a one-command wrapper around `evolution.skills.evolve_skill` so users don't have to remember the module path, venv interpreter, and `PYTHONPATH` unsetting needed on Windows.

## Details
- Auto-detects the hermes-agent repo: `HERMES_AGENT_REPO` env var first, then `~/.hermes/hermes-agent`, `%LOCALAPPDATA%/hermes/hermes-agent`, or a sibling checkout
- Picks the venv interpreter per platform (`.venv/Scripts/python.exe` on Windows, `.venv/bin/python` elsewhere)
- Clears `PYTHONPATH` for the child process to avoid collisions with hermes' own venv

## Test Plan
- [x] `./evolve.sh` with no args prints usage and exits 1
- [x] Repo auto-detection finds `%LOCALAPPDATA%/hermes/hermes-agent` on a non-default install
- [x] `./evolve.sh github-code-review 1 --dry-run` validates setup end-to-end
