### PR TITLE
fix: make GEPA actually run, wire the rubric judge, mine real session data

### DIFF
--- a/evolution/core/external_importers.py
+++ b/evolution/core/external_importers.py
@@ -25,6 +25,7 @@ Usage from evolve_skill.py:
 import json
 import re
 import random
+import sqlite3
 from pathlib import Path
 from typing import Optional
 
@@ -344,10 +345,15 @@ class HermesSessionImporter:
     """
 
     SESSION_DIR = Path.home() / ".hermes" / "sessions"
+    STATE_DB = Path.home() / ".hermes" / "state.db"
 
     @staticmethod
     def extract_messages(limit: int = 0) -> list[dict]:
-        """Read user/assistant pairs from Hermes session files.
+        """Read user/assistant pairs from Hermes session storage.
+
+        Modern Hermes stores conversations in SQLite (~/.hermes/state.db);
+        legacy installs used JSON transcripts in ~/.hermes/sessions/.
+        Auto-detect: use SQLite when present, else fall back to JSON files.
 
         Args:
             limit: Maximum messages to return (0 = no limit).
@@ -356,6 +362,79 @@ class HermesSessionImporter:
             List of dicts with keys: source, task_input, assistant_response,
             session_id.
         """
+        messages = HermesSessionImporter._extract_from_sqlite(limit)
+        if not messages:
+            messages = HermesSessionImporter._extract_from_json(limit)
+        return messages
+
+    @staticmethod
+    def _extract_from_sqlite(limit: int = 0) -> list[dict]:
+        """Mine state.db: pair each user message with the next assistant reply.
+
+        Faithful to the JSON-walk semantics: the assistant reply must be the
+        NEXT assistant message after the user turn, with no intervening user
+        message (a user message before the assistant reply means the turn got
+        no answer and the pair is skipped).
+        """
+        if not HermesSessionImporter.STATE_DB.exists():
+            return []
+
+        messages = []
+        try:
+            conn = sqlite3.connect(str(HermesSessionImporter.STATE_DB))
+            conn.row_factory = sqlite3.Row
+            sql_limit = limit if limit > 0 else 20000
+            rows = conn.execute(
+                """
+                SELECT m.session_id AS session_id,
+                       m.content AS task_input,
+                       (SELECT m2.content FROM messages m2
+                         WHERE m2.session_id = m.session_id
+                           AND m2.id > m.id
+                           AND m2.role = 'assistant'
+                           AND m2.content IS NOT NULL
+                           AND m2.content != ''
+                           AND NOT EXISTS (
+                               SELECT 1 FROM messages m3
+                                WHERE m3.session_id = m.session_id
+                                  AND m3.id > m.id
+                                  AND m3.id < m2.id
+                                  AND m3.role = 'user')
+                         ORDER BY m2.id LIMIT 1) AS assistant_response
+                  FROM messages m
+                 WHERE m.role = 'user'
+                   AND m.active = 1
+                   AND m.content IS NOT NULL
+                   AND length(m.content) >= 10
+                 ORDER BY m.timestamp DESC
+                 LIMIT ?
+                """,
+                (sql_limit,),
+            )
+            for row in rows:
+                user_text = row["task_input"]
+                assistant_text = row["assistant_response"]
+                if not assistant_text:
+                    continue
+                if _contains_secret(user_text) or _contains_secret(assistant_text):
+                    continue
+                messages.append({
+                    "source": "hermes",
+                    "task_input": user_text,
+                    "assistant_response": assistant_text,
+                    "session_id": row["session_id"],
+                })
+                if limit and len(messages) >= limit:
+                    break
+            conn.close()
+        except sqlite3.Error:
+            return []
+
+        return messages
+
+    @staticmethod
+    def _extract_from_json(limit: int = 0) -> list[dict]:
+        """Legacy path: JSON transcripts in ~/.hermes/sessions/*.json."""
         if not HermesSessionImporter.SESSION_DIR.exists():
             return []
 

--- a/evolution/core/fitness.py
+++ b/evolution/core/fitness.py
@@ -136,6 +136,61 @@ def skill_fitness_metric(example: dspy.Example, prediction: dspy.Prediction, tra
     return min(1.0, max(0.0, score))
 
 
+_skill_text: str = ""
+
+
+def set_current_skill_text(text: str) -> None:
+    """Thread the skill being evolved into the judge so it can grade against it."""
+    global _skill_text
+    _skill_text = text or ""
+
+
+class _RubricJudgeSignature(dspy.Signature):
+    """Evaluate an agent's response against an expected behavior rubric."""
+
+    task_input: str = dspy.InputField(desc="The task the agent was given")
+    expected_behavior: str = dspy.InputField(desc="Rubric describing what a good response looks like")
+    agent_output: str = dspy.InputField(desc="The agent's actual response")
+    skill_text: str = dspy.InputField(desc="The skill/instructions the agent was following")
+    correctness: float = dspy.OutputField(desc="Score 0.0-1.0: Did the response correctly address the task?")
+    procedure_following: float = dspy.OutputField(desc="Score 0.0-1.0: Did it follow the expected procedure?")
+    conciseness: float = dspy.OutputField(desc="Score 0.0-1.0: Appropriately concise?")
+    feedback: str = dspy.OutputField(desc="Specific, actionable feedback on what could be improved")
+
+
+_rubric_judge = None
+
+
+def llm_judge_metric(gold, pred, trace=None, pred_name=None, pred_trace=None) -> float:
+    """GEPA-compatible (gold, pred, trace, pred_name, pred_trace) rubric metric.
+
+    Grades with the real LLM judge (correctness / procedure / conciseness)
+    instead of the keyword-overlap heuristic. Falls back to the heuristic if
+    a judge call fails.
+    """
+    global _rubric_judge
+    agent_output = getattr(pred, "output", "") or ""
+    if not agent_output.strip():
+        return 0.0
+    expected = getattr(gold, "expected_behavior", "") or ""
+    task = getattr(gold, "task_input", "") or ""
+    try:
+        if _rubric_judge is None:
+            _rubric_judge = dspy.ChainOfThought(_RubricJudgeSignature)
+        result = _rubric_judge(
+            task_input=task,
+            expected_behavior=expected,
+            agent_output=agent_output,
+            skill_text=_skill_text,
+        )
+        c = _parse_score(result.correctness)
+        p = _parse_score(result.procedure_following)
+        x = _parse_score(result.conciseness)
+        return min(1.0, max(0.0, (c + p + x) / 3.0))
+    except Exception:
+        return skill_fitness_metric(gold, pred, trace)
+
+
 def _parse_score(value) -> float:
     """Parse a score value, handling various LLM output formats."""
     if isinstance(value, (int, float)):

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -177,10 +177,14 @@ def evolve(
 
     try:
         reflection_lm = _ProviderCompatLM(optimizer_model)
+        # num_threads=1: serialize valset evals. Parallel evals under rate
+        # limits can truncate a batch and short the outputs-by-example list,
+        # crashing gepa/core/engine.py with an IndexError mid-run (#10).
         optimizer = dspy.GEPA(
             metric=llm_judge_metric,
             max_full_evals=iterations,
             reflection_lm=reflection_lm,
+            num_threads=1,
         )
 
         optimized_module = optimizer.compile(

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -21,7 +21,7 @@ from rich.table import Table
 from evolution.core.config import EvolutionConfig, resolve_hermes_agent_path
 from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset, GoldenDatasetLoader
 from evolution.core.external_importers import build_dataset_from_external
-from evolution.core.fitness import skill_fitness_metric, LLMJudge, FitnessScore
+from evolution.core.fitness import llm_judge_metric, set_current_skill_text, skill_fitness_metric, LLMJudge, FitnessScore
 from evolution.core.constraints import ConstraintValidator
 from evolution.skills.skill_module import (
     SkillModule,
@@ -64,6 +64,7 @@ def evolve(
         sys.exit(1)
 
     skill = load_skill(skill_path)
+    set_current_skill_text(skill["raw"])
     console.print(f"  Loaded: {skill_path.relative_to(config.hermes_agent_path)}")
     console.print(f"  Name: {skill['name']}")
     console.print(f"  Size: {len(skill['raw']):,} chars")
@@ -136,8 +137,17 @@ def evolve(
     console.print(f"  Optimizer model: {optimizer_model}")
     console.print(f"  Eval model: {eval_model}")
 
-    # Configure DSPy
-    lm = dspy.LM(eval_model)
+    # Configure DSPy (provider compat: deepseek-chat serves only json_object; json_schema
+    # arrives as a pydantic class or dict and must be stripped before litellm serializes it)
+    class _ProviderCompatLM(dspy.LM):
+        def forward(self, prompt=None, messages=None, **kwargs):
+            model = str(getattr(self, "model", "") or "")
+            rf = kwargs.get("response_format")
+            if "deepseek" in model and not (isinstance(rf, dict) and rf.get("type") == "json_object"):
+                kwargs.pop("response_format", None)
+            return super().forward(prompt=prompt, messages=messages, **kwargs)
+
+    lm = _ProviderCompatLM(eval_model)
     dspy.configure(lm=lm)
 
     # Create the baseline skill module
@@ -153,9 +163,11 @@ def evolve(
     start_time = time.time()
 
     try:
+        reflection_lm = _ProviderCompatLM(optimizer_model)
         optimizer = dspy.GEPA(
-            metric=skill_fitness_metric,
-            max_steps=iterations,
+            metric=llm_judge_metric,
+            max_full_evals=iterations,
+            reflection_lm=reflection_lm,
         )
 
         optimized_module = optimizer.compile(
@@ -167,7 +179,7 @@ def evolve(
         # Fall back to MIPROv2 if GEPA isn't available in this DSPy version
         console.print(f"[yellow]GEPA not available ({e}), falling back to MIPROv2[/yellow]")
         optimizer = dspy.MIPROv2(
-            metric=skill_fitness_metric,
+            metric=llm_judge_metric,
             auto="light",
         )
         optimized_module = optimizer.compile(
@@ -185,7 +197,7 @@ def evolve(
 
     # ── 7. Validate evolved skill ───────────────────────────────────────
     console.print(f"\n[bold]Validating evolved skill[/bold]")
-    evolved_constraints = validator.validate_all(evolved_body, "skill", baseline_text=skill["body"])
+    evolved_constraints = validator.validate_all(evolved_full, "skill", baseline_text=skill["raw"])
     all_pass = True
     for c in evolved_constraints:
         icon = "✓" if c.passed else "✗"
@@ -214,11 +226,11 @@ def evolve(
         # Score baseline
         with dspy.context(lm=lm):
             baseline_pred = baseline_module(task_input=ex.task_input)
-            baseline_score = skill_fitness_metric(ex, baseline_pred)
+            baseline_score = llm_judge_metric(ex, baseline_pred)
             baseline_scores.append(baseline_score)
 
             evolved_pred = optimized_module(task_input=ex.task_input)
-            evolved_score = skill_fitness_metric(ex, evolved_pred)
+            evolved_score = llm_judge_metric(ex, evolved_pred)
             evolved_scores.append(evolved_score)
 
     avg_baseline = sum(baseline_scores) / max(1, len(baseline_scores))

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -22,6 +22,7 @@ from evolution.core.config import EvolutionConfig, resolve_hermes_agent_path
 from evolution.core.dataset_builder import SyntheticDatasetBuilder, EvalDataset, GoldenDatasetLoader
 from evolution.core.external_importers import build_dataset_from_external
 from evolution.core.fitness import llm_judge_metric, set_current_skill_text, skill_fitness_metric, LLMJudge, FitnessScore
+import difflib
 from evolution.core.constraints import ConstraintValidator
 from evolution.skills.skill_module import (
     SkillModule,
@@ -237,6 +238,11 @@ def evolve(
     avg_evolved = sum(evolved_scores) / max(1, len(evolved_scores))
     improvement = avg_evolved - avg_baseline
 
+    # Program gain vs skill gain: a holdout delta without a skill-text delta
+    # is candidate/demo selection, NOT a deployable skill change.
+    skill_similarity = difflib.SequenceMatcher(None, skill["body"], evolved_body).ratio()
+    text_changed = evolved_body.strip() != skill["body"].strip()
+
     # ── 9. Report results ───────────────────────────────────────────────
     table = Table(title="Evolution Results")
     table.add_column("Metric", style="bold")
@@ -256,6 +262,12 @@ def evolve(
         f"{len(skill['body']):,} chars",
         f"{len(evolved_body):,} chars",
         f"{len(evolved_body) - len(skill['body']):+,} chars",
+    )
+    table.add_row(
+        "Skill Text Delta",
+        "",
+        f"{skill_similarity:.1%} similar",
+        "[green]changed[/green]" if text_changed else "[red]UNCHANGED[/red]",
     )
     table.add_row("Time", "", f"{elapsed:.1f}s", "")
     table.add_row("Iterations", "", str(iterations), "")
@@ -291,14 +303,19 @@ def evolve(
         "holdout_examples": len(dataset.holdout),
         "elapsed_seconds": elapsed,
         "constraints_passed": all_pass,
+        "skill_text_changed": text_changed,
+        "skill_similarity": round(skill_similarity, 4),
     }
     (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
 
     console.print(f"\n  Output saved to {output_dir}/")
 
-    if improvement > 0:
+    if improvement > 0 and text_changed:
         console.print(f"\n[bold green]✓ Evolution improved skill by {improvement:+.3f} ({improvement/max(0.001, avg_baseline)*100:+.1f}%)[/bold green]")
         console.print(f"  Review the diff: diff {output_dir}/baseline_skill.md {output_dir}/evolved_skill.md")
+    elif improvement > 0 and not text_changed:
+        console.print(f"\n[yellow]⚠ Holdout improved by {improvement:+.3f} but the skill text is UNCHANGED[/yellow]")
+        console.print("  The gain is program-level (candidate/demo selection) — NOT deployable as a skill change.")
     else:
         console.print(f"\n[yellow]⚠ Evolution did not improve skill (change: {improvement:+.3f})[/yellow]")
         console.print("  Try: more iterations, better eval dataset, or different optimizer model")

--- a/evolution/skills/evolve_skill.py
+++ b/evolution/skills/evolve_skill.py
@@ -14,6 +14,18 @@ from typing import Optional
 
 import click
 import dspy
+import litellm
+
+# Transport-level timeout (bug observed on long runs): LiteLLM's default is no
+# timeout, so a single dead provider request parks the run forever — seen as a
+# multi-hour silent hang at the dataset relevance-filter stage. dspy.LM's
+# `timeout` kwarg does not reach every call path (importers construct their own
+# LMs), so set the module-level default once here: this process's entry point
+# imports evolve_skill first, and litellm reads module state at call time,
+# covering every LM construction anywhere in the run.
+litellm.request_timeout = 120
+litellm.num_retries = 2
+
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table

--- a/tests/core/test_external_importers.py
+++ b/tests/core/test_external_importers.py
@@ -482,7 +482,7 @@ class TestHermesSessionImporter:
         }
         (tmp_path / "session_001.json").write_text(json.dumps(session))
 
-        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path), patch.object(HermesSessionImporter, "STATE_DB", tmp_path / "no_state.db"):
             msgs = HermesSessionImporter.extract_messages()
 
         assert len(msgs) == 2
@@ -501,7 +501,7 @@ class TestHermesSessionImporter:
         }
         (tmp_path / "s.json").write_text(json.dumps(session))
 
-        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path), patch.object(HermesSessionImporter, "STATE_DB", tmp_path / "no_state.db"):
             msgs = HermesSessionImporter.extract_messages()
         assert len(msgs) == 0
 
@@ -514,19 +514,19 @@ class TestHermesSessionImporter:
         }
         (tmp_path / "s.json").write_text(json.dumps(session))
 
-        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path), patch.object(HermesSessionImporter, "STATE_DB", tmp_path / "no_state.db"):
             msgs = HermesSessionImporter.extract_messages()
         assert len(msgs) == 0
 
     def test_handles_missing_dir(self, tmp_path):
-        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path / "nonexistent"):
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path / "nonexistent"), patch.object(HermesSessionImporter, "STATE_DB", tmp_path / "no_state.db"):
             msgs = HermesSessionImporter.extract_messages()
         assert msgs == []
 
     def test_handles_malformed_json(self, tmp_path):
         (tmp_path / "bad.json").write_text("{not valid json")
 
-        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path), patch.object(HermesSessionImporter, "STATE_DB", tmp_path / "no_state.db"):
             msgs = HermesSessionImporter.extract_messages()
         assert msgs == []
 
@@ -538,7 +538,7 @@ class TestHermesSessionImporter:
         }
         (tmp_path / "s.json").write_text(json.dumps(session))
 
-        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path), patch.object(HermesSessionImporter, "STATE_DB", tmp_path / "no_state.db"):
             msgs = HermesSessionImporter.extract_messages()
         assert len(msgs) == 1
         assert msgs[0]["assistant_response"] == ""
@@ -551,7 +551,7 @@ class TestHermesSessionImporter:
         }
         (tmp_path / "s.json").write_text(json.dumps(session))
 
-        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path):
+        with patch.object(HermesSessionImporter, "SESSION_DIR", tmp_path), patch.object(HermesSessionImporter, "STATE_DB", tmp_path / "no_state.db"):
             msgs = HermesSessionImporter.extract_messages(limit=3)
         assert len(msgs) == 3
 


### PR DESCRIPTION
## What's broken (verified against real runs, deepseek-chat via LiteLLM, dspy 3.3.1)

Six independent bugs mean the headline optimizer has never actually run, and every score the tool prints is misleading:

1. **GEPA never runs.** `dspy.GEPA(metric=..., max_steps=iterations)` — dspy has no `max_steps` kwarg (it's `max_full_evals`), so `TypeError` on every invocation, silently swallowed by the broad `except` and replaced by the MIPROv2 fallback. The README's GEPA loop has been a disguised crash since the repo shipped. (Fixes #10)
2. **Even with the kwarg fixed, GEPA still dies.** GEPA's metric contract is `(gold, pred, trace, pred_name, pred_trace)`; `skill_fitness_metric` takes 3 args → `TypeError` in `GEPA.__init__` (verified: `inspect.signature(metric).bind(None, None, None, None, None)`).
3. **And a third time:** GEPA asserts a `reflection_lm` exists (`AssertionError: GEPA requires a reflection language model, or custom instruction proposer`) — the repo never passes one.
4. **The "fitness metric" is keyword overlap.** `skill_fitness_metric` returns `0.3 + 0.7 * word_overlap(expected, output)`. The 3-dimension LLM judge (`LLMJudge`, correctness/procedure/conciseness) sits in `fitness.py` as dead code. Every optimization run has been hill-climbing word-stuffing. (Judge-internal scores rose while holdout fell — receipts in run logs.)
5. **The structure gate validates the wrong artifact.** `validate_all(evolved_body)` — the bare body without frontmatter — so every reassembled variant (which *does* carry frontmatter) gets quarantined as "Skill missing: YAML frontmatter" while the file on disk has it.
6. **The session miner points at a dead path.** Modern Hermes stores conversations in SQLite `~/.hermes/state.db`; `~/.hermes/sessions/*.json` holds request dumps only. The importer mined 0 messages from a DB containing 8,332 user/assistant pairs.

Plus two found while running the fixed pipeline end-to-end:

7. **No transport-level timeout.** LiteLLM defaults to no request timeout, so one dead provider request parks the run forever — observed as a multi-hour silent hang at the dataset relevance-filter stage (CPU idle, socket ESTAB, zero progress). `dspy.LM`'s `timeout` kwarg doesn't reach every call path (the importers and dataset builder construct their own LMs), so a single module-level `litellm.request_timeout = 120` at the CLI entry point is the only site that covers them all.
8. **Importer tests hit live user data.** With the SQLite-first auto-detection, the JSON-path tests (which patch only `SESSION_DIR`) find the developer's real `~/.hermes/state.db` and win before the patched fallback — exercising live conversation data instead of fixtures. Fixtures now neutralize `STATE_DB` too.

## What this PR changes

- `evolution/skills/evolve_skill.py`
  - `max_steps` → `max_full_evals`
  - `reflection_lm` built from the optimizer model
  - `_ProviderCompatLM`: strips `response_format` values the provider can't serve (deepseek-chat rejects `json_schema`; DSPy's JSONAdapter passes a pydantic class which LiteLLM serializes → `400 "This response_format type is unavailable now"`). Provider-conditional — OpenAI/Anthropic paths unaffected.
  - metric = `llm_judge_metric` (real rubric judge) for GEPA, the MIPRO fallback, and the holdout comparison
  - validator receives `evolved_full` (the artifact actually deployed) with `skill["raw"]` as the growth baseline
  - module-level `litellm.request_timeout = 120` / `num_retries = 2`
- `evolution/core/fitness.py`
  - adds `llm_judge_metric(gold, pred, trace=None, pred_name=None, pred_trace=None)` — 5-arg GEPA contract, rubric-scored, falls back to the heuristic on judge failure
  - adds `set_current_skill_text()` so the judge grades against the skill being evolved
- `evolution/core/external_importers.py`
  - `HermesSessionImporter` auto-detects `~/.hermes/state.db` (SQLite) first, JSON fallback for legacy installs; pairing semantics preserved (assistant reply must precede the next user turn)
- `tests/core/test_external_importers.py`
  - `TestHermesSessionImporter` fixtures neutralize `STATE_DB` (hermetic; see #8 above)

## Verification

- Importer: `python -m evolution.core.external_importers --source hermes --skill <skill> --dry-run` → 8,332 messages mined (was 0)
- GEPA: constructs and compiles with the 5-arg metric + reflection LM (was 3 masked exceptions)
- Full pipeline on `deepseek/deepseek-chat`: dataset → optimize → all four constraint gates green → holdout → report, end to end
- `pytest tests/ -q` → 145 passed (was 6 failures on the first commit of this branch — the STATE_DB hermeticity fix)
- Post-timeout-fix runs pass the relevance-filter stage that previously wedged (two independent hang receipts pre-fix)

## Honest caveat (open issue, not fixed here)

Even with the judge wired in, the report can still overstate: when MIPRO's selected few-shot demos lift holdout while the skill text is unchanged, the tool prints "Evolution improved skill by +X%" for a byte-identical skill. The demos live in the program, not the deployed artifact. Worth either scoring instruction-only, or reporting program-vs-skill gains separately. (Partially addressed by the program/skill gain split in the report.)

Closes #10, #169, #171 (structure gate), and the importer half of #175's session-data item.